### PR TITLE
Don't complete hostnames found after Hostname in ~/.ssh/config

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/test/fixtures/scp/config
+++ b/test/fixtures/scp/config
@@ -4,3 +4,5 @@ UserKnownHostsFile  known_hosts
 Host gee
     # Indented, multiple hosts
     HostName hus ike
+
+Host hut

--- a/test/fixtures/sftp/config
+++ b/test/fixtures/sftp/config
@@ -4,3 +4,5 @@ UserKnownHostsFile  known_hosts
 Host gee
     # Indented, multiple hosts
     HostName hus ike
+
+Host hut

--- a/test/lib/completions/scp.exp
+++ b/test/lib/completions/scp.exp
@@ -55,13 +55,13 @@ set test "Tab should complete known-hosts"
 
     # Build string list of expected completions
     # Get hostnames and give them a colon (:) suffix
-    # Hosts `gee' and `hus' are defined in ./fixtures/scp/config
+    # Hosts `gee' and `hut' are defined in ./fixtures/scp/config
     # Hosts `blah', `doo' and `ike' are defined in ./fixtures/scp/known_hosts
 set expected {}
 foreach host [get_hosts] {
     lappend expected "$host:"
 }
-lappend expected blah: doo: gee: hus: ike:
+lappend expected blah: doo: gee: hut: ike:
     # Append local filenames
 lappend expected config known_hosts "spaced\\ \\ conf"
 assert_complete $expected "scp -F config " $test

--- a/test/lib/completions/sftp.exp
+++ b/test/lib/completions/sftp.exp
@@ -21,9 +21,9 @@ setup
 
     # Build string list of expected completions
 set expected [get_hosts]
-    # Hosts `gee' and `hus' are defined in ./fixtures/sftp/config
+    # Host `gee' and `hut' is defined in ./fixtures/sftp/config
     # Hosts `10.10.10.10', `doo' and `ike' are defined in ./fixtures/sftp/known_hosts
-lappend expected 10.10.10.10 doo gee hus ike
+lappend expected 10.10.10.10 doo gee hut ike
 assert_complete $expected "sftp -F config "
 
 
@@ -48,9 +48,9 @@ sync_after_int
     # Build string list of expected completions
     # Get hostnames and give them a colon (:) suffix
 set expected [get_hosts]
-    # Hosts `gee', `hus' and `jar' are defined in "./fixtures/sftp/spaced  conf"
+    # Hosts `gee' and `jar' are defined in "./fixtures/sftp/spaced  conf"
     # Hosts `10.10.10.10', `doo' and `ike' are defined in ./fixtures/sftp/known_hosts
-lappend expected 10.10.10.10 doo gee hus ike jar
+lappend expected 10.10.10.10 doo gee ike jar
 assert_complete $expected "sftp -F spaced\\ \\ conf "
 
 


### PR DESCRIPTION
When connecting to a host listed after Hostname the options in the
config file are not applied, so don't complete these names accordingly.

If you still want some hosts completed, just add an other entry with
just Host <yourhostname> at the end of the config file.

This closes scop/bash-completion#3 and https://bugs.debian.org/689585