### PR TITLE
Avoid custom aliases when using sed

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -847,7 +847,7 @@ _mac_addresses()
     # - ifconfig on FreeBSD: ether
     # - ip link: link/ether
     COMPREPLY+=( $( \
-        { LC_ALL=C ifconfig -a || ip link show; } 2>/dev/null | sed -ne \
+        { LC_ALL=C ifconfig -a || ip link show; } 2>/dev/null | command sed -ne \
         "s/.*[[:space:]]HWaddr[[:space:]]\{1,\}\($re\)[[:space:]].*/\1/p" -ne \
         "s/.*[[:space:]]HWaddr[[:space:]]\{1,\}\($re\)[[:space:]]*$/\1/p" -ne \
         "s|.*[[:space:]]\(link/\)\{0,1\}ether[[:space:]]\{1,\}\($re\)[[:space:]].*|\2|p" -ne \
@@ -855,12 +855,12 @@ _mac_addresses()
         ) )
 
     # ARP cache
-    COMPREPLY+=( $( { arp -an || ip neigh show; } 2>/dev/null | sed -ne \
+    COMPREPLY+=( $( { arp -an || ip neigh show; } 2>/dev/null | command sed -ne \
         "s/.*[[:space:]]\($re\)[[:space:]].*/\1/p" -ne \
         "s/.*[[:space:]]\($re\)[[:space:]]*$/\1/p" ) )
 
     # /etc/ethers
-    COMPREPLY+=( $( sed -ne \
+    COMPREPLY+=( $( command sed -ne \
         "s/^[[:space:]]*\($re\)[[:space:]].*/\1/p" /etc/ethers 2>/dev/null ) )
 
     COMPREPLY=( $( compgen -W '${COMPREPLY[@]}' -- "$cur" ) )
@@ -873,23 +873,23 @@ _configured_interfaces()
 {
     if [[ -f /etc/debian_version ]]; then
         # Debian system
-        COMPREPLY=( $( compgen -W "$( sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p'\
+        COMPREPLY=( $( compgen -W "$( command sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p'\
             /etc/network/interfaces )" -- "$cur" ) )
     elif [[ -f /etc/SuSE-release ]]; then
         # SuSE system
         COMPREPLY=( $( compgen -W "$( printf '%s\n' \
             /etc/sysconfig/network/ifcfg-* | \
-            sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
+            command sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
     elif [[ -f /etc/pld-release ]]; then
         # PLD Linux
         COMPREPLY=( $( compgen -W "$( command ls -B \
             /etc/sysconfig/interfaces | \
-            sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
+            command sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
     else
         # Assume Red Hat
         COMPREPLY=( $( compgen -W "$( printf '%s\n' \
             /etc/sysconfig/network-scripts/ifcfg-* | \
-            sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
+            command sed -ne 's|.*ifcfg-\(.*\)|\1|p' )" -- "$cur" ) )
     fi
 }
 
@@ -899,9 +899,9 @@ _ip_addresses()
 {
     local PATH=$PATH:/sbin
     COMPREPLY+=( $( compgen -W \
-        "$( { LC_ALL=C ifconfig -a || ip addr show; } 2>/dev/null |
-            sed -ne 's/.*addr:\([^[:space:]]*\).*/\1/p' \
-                -ne 's|.*inet[[:space:]]\{1,\}\([^[:space:]/]*\).*|\1|p' )" \
+        "$( { LC_ALL=C ifconfig -a || ip addr show; } 2>/dev/null | command sed -ne \
+            's/.*addr:\([^[:space:]]*\).*/\1/p' -ne \
+            's|.*inet[[:space:]]\{1,\}\([^[:space:]/]*\).*|\1|p' )" \
         -- "$cur" ) )
 }
 
@@ -1029,7 +1029,7 @@ _expand()
 [[ $OSTYPE == *@(solaris|aix)* ]] &&
 _pids()
 {
-    COMPREPLY=( $( compgen -W '$( command ps -efo pid | sed 1d )' -- "$cur" ))
+    COMPREPLY=( $( compgen -W '$( command ps -efo pid | command sed 1d )' -- "$cur" ))
 } ||
 _pids()
 {
@@ -1041,7 +1041,7 @@ _pids()
 [[ $OSTYPE == *@(solaris|aix)* ]] &&
 _pgids()
 {
-    COMPREPLY=( $( compgen -W '$( command ps -efo pgid | sed 1d )' -- "$cur" ))
+    COMPREPLY=( $( compgen -W '$( command ps -efo pgid | command sed 1d )' -- "$cur" ))
 } ||
 _pgids()
 {
@@ -1055,13 +1055,13 @@ _pgids()
 _pnames()
 {
     COMPREPLY=( $( compgen -X '<defunct>' -W '$( command ps -efo comm | \
-        sed -e 1d -e "s:.*/::" -e "s/^-//" | sort -u )' -- "$cur" ) )
+        command sed -e 1d -e "s:.*/::" -e "s/^-//" | sort -u )' -- "$cur" ) )
 } ||
 _pnames()
 {
     if [[ "$1" == -s ]]; then
         COMPREPLY=( $( compgen -X '<defunct>' \
-            -W '$( command ps axo comm | sed -e 1d )' -- "$cur" ) )
+            -W '$( command ps axo comm | command sed -e 1d )' -- "$cur" ) )
     else
         # FIXME: completes "[kblockd/0]" to "0". Previously it was completed
         # to "kblockd" which isn't correct either. "kblockd/0" would be
@@ -1069,9 +1069,12 @@ _pnames()
         # containing "/" specially unless -r is given so that wouldn't quite
         # work either. Perhaps it'd be best to not complete these to anything
         # for now.
-        COMPREPLY=( $( compgen -X '<defunct>' -W '$( command ps axo command= | \
-            sed -e "s/ .*//" -e "s:.*/::" -e "s/:$//" -e "s/^[[(-]//" \
-                -e "s/[])]$//" | sort -u )' -- "$cur" ) )
+        COMPREPLY=( $( compgen -X '<defunct>' -W '$( command ps axo command= | command sed -e \
+            "s/ .*//" -e \
+            "s:.*/::" -e \
+            "s/:$//" -e \
+            "s/^[[(-]//" -e \
+            "s/[])]$//" | sort -u )' -- "$cur" ) )
     fi
 }
 
@@ -1161,7 +1164,7 @@ _service()
     else
         local sysvdirs
         _sysvdirs
-        COMPREPLY=( $( compgen -W '`sed -e "y/|/ /" \
+        COMPREPLY=( $( compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
             ${sysvdirs[0]}/${prev##*/} 2>/dev/null` start stop' -- "$cur" ) )
     fi
@@ -1182,7 +1185,7 @@ _modules()
     local modpath
     modpath=/lib/modules/$1
     COMPREPLY=( $( compgen -W "$( command ls -RL $modpath 2>/dev/null | \
-        sed -ne 's/^\(.*\)\.k\{0,1\}o\(\.[gx]z\)\{0,1\}$/\1/p' )" -- "$cur" ) )
+        command sed -ne 's/^\(.*\)\.k\{0,1\}o\(\.[gx]z\)\{0,1\}$/\1/p' )" -- "$cur" ) )
 }
 
 # This function completes on installed modules
@@ -1385,7 +1388,7 @@ _dvd_devices()
 _terms()
 {
     COMPREPLY+=( $( compgen -W \
-        "$( sed -ne 's/^\([^[:space:]#|]\{2,\}\)|.*/\1/p' /etc/termcap \
+        "$( command sed -ne 's/^\([^[:space:]#|]\{2,\}\)|.*/\1/p' /etc/termcap \
             2>/dev/null )" -- "$cur" ) )
     COMPREPLY+=( $( compgen -W "$( { toe -a 2>/dev/null || toe 2>/dev/null; } \
         | awk '{ print $1 }' | sort -u )" -- "$cur" ) )
@@ -1793,7 +1796,7 @@ _longopt()
             return 0
             ;;
         --+([-a-z0-9_]))
-            local argtype=$( LC_ALL=C $1 --help 2>&1 | sed -ne \
+            local argtype=$( LC_ALL=C $1 --help 2>&1 | command sed -ne \
                 "s|.*$prev\[\{0,1\}=[<[]\{0,1\}\([-A-Za-z0-9_]\{1,\}\).*|\1|p" )
             case ${argtype,,} in
                 *dir*)
@@ -1812,7 +1815,7 @@ _longopt()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W "$( LC_ALL=C $1 --help 2>&1 | \
-            sed -ne 's/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p' | sort -u )" \
+            command sed -ne 's/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p' | sort -u )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     elif [[ "$1" == @(mk|rm)dir ]]; then

--- a/bash_completion
+++ b/bash_completion
@@ -1564,7 +1564,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/completions/2to3
+++ b/completions/2to3
@@ -11,7 +11,7 @@ _2to3()
             ;;
         -f|--fix|-x|--nofix)
             COMPREPLY=( $( compgen -W \
-                "$( $1 --list-fixes 2>/dev/null | sed -e 1d )" -- "$cur" ) )
+                "$( $1 --list-fixes 2>/dev/null | command sed -e 1d )" -- "$cur" ) )
             return
             ;;
         -j|--processes)

--- a/completions/7z
+++ b/completions/7z
@@ -106,7 +106,7 @@ _7z()
         if [[ ${words[1]} == d ]]; then
             local IFS=$'\n'
             COMPREPLY=( $( compgen -W "$( printf '%s\n' $( $1 l ${words[2]} \
-                -slt 2>/dev/null | sed -n '/^Path =/s/^Path = \(.*\)$/\1/p' \
+                -slt 2>/dev/null | command sed -n '/^Path =/s/^Path = \(.*\)$/\1/p' \
                 2>/dev/null | tail -n+2 ) )" -- "$cur" ) )
             compopt -o filenames
         else

--- a/completions/_mock
+++ b/completions/_mock
@@ -45,7 +45,7 @@ _mock()
             # This would actually depend on what the target root
             # can be used to build for...
             COMPREPLY=( $( compgen -W "$( command rpm --showrc | \
-                sed -ne 's/^\s*compatible\s\s*archs\s*:\s*\(.*\)/\1/i p' )" \
+                command sed -ne 's/^\s*compatible\s\s*archs\s*:\s*\(.*\)/\1/i p' )" \
                 -- "$cur" ) )
             return 0
             ;;

--- a/completions/_modules
+++ b/completions/_modules
@@ -23,13 +23,13 @@
 
 _module_list ()
 {
-    local modules="$( sed 's/:/ /g' <<<$LOADEDMODULES | sort )"
+    local modules="$( command sed 's/:/ /g' <<<$LOADEDMODULES | sort )"
     compgen -W "$modules" -- $1
 }
 
 _module_path ()
 {
-    local modules="$( sed 's/:/ /g' <<<$MODULEPATH | sort )"
+    local modules="$( command sed 's/:/ /g' <<<$MODULEPATH | sort )"
     compgen -W "$modules" -- $1
 }
 
@@ -38,7 +38,7 @@ _module_avail ()
     local modules="$( \
         module avail 2>&1 | \
         command grep -E -v '^(-|$)' | \
-        xargs printf '%s\n' | sed -e 's/(default)//g' | sort )"
+        xargs printf '%s\n' | command sed -e 's/(default)//g' | sort )"
 
     compgen -W "$modules" -- $1
 }
@@ -54,7 +54,7 @@ _module ()
 
         local options
         options="$( module help 2>&1 | command grep -E '^[[:space:]]*\+' | \
-                    awk '{print $2}' | sed -e 's/|/ /g' | sort )"
+                    awk '{print $2}' | command sed -e 's/|/ /g' | sort )"
 
         COMPREPLY=( $(compgen -W "$options" -- "$cur") )
 

--- a/completions/_svn
+++ b/completions/_svn
@@ -35,7 +35,7 @@ _svn()
                 ;;
             --encoding)
                 COMPREPLY=( $( compgen -W '$( iconv --list | \
-                    sed -e "s@//@@;" )' -- "$cur" ) )
+                    command sed -e "s@//@@;" )' -- "$cur" ) )
                 return 0
                 ;;
             --editor-cmd|--diff-cmd|--diff3-cmd)

--- a/completions/_yum
+++ b/completions/_yum
@@ -9,12 +9,12 @@ _yum_list()
         # Try to strip in between headings like "Available Packages"
         # This will obviously only work for English :P
         COMPREPLY=( $( yum -d 0 -C list $1 "$cur*" 2>/dev/null | \
-            sed -ne '/^Available /d' -e '/^Installed /d' -e '/^Updated /d' \
+            command sed -ne '/^Available /d' -e '/^Installed /d' -e '/^Updated /d' \
             -e 's/[[:space:]].*//p' ) )
     else
         # Drop first line (e.g. "Updated Packages")
         COMPREPLY=( $( yum -d 0 -C list $1 "$cur*" 2>/dev/null | \
-            sed -ne 1d -e 's/[[:space:]].*//p' ) )
+            command sed -ne 1d -e 's/[[:space:]].*//p' ) )
     fi
 }
 
@@ -24,13 +24,13 @@ _yum_repolist()
     # http://yum.baseurl.org/ticket/83
     # Drop first ("repo id      repo name") and last ("repolist: ...") rows
     yum --noplugins -C repolist $1 2>/dev/null | \
-        sed -ne '/^repo\s\s*id/d' -e '/^repolist:/d' -e 's/[[:space:]].*//p'
+        command sed -ne '/^repo\s\s*id/d' -e '/^repolist:/d' -e 's/[[:space:]].*//p'
 }
 
 _yum_plugins()
 {
     command ls /usr/lib/yum-plugins/*.py{,c,o} 2>/dev/null \
-        | sed -ne 's|.*/\([^./]*\)\.py[co]\{0,1\}$|\1|p' | sort -u
+        | command sed -ne 's|.*/\([^./]*\)\.py[co]\{0,1\}$|\1|p' | sort -u
 }
 
 _yum()

--- a/completions/abook
+++ b/completions/abook
@@ -23,12 +23,12 @@ _abook()
     case $prev in
         --informat)
             COMPREPLY=( $( compgen -W "$($1 --formats | \
-                sed -n -e 's/^'$'\t''\([a-z]*\).*/\1/p' -e '/^$/q')" -- "$cur" ) )
+                command sed -n -e 's/^'$'\t''\([a-z]*\).*/\1/p' -e '/^$/q')" -- "$cur" ) )
             return 0
             ;;
         --outformat)
             COMPREPLY=( $( compgen -W "$($1 --formats | \
-                sed -n -e '/^$/,$s/^'$'\t''\([a-z]*\).*/\1/p')" -- "$cur" ) )
+                command sed -n -e '/^$/,$s/^'$'\t''\([a-z]*\).*/\1/p')" -- "$cur" ) )
             return 0
             ;;
         --infile)

