### PR TITLE
[FIX] improvement for BSD sed

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1567,7 +1567,7 @@ _known_hosts_real()
 
     # append any available aliases from config files
     if [[ ${#config[@]} -gt 0 && -n "$aliases" ]]; then
-        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['"$'\t '"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
+        local hosts=$( command sed -ne 's/^['"$'\t '"']*[Hh][Oo][Ss][Tt]['\"$'\t '\"']\{1,\}\([^#*?%]*\)\(#.*\)\{0,1\}$/\1/p' "${config[@]}" )
         COMPREPLY+=( $( compgen -P "$prefix$user" \
             -S "$suffix" -W "$hosts" -- "$cur" ) )
     fi


### PR DESCRIPTION
Currently with BSD sed on MacOS X an .ssh/config entry like this
`Host tfirst-letter`
would complete to
`ssh first-letter`
So only the letter "t" in the beginning will be cut off.