### PR TITLE
xmllint, xmlwf, xsltproc: Complete on Mallard *.page files

### DIFF
--- a/completions/xmllint
+++ b/completions/xmllint
@@ -38,7 +38,7 @@ _xmllint()
         return 0
     fi
 
-    _filedir '@(*ml|htm|svg?(z)|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook)?(.gz)'
+    _filedir '@(*ml|htm|svg?(z)|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)?(.gz)'
 } &&
 complete -F _xmllint xmllint
 

--- a/completions/xmlwf
+++ b/completions/xmlwf
@@ -25,7 +25,7 @@ _xmlwf()
         return 0
     fi
 
-    _filedir '@(*ml|htm|svg|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook)'
+    _filedir '@(*ml|htm|svg|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)'
 } &&
 complete -F _xmlwf xmlwf
 

--- a/completions/xsltproc
+++ b/completions/xsltproc
@@ -42,7 +42,7 @@ _xsltproc()
         COMPREPLY=( "${COMPREPLY[@]%:}" )
     else
         # TODO: 1st file xsl|xslt, 2nd XML
-	_filedir '@(xsl|xslt|xml|dbk|docbook)'
+	_filedir '@(xsl|xslt|xml|dbk|docbook|page)'
     fi
 } &&
 complete -F _xsltproc xsltproc


### PR DESCRIPTION
I use xmllint and xsltproc on Mallard page files almost daily. It's unpleasant with bash refusing to complete on those files. This patch makes it pleasant again.