--- a/completions/adb
+++ b/completions/adb
@@ -4,7 +4,7 @@ _adb_command_usage()
 {
     COMPREPLY=( $( compgen -W \
         '$( "$1" help 2>&1 | command grep "^ *\(adb \)\? *$2 " \
-            | sed -e "s/[]|[]/\n/g" | _parse_help - )' -- "$cur" ) )
+            | command sed -e "s/[]|[]/\n/g" | _parse_help - )' -- "$cur" ) )
 }
 
 _adb()
@@ -53,7 +53,7 @@ _adb()
             ;;
         forward)
             COMPREPLY=( $( compgen -W \
-                '$( "$1" help 2>&1 | sed -ne "s/^ *adb  *forward  *-/-/p" | \
+                '$( "$1" help 2>&1 | command sed -ne "s/^ *adb  *forward  *-/-/p" | \
                     _parse_help - )' -- "$cur" ) )
             ;;
         reboot)

--- a/completions/alias
+++ b/completions/alias
@@ -10,7 +10,7 @@ _alias()
             COMPREPLY=( $( compgen -A alias -- "$cur" ) )
             ;;
         *=)
-            COMPREPLY=( "$( alias ${cur%=} 2>/dev/null | sed \
+            COMPREPLY=( "$( alias ${cur%=} 2>/dev/null | command sed \
                 -e 's|^alias '"$cur"'\(.*\)$|\1|' )" )
             ;;
     esac

--- a/completions/appdata-validate
+++ b/completions/appdata-validate
@@ -11,7 +11,7 @@ _appdata_validate()
             ;;
         --output-format)
             COMPREPLY=( $( compgen -W "$( $1 --help |
-                sed -ne 's/--output-format.*\[\(.*\)\]/\1/' -e 's/|/ /gp' )" \
+                command sed -ne 's/--output-format.*\[\(.*\)\]/\1/' -e 's/|/ /gp' )" \
                     -- "$cur" ) )
             return
             ;;

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -47,7 +47,7 @@ _apt_get()
         -t|--target-release|--default-release)
              COMPREPLY=( $( apt-cache policy | \
                  command grep "release.o=Debian,a=$cur" | \
-                 sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2> /dev/null) )
+                 command sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2> /dev/null) )
              return 0
              ;;
     esac

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -66,7 +66,7 @@ _aptitude()
         -t|--target-release|--default-release)
             COMPREPLY=( $( apt-cache policy | \
                 command grep "release.o=Debian,a=$cur" | \
-                sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2> /dev/null ) )
+                command sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2> /dev/null ) )
             return 0
             ;;
     esac

--- a/completions/complete
+++ b/completions/complete
@@ -29,7 +29,7 @@ _complete()
             return 0
             ;;
         -p|-r)
-            COMPREPLY=( $( complete -p | sed -e 's|.* ||' ) )
+            COMPREPLY=( $( complete -p | command sed -e 's|.* ||' ) )
             COMPREPLY=( $( compgen -W '${COMPREPLY[@]}' -- "$cur" ) )
             return 0
             ;;

--- a/completions/configure
+++ b/completions/configure
@@ -29,7 +29,7 @@ _configure()
     if [[ -n $COMP_CONFIGURE_HINTS ]]; then
         COMPREPLY=( $( compgen -W "$( $1 --help 2>&1 | \
             awk '/^  --[A-Za-z]/ { print $1; \
-            if ($2 ~ /--[A-Za-z]/) print $2 }' | sed -e 's/[[,].*//g' )" \
+            if ($2 ~ /--[A-Za-z]/) print $2 }' | command sed -e 's/[[,].*//g' )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *=* ]] && compopt -o nospace
     else

--- a/completions/cpan2dist
+++ b/completions/cpan2dist
@@ -29,7 +29,7 @@ _cpan2dist()
                 packagelist="$dir/02packages.details.txt.gz"
         done
         [[ $packagelist ]] && COMPREPLY=( $( zgrep "^${cur//-/::}" \
-            $packagelist 2>/dev/null | awk '{print $1}' | sed -e 's/::/-/g' ) )
+            $packagelist 2>/dev/null | awk '{print $1}' | command sed -e 's/::/-/g' ) )
     fi
 } &&
 complete -F _cpan2dist -o default cpan2dist

