### PR TITLE
[FIX] BSD sed won't cut off ^t anymore

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['$'\t '']*[Hh][Oo][Ss][Tt]['$'\t '']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['$'\t '']*[Hh][Oo][Ss][Tt]['$'\t '']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['\"$'\t '\"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['$'\t '']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['$'\t '']\{1,\}\([^#*?]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi

--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['$'\t '']*[Hh][Oo][Ss][Tt]\([Nn][Aa][Mm][Ee]\)\{0,1\}['$'\t '']\{1,\}\([^#*?]*\)\(#.*\)\{0,1\}$/\2/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi


### PR DESCRIPTION
Hope this fits better now. I tried it with gsed and bsd sed, worked same for both. 