### PR TITLE
Don't complete hostnames found after Hostname in ~/.ssh/config

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1564,7 +1564,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
+        local hosts=$( sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/test/fixtures/scp/config
+++ b/test/fixtures/scp/config
@@ -4,3 +4,5 @@ UserKnownHostsFile  known_hosts
 Host gee
     # Indented, multiple hosts
     HostName hus ike
+
+Host hus

--- a/test/lib/completions/scp.exp
+++ b/test/lib/completions/scp.exp
@@ -61,7 +61,7 @@ set expected {}
 foreach host [get_hosts] {
     lappend expected "$host:"
 }
-lappend expected blah: doo: gee: hus: ike:
+lappend expected blah: doo: gee: hus:
     # Append local filenames
 lappend expected config known_hosts "spaced\\ \\ conf"
 assert_complete $expected "scp -F config " $test


### PR DESCRIPTION
When connecting to a host listed after Hostname the options in the
config file are not applied, so don't complete these names accordingly.

If you still want some hosts completed, just add an other entry with
just Host <yourhostname> at the end of the config file.

This closes scop/bash-completion#3 and https://bugs.debian.org/689585