--- a/completions/cvs
+++ b/completions/cvs
@@ -248,9 +248,9 @@ _cvs()
                     # far, but other changes (something other than
                     # changed/removed/new) may be missing
                     changed=( $( cvs -q diff --brief 2>&1 | \
-                        sed -ne 's/^Files [^ ]* and \([^ ]*\) differ$/\1/p' ) )
+                        command sed -ne 's/^Files [^ ]* and \([^ ]*\) differ$/\1/p' ) )
                     newremoved=( $( cvs -q diff --brief 2>&1 | \
-                        sed -ne 's/^cvs diff: \([^ ]*\) .*, no comparison available$/\1/p' ) )
+                        command sed -ne 's/^cvs diff: \([^ ]*\) .*, no comparison available$/\1/p' ) )
                     COMPREPLY=( $( compgen -W '${changed[@]:-} \
                         ${newremoved[@]:-}' -- "$cur" ) )
                 else

--- a/completions/dict
+++ b/completions/dict
@@ -2,7 +2,7 @@
 
 _dictdata()
 {
-    dict $host $port $1 2>/dev/null | sed -ne \
+    dict $host $port $1 2>/dev/null | command sed -ne \
         's/^['$'\t '']\{1,\}\([^ '$'\t'']*\).*$/\1/p'
 }
 

--- a/completions/dot
+++ b/completions/dot
@@ -13,13 +13,13 @@ _dot()
             ;;
         -T*)
             local langs=( $( "$1" -TNON_EXISTENT 2>&1 | \
-                sed -ne 's/.*one of://p' ) )
+                command sed -ne 's/.*one of://p' ) )
             COMPREPLY=( $( compgen -P -T -W '${langs[@]}' -- "${cur#-T}" ) )
             return
             ;;
         -K*)
             local layouts=( $( "$1" -KNON_EXISTENT 2>&1 | \
-                sed -ne 's/.*one of://p' ) )
+                command sed -ne 's/.*one of://p' ) )
             COMPREPLY=( $( compgen -P -K -W '${layouts[@]}' -- "${cur#-K}" ) )
             return
             ;;

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -12,7 +12,7 @@ _fbgs()
             return
             ;;
         -m|--mode)
-            COMPREPLY=( $( compgen -W '$( sed \
+            COMPREPLY=( $( compgen -W '$( command sed \
                 -n "/^mode/{s/^mode \{1,\}\"\([^\"]\{1,\}\)\"/\1/g;p}" \
                 /etc/fb.modes 2> /dev/null )' -- "$cur" ) )
             return

--- a/completions/fbi
+++ b/completions/fbi
@@ -20,7 +20,7 @@ _fbi()
             return
             ;;
         -m|--mode)
-            COMPREPLY=( $( compgen -W '$( sed \
+            COMPREPLY=( $( compgen -W '$( command sed \
                 -n "/^mode/{s/^mode \{1,\}\"\([^\"]\{1,\}\)\"/\1/g;p}" \
                 /etc/fb.modes 2> /dev/null )' -- "$cur" ) )
             return

--- a/completions/function
+++ b/completions/function
@@ -14,7 +14,7 @@ _function()
     elif [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -A function -- "$cur" ) )
     else
-        COMPREPLY=( "() $( type -- ${words[1]} | sed -e 1,2d )" )
+        COMPREPLY=( "() $( type -- ${words[1]} | command sed -e 1,2d )" )
     fi
 } &&
 complete -F _function function declare typeset

--- a/completions/gcc
+++ b/completions/gcc
@@ -42,7 +42,7 @@ _gcc()
         # for C/C++/ObjectiveC it's useless
         # for FORTRAN/Java it's an error
         COMPREPLY=( $( compgen -W "$( $cc --help 2>/dev/null | tr '\t' ' ' |\
-           sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/' )" -- "$cur" ) )
+           command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/' )" -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     else
         _filedir

--- a/completions/gdb
+++ b/completions/gdb
@@ -27,7 +27,7 @@ _gdb()
             # names manually.
             IFS=":"
             local path_array=( $( \
-                sed -e 's/:\{2,\}/:/g' -e 's/^://' -e 's/:$//' <<<"$PATH" ) )
+                command sed -e 's/:\{2,\}/:/g' -e 's/^://' -e 's/:$//' <<<"$PATH" ) )
             IFS=$'\n'
             COMPREPLY=( $( compgen -d -W '$(find "${path_array[@]}" . \
                 -mindepth 1 -maxdepth 1 -not -type d -executable \

--- a/completions/gnokii
+++ b/completions/gnokii
@@ -25,7 +25,7 @@ _gnokii()
             done
             [[ ! -f $config_file ]] && return
             COMPREPLY=( $( compgen -W \
-                "$( sed -n 's/^\[phone_\(.*\)\]/\1/p' $config_file )" \
+                "$( command sed -n 's/^\[phone_\(.*\)\]/\1/p' $config_file )" \
 		-- "$cur" ) )
             return
             ;;

--- a/completions/gpg
+++ b/completions/gpg
@@ -12,16 +12,16 @@ _gpg()
             ;;
         --export|--sign-key|--lsign-key|--nrsign-key|--nrlsign-key|--edit-key)
             # return list of public keys
-            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | \
-                sed -ne 's@^pub.*/\([^ ]*\).*$@\1@p' \
-                    -ne 's@^.*\(<\([^>]*\)>\).*$@\2@p' )" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | command sed -ne \
+                's@^pub.*/\([^ ]*\).*$@\1@p' -ne \
+                's@^.*\(<\([^>]*\)>\).*$@\2@p' )" -- "$cur" ) )
             return 0
             ;;
         -r|--recipient)
-            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | \
-                sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | command sed -ne \
+                's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur" ) )
             if [[ -e ~/.gnupg/gpg.conf ]]; then
-                COMPREPLY+=( $( compgen -W "$( sed -ne \
+                COMPREPLY+=( $( compgen -W "$( command sed -ne \
                     's@^[ \t]*group[ \t][ \t]*\([^=]*\).*$@\1@p' \
                     ~/.gnupg/gpg.conf  )" -- "$cur" ) )
             fi

--- a/completions/gpg2
+++ b/completions/gpg2
@@ -16,16 +16,16 @@ _gpg2()
             ;;
         --export|--sign-key|--lsign-key|--nrsign-key|--nrlsign-key|--edit-key)
             # return list of public keys
-            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | \
-                sed -ne 's@^pub.*/\([^ ]*\).*$@\1@p' \
-                    -ne 's@^.*\(<\([^>]*\)>\).*$@\2@p' )" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | command sed -ne \
+                's@^pub.*/\([^ ]*\).*$@\1@p' -ne \
+                's@^.*\(<\([^>]*\)>\).*$@\2@p' )" -- "$cur" ) )
             return 0
             ;;
         -r|--recipient)
             COMPREPLY=( $( compgen -W "$( $1 --list-keys 2>/dev/null | \
-                sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur" ) )
+                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur" ) )
             if [[ -e ~/.gnupg/gpg.conf ]]; then
-                COMPREPLY+=( $( compgen -W "$( sed -ne \
+                COMPREPLY+=( $( compgen -W "$( command sed -ne \
                     's@^[ \t]*group[ \t][ \t]*\([^=]*\).*$@\1@p' \
                     ~/.gnupg/gpg.conf)" -- "$cur" ) )
             fi

--- a/completions/iconv
+++ b/completions/iconv
@@ -12,7 +12,7 @@ _iconv()
             ;;
         -f|--from-code|-t|--to-code)
             COMPREPLY=( $( compgen -W '$( iconv -l | \
-                sed -e "s@/*\$@@" -e "s/[,()]//g" )' -- "$cur" ) )
+                command sed -e "s@/*\$@@" -e "s/[,()]//g" )' -- "$cur" ) )
             return 0
             ;;
         -o|--output)

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -20,12 +20,12 @@ _invoke_rc_d()
     if [[ ($cword -eq 1) || ("$prev" == --* ) ]]; then
     valid_options=( $( \
         tr " " "\n" <<<"${words[@]} ${options[@]}" \
-        | sed -ne "/$( sed "s/ /\\\\|/g" <<<"${options[@]}" )/p" \
+        | command sed -ne "/$( command sed "s/ /\\\\|/g" <<<"${options[@]}" )/p" \
         | sort | uniq -u \
         ) )
     COMPREPLY=( $( compgen -W '${valid_options[@]} ${services[@]}' -- "$cur" ) )
     elif [[ -x $sysvdir/$prev ]]; then
-        COMPREPLY=( $( compgen -W '`sed -e "y/|/ /" \
+        COMPREPLY=( $( compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}\"]*\).*$/\1/p" \
             $sysvdir/$prev`' -- "$cur" ) )
     else

--- a/completions/ip
+++ b/completions/ip
@@ -49,9 +49,11 @@ _ip()
                 return 0
                 ;;
             *)
-                COMPREPLY=( $( compgen -W "help $( ip help 2>&1 | \
-                    sed -e '/OBJECT := /,/}/!d' \
-                        -e 's/.*{//' -e 's/}.*//' -e 's/|//g' )" -- "$cur" ) )
+                COMPREPLY=( $( compgen -W "help $( ip help 2>&1 | command sed -e \
+                    '/OBJECT := /,/}/!d' -e \
+                    's/.*{//' -e \
+                    's/}.*//' -e \
+                    's/|//g' )" -- "$cur" ) )
                 return 0
                 ;;
         esac

--- a/completions/iperf
+++ b/completions/iperf
@@ -45,10 +45,10 @@ _iperf()
     for i in ${words[@]}; do
         case $i in
             -s|--server)
-                filter='sed -e /^Client.specific/,/^$/d'
+                filter='command sed -e /^Client.specific/,/^$/d'
                 ;;
             -c|--client)
-                filter='sed -e /^Server.specific/,/^$/d'
+                filter='command sed -e /^Server.specific/,/^$/d'
                 ;;
         esac
     done

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -3,7 +3,7 @@
 _ipmitool_singleline_help()
 {
     COMPREPLY=( $( compgen -W "$( $1 $2 2>&1 | \
-        sed -ne 's/[,\r]//g' -e 's/^.*[Cc]ommands://p' )" -- "$cur" ) )
+        command sed -ne 's/[,\r]//g' -e 's/^.*[Cc]ommands://p' )" -- "$cur" ) )
 }
 
 _ipmitool()
@@ -18,13 +18,13 @@ _ipmitool()
         -d)
             COMPREPLY=( $( compgen -W "$( \
                 command ls -d /dev/ipmi* /dev/ipmi/* /dev/ipmidev/* \
-                2>/dev/null | sed -ne 's/^[^0-9]*\([0-9]\{1,\}\)/\1/p' )" \
+                2>/dev/null | command sed -ne 's/^[^0-9]*\([0-9]\{1,\}\)/\1/p' )" \
                 -- "$cur" ) )
             return 0
             ;;
         -I)
             COMPREPLY=( $( compgen -W "$( $1 -h 2>&1 | \
-                sed -e '/^Interfaces:/,/^[[:space:]]*$/!d' \
+                command sed -e '/^Interfaces:/,/^[[:space:]]*$/!d' \
                 -ne 's/^[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p' )" \
                 -- "$cur" ) )
             return 0

--- a/completions/iptables
+++ b/completions/iptables
@@ -18,7 +18,7 @@ _iptables()
     case $prev in
     -*[AIDRPFXLZ])
         COMPREPLY=( $( compgen -W '`iptables $table -nL | \
-                sed -ne "s/^Chain \([^ ]\{1,\}\).*$/\1/p"`' -- "$cur" ) )
+                command sed -ne "s/^Chain \([^ ]\{1,\}\).*$/\1/p"`' -- "$cur" ) )
         ;;
     -*t)
         COMPREPLY=( $( compgen -W 'nat filter mangle' -- "$cur" ) )
@@ -26,17 +26,17 @@ _iptables()
     -j)
         if [[ "$table" == "-t filter" || -z "$table" ]]; then
             COMPREPLY=( $( compgen -W 'ACCEPT DROP LOG ULOG REJECT
-                `iptables $table -nL | sed -ne "$chain" \
+                `iptables $table -nL | command sed -ne "$chain" \
                 -e "s/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//"`' -- \
                 "$cur" ) )
         elif [[ $table == "-t nat" ]]; then
             COMPREPLY=( $( compgen -W 'ACCEPT DROP LOG ULOG REJECT MIRROR SNAT
                 DNAT MASQUERADE `iptables $table -nL | \
-                sed -ne "$chain" -e "s/OUTPUT|PREROUTING|POSTROUTING//"`' \
+                command sed -ne "$chain" -e "s/OUTPUT|PREROUTING|POSTROUTING//"`' \
                 -- "$cur" ) )
         elif [[ $table == "-t mangle" ]]; then
             COMPREPLY=( $( compgen -W 'ACCEPT DROP LOG ULOG REJECT MARK TOS
-                `iptables $table -nL | sed -ne "$chain" \
+                `iptables $table -nL | command sed -ne "$chain" \
                 -e "s/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//"`' -- \
                 "$cur" ) )
         fi

--- a/completions/ipv6calc
+++ b/completions/ipv6calc
@@ -12,7 +12,7 @@ _ipv6calc()
         -I|--in|-O|--out|-A|--action)
             # With ipv6calc < 0.73.0, -m does nothing here, so use sed instead.
             COMPREPLY=( $( compgen -W "$( $1 "$prev" -h 2>&1 | \
-                sed -ne 's/^[[:space:]]\{1,\}\([^[:space:]:]\{1,\}\)[[:space:]]*:.*/\1/p' )" \
+                command sed -ne 's/^[[:space:]]\{1,\}\([^[:space:]:]\{1,\}\)[[:space:]]*:.*/\1/p' )" \
                 -- "$cur" ) )
             return 0
             ;;

--- a/completions/java
+++ b/completions/java
@@ -71,9 +71,9 @@ _java_classes()
 
         elif [[ -d $i ]]; then
             COMPREPLY+=(
-                $( compgen -d -- "$i/$cur" | sed -e "s|^$i/\(.*\)|\1.|" )
+                $( compgen -d -- "$i/$cur" | command sed -e "s|^$i/\(.*\)|\1.|" )
                 $( compgen -f -X '!*.class' -- "$i/$cur" | \
-                    sed -e '/\$/d' -e "s|^$i/||" )
+                    command sed -e '/\$/d' -e "s|^$i/||" )
             )
             [[ $COMPREPLY == *.class ]] || compopt -o nospace
 
@@ -103,7 +103,7 @@ _java_packages()
     for i in ${sourcepath//:/ }; do
         if [[ -d $i ]]; then
             COMPREPLY+=( $( command ls -F -d $i/$cur* 2>/dev/null | \
-                sed -e 's|^'$i'/||' ) )
+                command sed -e 's|^'$i'/||' ) )
         fi
     done
     # keep only packages
@@ -294,7 +294,7 @@ _javac()
         # For some reason there may be -g:none AND -g:{lines,source,vars};
         # convert the none case to the curly brace format so it parses like
         # the others.
-        local opts=$( "$1" $helpopt 2>&1 | sed -e 's/-g:none/-g:{none}/' -ne \
+        local opts=$( "$1" $helpopt 2>&1 | command sed -e 's/-g:none/-g:{none}/' -ne \
             "s/^[[:space:]]*${cur%%:*}:{\([^}]\{1,\}\)}.*/\1/p" )
         COMPREPLY=( $( compgen -W "${opts//,/ }" -- "${cur#*:}" ) )
         return

--- a/completions/kldunload
+++ b/completions/kldunload
@@ -8,7 +8,7 @@ _kldunload()
     _init_completion || return
 
     COMPREPLY=( $( kldstat | \
-        sed -ne "s/^.*[ $'\t']\{1,\}\($cur[a-z_]\{1,\}\).ko$/\1/p" ) )
+        command sed -ne "s/^.*[ $'\t']\{1,\}\($cur[a-z_]\{1,\}\).ko$/\1/p" ) )
 } &&
 complete -F _kldunload kldunload
 

--- a/completions/lilo
+++ b/completions/lilo
@@ -3,7 +3,7 @@
 _lilo_labels()
 {
     COMPREPLY=( $( compgen -W "$( awk -F'=' '/label/ {print $2}' \
-        /etc/lilo.conf | sed -e 's/\"//g' )" -- "$cur" ) )
+        /etc/lilo.conf | command sed -e 's/\"//g' )" -- "$cur" ) )
 }
 
 _lilo()

--- a/completions/lintian
+++ b/completions/lintian
@@ -10,7 +10,7 @@ _lintian_tags()
         for item in $search; do
             match=$( command grep -nE "^Tag: $item$" \
                 /usr/share/lintian/checks/*.desc | cut -d: -f1 )
-            tags=$( sed -e "s/\<$item\>//g" <<<$tags )
+            tags=$( command sed -e "s/\<$item\>//g" <<<$tags )
         done
         COMPREPLY+=( $(compgen -W "$tags") )
     elif [[ "$cur" == *,* ]]; then
@@ -34,7 +34,7 @@ _lintian_checks()
                 /usr/share/lintian/checks/*.desc | cut -d: -f1 )
             todisable=$( awk '/^(Check-Script|Abbrev)/ { print $2 }' $match )
             for name in $todisable; do
-                checks=$( sed -e "s/\<$name\>//g" <<<$checks )
+                checks=$( command sed -e "s/\<$name\>//g" <<<$checks )
             done
         done
         COMPREPLY+=( $(compgen -W "$checks") )
@@ -57,7 +57,7 @@ _lintian_infos()
         for item in $search; do
             match=$( command grep -nE "^Collector: $item$" \
                 /usr/share/lintian/collection/*.desc | cut -d: -f1 )
-            infos=$( sed -e "s/\<$item\>//g" <<<$infos )
+            infos=$( command sed -e "s/\<$item\>//g" <<<$infos )
         done
         COMPREPLY+=( $(compgen -W "$infos") )
     elif [[ "$cur" == *,* ]]; then

--- a/completions/lvm
+++ b/completions/lvm
@@ -3,19 +3,19 @@
 _lvm_volumegroups()
 {
     COMPREPLY=( $(compgen -W "$( vgscan 2>/dev/null | \
-        sed -n -e 's|.*Found.*"\(.*\)".*$|\1|p' )" -- "$cur" ) )
+        command sed -n -e 's|.*Found.*"\(.*\)".*$|\1|p' )" -- "$cur" ) )
 }
 
 _lvm_physicalvolumes()
 {
     COMPREPLY=( $(compgen -W "$( pvscan 2>/dev/null | \
-        sed -n -e 's|^.*PV \(.*\) VG.*$|\1|p' )" -- "$cur" ) )
+        command sed -n -e 's|^.*PV \(.*\) VG.*$|\1|p' )" -- "$cur" ) )
 }
 
 _lvm_logicalvolumes()
 {
     COMPREPLY=( $(compgen -W "$( lvscan 2>/dev/null | \
-        sed -n -e "s|^.*'\(.*\)'.*$|\1|p" )" -- "$cur" ) )
+        command sed -n -e "s|^.*'\(.*\)'.*$|\1|p" )" -- "$cur" ) )
     if [[ $cur == /dev/mapper/* ]]; then
         _filedir
         local i

--- a/completions/lz4
+++ b/completions/lz4
@@ -14,7 +14,7 @@ _lz4()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W \
-            '$( _parse_help "$1" -h | sed -e "/#/d" ) -B{4..7} -i{1..9}' \
+            '$( _parse_help "$1" -h | command sed -e "/#/d" ) -B{4..7} -i{1..9}' \
             -- "$cur" ) )
         return
     fi

--- a/completions/make
+++ b/completions/make
@@ -7,7 +7,7 @@ function _make_target_extract_script()
 
     local prefix="$1"
     local prefix_pat=$( printf "%s\n" "$prefix" | \
-                        sed 's/[][\,.*^$(){}?+|/]/\\&/g' )
+                        command sed 's/[][\,.*^$(){}?+|/]/\\&/g' )
     local basename=${prefix##*/}
     local dirname_len=$(( ${#prefix} - ${#basename} ))
 
@@ -157,7 +157,7 @@ _make()
         COMPREPLY=( $( LC_ALL=C \
             make -npq __BASH_MAKE_COMPLETION__=1 \
                 "${makef[@]}" "${makef_dir[@]}" .DEFAULT 2>/dev/null | \
-            sed -nf <(_make_target_extract_script $mode "$cur") ) )
+            command sed -nf <(_make_target_extract_script $mode "$cur") ) )
         $reset
 
         if [[ $mode != -d ]]; then

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -28,7 +28,7 @@ _mcrypt()
             ;;
         -h|--hash)
             COMPREPLY=( $( compgen -W '$( $1 --list-hash 2>/dev/null | \
-                sed -e 1d )' -- "$cur" ) )
+                command sed -e 1d )' -- "$cur" ) )
             return 0
             ;;
         -k|-s|--key|--keysize)

--- a/completions/medusa
+++ b/completions/medusa
@@ -16,7 +16,7 @@ _medusa()
             ;;
         -M)
             COMPREPLY=( $( compgen -W "$($1 -d | awk '/^ +\+/ {print $2}' \
-                | sed -e 's/\.mod$//')" ) )
+                | command sed -e 's/\.mod$//')" ) )
             return 0
             ;;
     esac

--- a/completions/minicom
+++ b/completions/minicom
@@ -30,7 +30,7 @@ _minicom()
     else
         COMPREPLY=(
             $( command ls /etc/minirc.* /etc/minicom/minirc.* ~/.minirc.* \
-                       2>/dev/null | sed 's|^.*minirc\.||' | \
+                       2>/dev/null | command sed 's|^.*minirc\.||' | \
                    grep "^${cur}" ) )
         [[ $COMPREPLY ]] && return
     fi

--- a/completions/mount
+++ b/completions/mount
@@ -42,8 +42,8 @@ _mount()
         if [[ -n $host ]]; then
             COMPREPLY=( $( compgen -P "//$host" -W \
                 "$( smbclient -d 0 -NL $host 2>/dev/null |
-                sed -ne '/^['"$'\t '"']*Sharename/,/^$/p' |
-                sed -ne '3,$s|^[^A-Za-z]*\([^'"$'\t '"']*\).*$|/\1|p' )" \
+                command sed -ne '/^['"$'\t '"']*Sharename/,/^$/p' |
+                command sed -ne '3,$s|^[^A-Za-z]*\([^'"$'\t '"']*\).*$|/\1|p' )" \
                     -- "${cur#//$host}" ) )
         fi
     elif [[ -r /etc/vfstab ]]; then

--- a/completions/mount.linux
+++ b/completions/mount.linux
@@ -232,8 +232,8 @@ _mount()
         if [[ -n $host ]]; then
             COMPREPLY=( $( compgen -P "//$host" -W \
                 "$( smbclient -d 0 -NL $host 2>/dev/null |
-                sed -ne '/^['"$'\t '"']*Sharename/,/^$/p' |
-                sed -ne '3,$s|^[^A-Za-z]*\([^'"$'\t '"']*\).*$|/\1|p' )" \
+                command sed -ne '/^['"$'\t '"']*Sharename/,/^$/p' |
+                command sed -ne '3,$s|^[^A-Za-z]*\([^'"$'\t '"']*\).*$|/\1|p' )" \
                     -- "${cur#//$host}" ) )
         fi
     fi

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -4,8 +4,8 @@ _mplayer_options_list()
 {
     cur=${cur%\\}
     COMPREPLY=( $( compgen -W "$( $1 -nomsgcolor -nomsgmodule $2 help 2>/dev/null | \
-        sed -e '/^Available/,/^$/!d' -e '/^Available/d' | awk '{print $1}' | \
-        sed -e 's/:$//' -e 's/^'${2#-}'$//' -e 's/<.*//' )" -- "$cur" ) )
+        command sed -e '/^Available/,/^$/!d' -e '/^Available/d' | awk '{print $1}' | \
+        command sed -e 's/:$//' -e 's/^'${2#-}'$//' -e 's/<.*//' )" -- "$cur" ) )
 }
 
 _mplayer()
@@ -57,7 +57,7 @@ _mplayer()
             ;;
         -subcp|-msgcharset)
             local cp
-            cp=( $( iconv --list 2>/dev/null | sed -e "s@//@@;" 2>/dev/null ) )
+            cp=( $( iconv --list 2>/dev/null | command sed -e "s@//@@;" 2>/dev/null ) )
             if [[ "$cur" == "${cur,,}" ]]; then
                 COMPREPLY=( $( compgen -W '${cp[@],,}' -- "$cur" ) )
             else
@@ -275,7 +275,7 @@ _mplayer()
     case $cur in
         -*)
             COMPREPLY=( $( compgen -W '$( $cmd -nomsgcolor -nomsgmodule -list-options 2>/dev/null | \
-                sed -ne '1,/^[[:space:]]*Name/d' \
+                command sed -ne '1,/^[[:space:]]*Name/d' \
                     -e "s/^[[:space:]]*/-/" -e "s/[[:space:]:].*//" \
                     -e "/^-\(Total\|.*\*\)\{0,1\}$/!p" )' -- "$cur" ) )
             ;;

--- a/completions/msynctool
+++ b/completions/msynctool
@@ -8,13 +8,13 @@ _msynctool()
     case $words in
         --configure)
             COMPREPLY=( $( compgen -W "$($1 --showgroup \
-                $prev | awk '/^Member/ {print $2}' | sed \
+                $prev | awk '/^Member/ {print $2}' | command sed \
                 -e 's/:$//' )" -- "$cur" ) )
             return 0
             ;;
         --addmember)
             COMPREPLY=( $( compgen -W '$($1 --listplugins \
-                | sed -e '1d' )' -- "$cur" ) )
+                | command sed -e '1d' )' -- "$cur" ) )
             return 0
             ;;
     esac
@@ -22,12 +22,12 @@ _msynctool()
     case $prev in
         --configure|--addgroup|--delgroup|--showgroup|--sync|--addmember)
             COMPREPLY=( $( compgen -W '$($1 --listgroups \
-                | sed -e '1d' )' -- "$cur" ) )
+                | command sed -e '1d' )' -- "$cur" ) )
             return 0
             ;;
         --showformats|--filter-objtype|--slow-sync)
             COMPREPLY=( $( compgen -W '$($1 --listobjects \
-                | sed -e '1d' )' -- "$cur" ) )
+                | command sed -e '1d' )' -- "$cur" ) )
             return 0
             ;;
     esac

--- a/completions/mutt
+++ b/completions/mutt
@@ -57,7 +57,7 @@ _muttconffiles()
     sofar=" $1 "
     shift
     while [[ "$1" ]]; do
-        newconffiles=( $(sed -n 's|^source[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' $(eval printf %s $1) ) )
+        newconffiles=( $(command sed -n 's|^source[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' $(eval printf %s $1) ) )
         for file in "${newconffiles[@]}"; do
             __expand_tilde_by_ref file
             [[ ! -f "$file" || $sofar == *\ $file\ * ]] && continue
@@ -80,7 +80,7 @@ _muttaliases()
     [[ -z $muttrc ]] && return 0
 
     conffiles=( $(eval _muttconffiles $muttrc $muttrc) )
-    aliases=( $( sed -n 's|^alias[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' \
+    aliases=( $( command sed -n 's|^alias[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' \
         $(eval echo "${conffiles[@]}") ) )
     COMPREPLY+=( $( compgen -W "${aliases[*]}" -- "$cur" ) )
 
@@ -94,13 +94,13 @@ _muttquery()
     local cur=$1 querycmd muttcmd=${words[0]}
     local -a queryresults
 
-    querycmd="$( $muttcmd -Q query_command 2>/dev/null | sed -e 's|^query_command=\"\(.*\)\"$|\1|' -e 's|%s|'$cur'|' )"
+    querycmd="$( $muttcmd -Q query_command 2>/dev/null | command sed -e 's|^query_command=\"\(.*\)\"$|\1|' -e 's|%s|'$cur'|' )"
     if [[ -z "$cur" || -z "$querycmd" ]]; then
         queryresults=()
     else
         __expand_tilde_by_ref querycmd
         queryresults=( $( $querycmd | \
-            sed -n '2,$s|^\([^[:space:]]\{1,\}\).*|\1|p' ) )
+            command sed -n '2,$s|^\([^[:space:]]\{1,\}\).*|\1|p' ) )
     fi
 
     COMPREPLY+=( $( compgen -W "${queryresults[*]}" -- "$cur" ) )
@@ -116,7 +116,7 @@ _muttfiledir()
 
     muttrc=$(_muttrc)
     if [[ $cur == [=+]* ]]; then
-        folder="$( $muttcmd -F "$muttrc" -Q folder 2>/dev/null | sed -e 's|^folder=\"\(.*\)\"$|\1|' )"
+        folder="$( $muttcmd -F "$muttrc" -Q folder 2>/dev/null | command sed -e 's|^folder=\"\(.*\)\"$|\1|' )"
         : folder:=~/Mail
 
         # Match any file in $folder beginning with $cur
@@ -127,7 +127,7 @@ _muttfiledir()
         return 0
     elif [[ $cur == !* ]]; then
         spoolfile="$( $muttcmd -F "$muttrc" -Q spoolfile 2>/dev/null | \
-            sed -e 's|^spoolfile=\"\(.*\)\"$|\1|' )"
+            command sed -e 's|^spoolfile=\"\(.*\)\"$|\1|' )"
         [[ ! -z $spoolfile ]] && eval cur="${cur/^!/$spoolfile}"
     fi
     _filedir

--- a/completions/mysql
+++ b/completions/mysql
@@ -11,7 +11,7 @@ _mysql()
             return 0
             ;;
         -D|--database)
-            COMPREPLY=( $( compgen -W "$(mysqlshow 2>/dev/null|sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" -- "$cur" ) )
+            COMPREPLY=( $( compgen -W "$(mysqlshow 2>/dev/null | command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" -- "$cur" ) )
             return 0
             ;;
 
@@ -21,7 +21,7 @@ _mysql()
             ;;
         --default-character-set)
             [[ -d /usr/share/mysql/charsets ]] && \
-                COMPREPLY=( $( compgen -W "$(command ls /usr/share/mysql/charsets|sed -e '/^\(README\|Index\.xml\)$/d' -e 's/.xml$//') utf8" -- "$cur" ) )
+                COMPREPLY=( $( compgen -W "$(command ls /usr/share/mysql/charsets | command sed -e '/^\(README\|Index\.xml\)$/d' -e 's/.xml$//') utf8" -- "$cur" ) )
             return 0
             ;;
 
@@ -74,7 +74,7 @@ _mysql()
     esac
 
     COMPREPLY=( $( compgen -W \
-        "$(mysqlshow 2>/dev/null|sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" \
+        "$(mysqlshow 2>/dev/null | command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" \
         -- "$cur" ) )
 } &&
 complete -F _mysql mysql

--- a/completions/ncftp
+++ b/completions/ncftp
@@ -17,7 +17,7 @@ _ncftp()
     fi
 
     if [[ $cword -eq 1 && -f ~/.ncftp/bookmarks ]]; then
-        COMPREPLY=( $( compgen -W '$( sed -ne "s/^\([^,]\{1,\}\),.*$/\1/p" \
+        COMPREPLY=( $( compgen -W '$( command sed -ne "s/^\([^,]\{1,\}\),.*$/\1/p" \
             ~/.ncftp/bookmarks )' -- "$cur" ) )
     fi
 

--- a/completions/pdftotext
+++ b/completions/pdftotext
@@ -11,7 +11,7 @@ _pdftotext()
             ;;
         -enc)
             COMPREPLY=( $( compgen -W '$( "$1" -listenc 2>/dev/null |
-                sed -e 1d )' -- "$cur" ) )
+                command sed -e 1d )' -- "$cur" ) )
             return
             ;;
         -eol)

--- a/completions/perl
+++ b/completions/perl
@@ -125,7 +125,7 @@ _perldoc()
             if [[ $cur == p* ]]; then
                 COMPREPLY+=( $( compgen -W \
                     '$( PERLDOC_PAGER=/bin/cat "$1" -u perl |  \
-                     sed -ne "/perl.*Perl overview/,/perlwin32/p" | \
+                     command sed -ne "/perl.*Perl overview/,/perlwin32/p" | \
                      awk "\$NF=2 && \$1 ~ /^perl/ { print \$1 }" )' \
                     -- "$cur" ) )
             fi

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -38,7 +38,7 @@ _pgrep()
     if [[ $cur == -* ]]; then
         local help='$( _parse_help "$1" )'
         [[ $help ]] || help='$( "$1" --usage 2>&1 |
-            sed -e "s/\[-signal\]//" -e "s/\[-SIGNAL\]//" |
+            command sed -e "s/\[-signal\]//" -e "s/\[-SIGNAL\]//" |
             _parse_usage - )'
         COMPREPLY=( $( compgen -W "$help" -- "$cur" ) )
         [[ $cword -eq 1 && $1 == *pkill ]] && _signals -

--- a/completions/pngfix
+++ b/completions/pngfix
@@ -15,7 +15,7 @@ _pngfix()
             ;;
         --strip)
             COMPREPLY=( $( IFS='|' compgen -W '$( "$1" --help 2>&1 |
-                sed -ne "s/.*--strip=\[\([^]]*\)\].*/\1/p" )' -- "$cur" ) )
+                command sed -ne "s/.*--strip=\[\([^]]*\)\].*/\1/p" )' -- "$cur" ) )
             return
             ;;
     esac

--- a/completions/postcat
+++ b/completions/postcat
@@ -25,7 +25,7 @@ _postcat()
         local len=${#cur} pval
         idx=0
         for pval in $( mailq 2>/dev/null | \
-            sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* !].*$//' ); do
+            command sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* !].*$//' ); do
             if [[ "$cur" == "${pval:0:$len}" ]]; then
                 COMPREPLY[$idx]=$pval
                 idx=$(($idx+1))

--- a/completions/postsuper
+++ b/completions/postsuper
@@ -16,7 +16,7 @@ _postsuper()
             len=${#cur}
             idx=0
             for pval in ALL $( mailq 2>/dev/null | \
-                sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* !].*$//' ); do
+                command sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* !].*$//' ); do
                 if [[ "$cur" == "${pval:0:$len}" ]]; then
                     COMPREPLY[$idx]=$pval
                     idx=$(($idx+1))
@@ -28,7 +28,7 @@ _postsuper()
             len=${#cur}
             idx=0
             for pval in ALL $( mailq 2>/dev/null | \
-                sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* ].*$//; /!$/d' ); do
+                command sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* ].*$//; /!$/d' ); do
                 if [[ "$cur" == "${pval:0:$len}" ]]; then
                     COMPREPLY[$idx]=$pval
                     idx=$(($idx+1))
@@ -40,7 +40,7 @@ _postsuper()
             len=${#cur}
             idx=0
             for pval in ALL $( mailq 2>/dev/null | \
-                sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; /^[0-9A-Z]*[* ]/d; s/!.*$//' ); do
+                command sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; /^[0-9A-Z]*[* ]/d; s/!.*$//' ); do
                 if [[ "$cur" == "${pval:0:$len}" ]]; then
                     COMPREPLY[$idx]=$pval
                     idx=$(($idx+1))

--- a/completions/povray
+++ b/completions/povray
@@ -41,7 +41,7 @@ _povray()
             cur="${povcur#*\[}"
             pfx="${povcur%\["$cur"}" # prefix == filename
             [[ -r $pfx ]] || return 0
-            COMPREPLY=( $(sed -e 's/^[[:space:]]*\[\('"$cur"'[^]]*\]\).*$/\1/' \
+            COMPREPLY=( $(command sed -e 's/^[[:space:]]*\[\('"$cur"'[^]]*\]\).*$/\1/' \
                 -e 't' -e 'd' -- "$pfx") )
             # to prevent [bar] expand to nothing.  can be done more easily?
             COMPREPLY=( "${COMPREPLY[@]/#/$pfx[}" )

--- a/completions/puppet
+++ b/completions/puppet
@@ -22,7 +22,7 @@ _puppet_certs()
         && puppetca=puppetca
 
     if [[ "$1" == --all ]]; then
-        cert_list=$( $puppetca --list --all | sed -e 's/^[+-]\?\s*\(\S\+\)\s\+.*$/\1/' )
+        cert_list=$( $puppetca --list --all | command sed -e 's/^[+-]\?\s*\(\S\+\)\s\+.*$/\1/' )
     else
         cert_list=$( $puppetca --list )
     fi
@@ -31,7 +31,7 @@ _puppet_certs()
 
 _puppet_types()
 {
-    puppet_types=$( puppet describe --list | sed -e 's/^\(\S\+\).*$/\1/' )
+    puppet_types=$( puppet describe --list | command sed -e 's/^\(\S\+\).*$/\1/' )
     COMPREPLY+=( $( compgen -W "$puppet_types" -- "$cur" ) )
 }
 
@@ -41,7 +41,7 @@ _puppet_references()
     PATH=$PATH:/sbin:/usr/sbin:/usr/local/sbin type puppetdoc  &>/dev/null \
         && puppetdoc=puppetdoc
 
-    puppet_doc_list=$( $puppetdoc --list | sed -e 's/^\(\S\+\).*$/\1/' )
+    puppet_doc_list=$( $puppetdoc --list | command sed -e 's/^\(\S\+\).*$/\1/' )
     COMPREPLY+=( $( compgen -W "$puppet_doc_list" -- "$cur" ) )
 }
 

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -17,7 +17,7 @@ _pydoc()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W \
-            '$( "$1" | sed -e "s/^pydoc3\{0,1\} //" | _parse_help - )' \
+            '$( "$1" | command sed -e "s/^pydoc3\{0,1\} //" | _parse_help - )' \
             -- "$cur" ) )
         return
     fi
@@ -30,7 +30,7 @@ _pydoc()
     # Note that we don't do "pydoc modules" as it is known to hang on
     # some systems; _python_modules tends to work better and faster.
     COMPREPLY+=( $( compgen -W \
-        '$( $1 keywords topics | sed -e /^Here/d )' -- "$cur" ) )
+        '$( $1 keywords topics | command sed -e /^Here/d )' -- "$cur" ) )
 
     _filedir py
 } &&

--- a/completions/qdbus
+++ b/completions/qdbus
@@ -7,7 +7,7 @@ _qdbus()
 
     [[ -n $cur ]] && unset "words[$((${#words[@]}-1))]"
     COMPREPLY=( $( compgen -W '$( command ${words[@]} 2>/dev/null | \
-        sed "s/(.*)//" )' -- "$cur" ) )
+        command sed "s/(.*)//" )' -- "$cur" ) )
 } &&
 complete -F _qdbus qdbus dcop
 

--- a/completions/rpcdebug
+++ b/completions/rpcdebug
@@ -13,7 +13,7 @@ _rpcdebug_flags()
 
     if [[ -n $module ]]; then
         COMPREPLY=( $( compgen -W "$( rpcdebug -vh 2>&1 | \
-            sed -ne 's/^'$module'[[:space:]]\{1,\}//p' )" -- "$cur" ) )
+            command sed -ne 's/^'$module'[[:space:]]\{1,\}//p' )" -- "$cur" ) )
     fi
 }
 

--- a/completions/rpm
+++ b/completions/rpm
@@ -7,7 +7,7 @@ _rpm_installed_packages()
     if [[ -r /var/log/rpmpkgs && \
         /var/log/rpmpkgs -nt /var/lib/rpm/Packages ]]; then
         # using RHL 7.2 or later - this is quicker than querying the DB
-        COMPREPLY=( $( compgen -W "$( sed -ne \
+        COMPREPLY=( $( compgen -W "$( command sed -ne \
             's|^\([^[:space:]]\{1,\}\)-[^[:space:]-]\{1,\}-[^[:space:]-]\{1,\}\.rpm$|\1|p' \
             /var/log/rpmpkgs )" -- "$cur" ) )
     elif type rpmqpack &>/dev/null ; then
@@ -29,14 +29,14 @@ _rpm_groups()
 _rpm_macros()
 {
     # get a list of macros
-    COMPREPLY=( $( compgen -W "$( ${1:-rpm} --showrc | sed -ne \
+    COMPREPLY=( $( compgen -W "$( ${1:-rpm} --showrc | command sed -ne \
         's/^-\{0,1\}[0-9]\{1,\}[:=][[:space:]]\{1,\}\([^[:space:](]\{3,\}\).*/%\1/p' )" \
         -- "$cur" ) )
 }
 
 _rpm_buildarchs()
 {
-    COMPREPLY=( $( compgen -W "$( ${1:-rpm} --showrc | sed -ne \
+    COMPREPLY=( $( compgen -W "$( ${1:-rpm} --showrc | command sed -ne \
         's/^\s*compatible\s\s*build\s\s*archs\s*:\s*\(.*\)/\1/ p' )" \
         -- "$cur" ) )
 }
@@ -264,7 +264,7 @@ _rpmbuild()
             local cfgdir=$( $rpm --eval '%{_rpmconfigdir}' 2>/dev/null )
             if [[ $cfgdir ]]; then
                 COMPREPLY=( $( compgen -W "$( command ls $cfgdir 2>/dev/null \
-                    | sed -ne 's/^brp-//p' )" -- "$cur" ) )
+                    | command sed -ne 's/^brp-//p' )" -- "$cur" ) )
             fi
             ;;
         --define|-D|--with|--without)

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -61,7 +61,7 @@ _sbopkg()
     done
     [[ -r $REPO_ROOT/$REPO_NAME/$REPO_BRANCH/SLACKBUILDS.TXT ]] || return
 
-    COMPREPLY=( $( sed -ne "/^SLACKBUILD NAME: $cur/{s/^SLACKBUILD NAME: //;p}"\
+    COMPREPLY=( $( command sed -ne "/^SLACKBUILD NAME: $cur/{s/^SLACKBUILD NAME: //;p}"\
         $REPO_ROOT/$REPO_NAME/$REPO_BRANCH/SLACKBUILDS.TXT )
         $( cd $QUEUEDIR; compgen -f -X "!*.sqf"  -- "$cur" ) )
 } && complete -F _sbopkg sbopkg

--- a/completions/screen
+++ b/completions/screen
@@ -2,7 +2,7 @@
 
 _screen_sessions()
 {
-    local sessions=( $( command screen -ls | sed -ne \
+    local sessions=( $( command screen -ls | command sed -ne \
         's|^\t\{1,\}\([0-9]\{1,\}\.[^\t]\{1,\}\).*'"$1"'.*$|\1|p' ) )
     if [[ $cur == +([0-9])?(.*) ]]; then
         # Complete sessions including pid prefixes

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -57,12 +57,12 @@ _slapt_get()
             # it can search for names only
             local name=${cur%%-*}
             COMPREPLY=( $( LC_ALL=C "$1" -c "$config" --search "^$name" 2> \
-                /dev/null | LC_ALL=C sed -ne "/^$cur/{s/ .*$//;p}" ) )
+                /dev/null | LC_ALL=C command sed -ne "/^$cur/{s/ .*$//;p}" ) )
             return
             ;;
         avl) # --install|-i|
             COMPREPLY=( $( LC_ALL=C "$1" -c "$config" --available 2> \
-                /dev/null | LC_ALL=C sed -ne "/^$cur/{s/ .*$//;p}" ) )
+                /dev/null | LC_ALL=C command sed -ne "/^$cur/{s/ .*$//;p}" ) )
             return
             ;;
         ins) # --remove|--filelist

--- a/completions/slapt-src
+++ b/completions/slapt-src
@@ -55,11 +55,11 @@ _slapt_src()
         local name=${cur%:*}
         local version=${cur##*:}
         COMPREPLY=( $( LC_ALL=C "$1" --config "$config" --search "^$name" 2> \
-            /dev/null | LC_ALL=C sed -ne \
+            /dev/null | LC_ALL=C command sed -ne \
             "/^$cur/{s/^$name:\([^ ]*\) .*$/\1/;p}" ) )
     else
         COMPREPLY=( $( LC_ALL=C "$1" --config "$config" --search "^$cur" 2> \
-            /dev/null | LC_ALL=C sed -ne "/^$cur/{s/ .*$//;p}" ) )
+            /dev/null | LC_ALL=C command sed -ne "/^$cur/{s/ .*$//;p}" ) )
     fi
 } && complete -F _slapt_src slapt-src
 

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -16,7 +16,7 @@ _samba_hosts()
 {
     if [[ -n ${COMP_SAMBA_SCAN:-} ]]; then
         COMPREPLY=( $( compgen -W "$( smbtree -N -S | \
-            sed -ne 's/^[[:space:]]*\\\\*\([^[:space:]]*\).*/\1/p' \
+            command sed -ne 's/^[[:space:]]*\\\\*\([^[:space:]]*\).*/\1/p' \
             )" -- "$cur" ) )
     fi
 }

--- a/completions/ss
+++ b/completions/ss
@@ -17,7 +17,7 @@ _ss()
         -A|--query)
             local prefix=; [[ $cur == *,* ]] && prefix="${cur%,*},"
             COMPREPLY=( $( compgen -P "$prefix" -W '$( "$1" --help | \
-                sed -e "s/|/ /g" -ne "s/.*QUERY := {\([^}]*\)}.*/\1/p"  )' \
+                command sed -e "s/|/ /g" -ne "s/.*QUERY := {\([^}]*\)}.*/\1/p"  )' \
                 -- "${cur##*,}" ) )
             return
             ;;

--- a/completions/ssh
+++ b/completions/ssh
@@ -302,7 +302,7 @@ _scp_remote_files()
     local path=${cur#*:}
 
     # unescape (3 backslashes to 1 for chars we escaped)
-    path=$( sed -e 's/\\\\\\\('$_scp_path_esc'\)/\\\1/g' <<<"$path" )
+    path=$( command sed -e 's/\\\\\\\('$_scp_path_esc'\)/\\\1/g' <<<"$path" )
 
     # default to home dir of specified user on remote host
     if [[ -z $path ]]; then
@@ -314,13 +314,13 @@ _scp_remote_files()
         # escape problematic characters; remove non-dirs
         files=$( ssh -o 'Batchmode yes' $userhost \
             command ls -aF1dL "$path*" 2>/dev/null | \
-            sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e '/[^\/]$/d' )
+            command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e '/[^\/]$/d' )
     else
         # escape problematic characters; remove executables, aliases, pipes
         # and sockets; add space at end of file names
         files=$( ssh -o 'Batchmode yes' $userhost \
             command ls -aF1dL "$path*" 2>/dev/null | \
-            sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e 's/[*@|=]$//g' \
+            command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e 's/[*@|=]$//g' \
             -e 's/[^\/]$/& /g' )
     fi
     COMPREPLY+=( $files )
@@ -342,10 +342,10 @@ _scp_local_files()
 
     if $dirsonly ; then
         COMPREPLY+=( $( command ls -aF1dL $cur* 2>/dev/null | \
-            sed -e "s/$_scp_path_esc/\\\\&/g" -e '/[^\/]$/d' -e "s/^/$1/") )
+            command sed -e "s/$_scp_path_esc/\\\\&/g" -e '/[^\/]$/d' -e "s/^/$1/") )
     else
         COMPREPLY+=( $( command ls -aF1dL $cur* 2>/dev/null | \
-            sed -e "s/$_scp_path_esc/\\\\&/g" -e 's/[*@|=]$//g' \
+            command sed -e "s/$_scp_path_esc/\\\\&/g" -e 's/[*@|=]$//g' \
             -e 's/[^\/]$/& /g' -e "s/^/$1/") )
     fi
 }

--- a/completions/strings
+++ b/completions/strings
@@ -15,7 +15,7 @@ _strings()
             ;;
         -T|--target)
             COMPREPLY=( $( compgen -W '$( LC_ALL=C "$1" --help 2>/dev/null | \
-                sed -ne "s/: supported targets: \(.*\)/\1/p" )' -- "$cur" ) )
+                command sed -ne "s/: supported targets: \(.*\)/\1/p" )' -- "$cur" ) )
             return
             ;;
         -e|--encoding)

--- a/completions/svk
+++ b/completions/svk
@@ -28,7 +28,7 @@ _svk()
                 ;;
             --encoding)
                 COMPREPLY=( $( compgen -W \
-                    '$( iconv --list | sed -e "s@//@@;" )' -- "$cur" ) )
+                    '$( iconv --list | command sed -e "s@//@@;" )' -- "$cur" ) )
                 return 0
                 ;;
         esac
@@ -201,7 +201,7 @@ _svk()
                         path=//
                     fi
                     COMPREPLY=( $( compgen -W "$( $1 list $path 2>/dev/null | \
-                        sed -e 's|\(.*\)|'$path'\1|')" -- "$cur" ) )
+                        command sed -e 's|\(.*\)|'$path'\1|')" -- "$cur" ) )
                     ;;
                 *)
                     _filedir

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -79,7 +79,7 @@ _sysbench()
             ;;
         --db-driver)
             COMPREPLY=( $( compgen -W "$( $1 --test=oltp help 2>/dev/null |
-                sed -e '/^.*database drivers:/,/^$/!d' \
+                command sed -e '/^.*database drivers:/,/^$/!d' \
                    -ne 's/^  *\([^ ]*\) .*/\1/p' )" -- "$cur" ) )
             return 0
             ;;

--- a/completions/tar
+++ b/completions/tar
@@ -411,7 +411,7 @@ __tar_try_list_archive()
     shift
 
     read tarball <<<"$(printf -- '%s\n' "$@" \
-        | sed -n "/^.\{1,\}$regex\$/p" | tee /tmp/jetel)"
+        | command sed -n "/^.\{1,\}$regex\$/p" | tee /tmp/jetel)"
     if [[ -n "$tarball" ]]; then
         local IFS=$'\n'
         COMPREPLY=($(compgen -o filenames -W "$(

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -19,7 +19,7 @@ _update_rc_d()
     if [[ $cword -eq 1 || "$prev" == -* ]]; then
     valid_options=( $( \
         tr " " "\n" <<<"${words[@]} ${options[@]}" \
-        | sed -ne "/$( sed "s/ /\\|/g" <<<"${options[@]}" )/p" \
+        | command sed -ne "/$( command sed "s/ /\\|/g" <<<"${options[@]}" )/p" \
         | sort | uniq -u \
         ) )
     COMPREPLY=( $( compgen -W '${options[@]} ${services[@]}' \

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -34,7 +34,7 @@ _valgrind()
             COMPREPLY=( $( compgen -W '$(
                 for f in /usr{,/local}/lib{,64}/valgrind/*; do
                     [[ $f != *.so && -x $f ]] &&
-                        sed -ne "s/^.*\/\(.*\)-\([^-]*\)-\([^-]*\)/\1/p" <<<$f
+                        command sed -ne "s/^.*\/\(.*\)-\([^-]*\)-\([^-]*\)/\1/p" <<<$f
                 done )' -- "$cur" ) )
             return
             ;;
@@ -70,7 +70,7 @@ _valgrind()
         # generic cases parsed from --help output
         --+([-A-Za-z0-9_]))
             local value=$( $1 --help-debug $tool 2>/dev/null | \
-                sed -ne "s|^[$' \t']*$prev=\([^$' \t']\{1,\}\).*|\1|p" )
+                command sed -ne "s|^[$' \t']*$prev=\([^$' \t']\{1,\}\).*|\1|p" )
             case $value in
                 \<file*\>)
                     _filedir

--- a/completions/wget
+++ b/completions/wget
@@ -115,7 +115,7 @@ _wget()
             return
             ;;
         --user|--http-user|--proxy-user|--ftp-user)
-            COMPREPLY=( $( compgen -W "$( sed -n \
+            COMPREPLY=( $( compgen -W "$( command sed -n \
                 '/^login/s/^[[:blank:]]*login[[:blank:]]//p' ~/.netrc \
                 2>/dev/null )" -- "$cur" ) )
             return
@@ -137,7 +137,7 @@ _wget()
         --local-encoding|--remote-encoding)
             type -P xauth &>/dev/null && \
             COMPREPLY=( $( compgen -W '$( iconv -l 2>/dev/null | \
-                sed -e "s@/*\$@@" -e "s/[,()]//g" 2>/dev/null )' -- "$cur" ) )
+                command sed -e "s@/*\$@@" -e "s/[,()]//g" 2>/dev/null )' -- "$cur" ) )
             return
             ;;
         -e|--execute)

--- a/completions/wol
+++ b/completions/wol
@@ -13,7 +13,7 @@ _wol()
             # Broadcast addresses
             local PATH=$PATH:/sbin
             COMPREPLY=( $( { ip addr show || ifconfig -a; } 2>/dev/null | \
-                sed -ne 's/.*[[:space:]]Bcast:\([^[:space:]]*\).*/\1/p' -ne \
+                command sed -ne 's/.*[[:space:]]Bcast:\([^[:space:]]*\).*/\1/p' -ne \
                 's/.*inet.*[[:space:]]brd[[:space:]]\([^[:space:]]*\).*/\1/p' -ne \
                 's/.*[[:space:]]broadcast[[:space:]]\{1,\}\([^[:space:]]*\).*/\1/p' ) )
             _known_hosts_real "$cur"

--- a/completions/wvdial
+++ b/completions/wvdial
@@ -33,7 +33,7 @@ _wvdial()
             done
             # parse config files for sections and
             # remove default section
-            COMPREPLY=( $( sed -ne "s|^\[Dialer \($cur.*\)\]$|\1|p" $config \
+            COMPREPLY=( $( command sed -ne "s|^\[Dialer \($cur.*\)\]$|\1|p" $config \
                 2>/dev/null | command grep -v '^Defaults$'))
             # escape spaces
             COMPREPLY=${COMPREPLY// /\\ }

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -7,7 +7,7 @@ _xgamma()
 
     case "$prev" in
         -screen)
-            local screens=$( xrandr --query 2>/dev/null | sed -n \
+            local screens=$( xrandr --query 2>/dev/null | command sed -n \
                 '/^Screen /s|^Screen \{1,\}\(.*\):.*$|\1|p' 2>/dev/null )
             COMPREPLY=( $( compgen -W "$screens" -- "$cur" ) )
             return
@@ -30,7 +30,7 @@ _xgamma()
                 compopt -o nospace
             elif [[ "$cur" == :*.* ]]; then
                 # local screen numbers
-                local t screens=$( xrandr --query 2>/dev/null | sed -ne \
+                local t screens=$( xrandr --query 2>/dev/null | command sed -ne \
                     '/^Screen /s|^Screen \{1,\}\(.*\):.*$|\1|p' 2>/dev/null )
                 t="${cur#:}"
                 COMPREPLY=( $( compgen -P "${t%.*}." -W "$screens" -- \

--- a/completions/xrandr
+++ b/completions/xrandr
@@ -25,7 +25,7 @@ _xrandr()
                 fi
             done
             if [[ $output ]]; then
-                local modes=$( "$1" | sed -e "1,/$output/ d" \
+                local modes=$( "$1" | command sed -e "1,/$output/ d" \
                     -e "/connected/,$ d" \
                     -e "s/\([^[:space:]]\)[[:space:]].*/\1/" )
                 COMPREPLY=( $( compgen -W "$modes" -- "$cur" ) )
@@ -47,7 +47,7 @@ _xrandr()
             ;;
         --setprovideroutputsource|--setprovideroffloadsink)
             local providers=$( "$1" --listproviders 2>/dev/null |
-                sed -ne 's/.* name:\([^ ]*\).*/\1/p' )
+                command sed -ne 's/.* name:\([^ ]*\).*/\1/p' )
             COMPREPLY=( $( compgen -W "$providers" -- "$cur" ) )
             # TODO 2nd arg needed, is that a provider as well?
             return
@@ -55,7 +55,7 @@ _xrandr()
     esac
 
     COMPREPLY=( $( compgen -W '$( "$1" -help 2>&1 |
-        sed -e "s/ or / /g" -e "s/<[^>]*>]//g" | _parse_help - )' -- "$cur" ) )
+        command sed -e "s/ or / /g" -e "s/<[^>]*>]//g" | _parse_help - )' -- "$cur" ) )
 } &&
 complete -F _xrandr xrandr
 

--- a/completions/xsltproc
+++ b/completions/xsltproc
@@ -16,7 +16,7 @@ _xsltproc()
             ;;
         --encoding)
             # some aliases removed
-            COMPREPLY=( $( compgen -W "$( iconv -l | sed -e '/^UTF[1378]/d' \
+            COMPREPLY=( $( compgen -W "$( iconv -l | command sed -e '/^UTF[1378]/d' \
                 -e '/^ISO[0-9_]/d' -e '/^8859/d' -e 's/\/.*//')" -- "$cur" ) )
             return 0
             ;;

--- a/completions/zopfli
+++ b/completions/zopfli
@@ -13,7 +13,7 @@ _zopfli()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W \
-            '$( _parse_help "$1" -h | sed -e "s/#$//" )' -- "$cur" ) )
+            '$( _parse_help "$1" -h | command sed -e "s/#$//" )' -- "$cur" ) )
         [[ $COMPREPLY == --i ]] && compopt -o nospace
         return
     fi


### PR DESCRIPTION
The nature of bash completions means they're sourced into a user's
existing shell. This means they have to play nicely with any
customisations the user makes. The biggest source of problems are
undoubtedly when a user has a custom alias for a core command.

If you alias 'sed' to 'sed -r' to enable modern regex syntax by default,
it can sometimes cause conflicts. This is the case with the
"_known_hosts_real" helper function provided by the bash_completion
project to all completion functions. Fortunately, this is easy to work
around: just look up sed in the user's path and use the full path to the
sed binary. This avoids the conflict altogether.