### PR TITLE
Better handling of typeset/declare

### DIFF
--- a/completions/function
+++ b/completions/function
@@ -6,10 +6,25 @@ _function()
     _init_completion || return
 
     if [[ $1 == @(declare|typeset) ]]; then
-        if [[ $prev == -f ]]; then
-            COMPREPLY=( $( compgen -A function -- "$cur" ) )
-        elif [[ "$cur" == -* ]]; then
-            COMPREPLY=( $( compgen -W '$( _parse_usage "$1" )' -- "$cur" ) )
+        if [[ $cur == [-+]* ]]; then
+            local opts
+            opts=( $( _parse_usage "$1" ) )
+            # Most options also have a '+' form.  We'll exclude the ones that don't with compgen.
+            opts+=( ${opts[*]/-/+} )
+            COMPREPLY=( $( compgen -W "${opts[*]}" -X '+[Ffgp]' -- "$cur" ) )
+        else
+            local i=1
+            while [[ ${words[i]} == [-+]* ]]; do
+                if [[ ${words[i]} == -*[fF]* ]]; then
+                    COMPREPLY=( $( compgen -A function -- "$cur" ) )
+                    return
+                fi
+                ((i++))
+            done
+            if [[ $i -gt 1 ]]; then
+                # There was at least one option and it was not one that limited operations to functions
+                COMPREPLY=( $( compgen -A variable -- "$cur" ) )
+            fi
         fi
     elif [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -A function -- "$cur" ) )

--- a/test/lib/completions/declare.exp
+++ b/test/lib/completions/declare.exp
@@ -14,5 +14,13 @@ setup
 assert_complete_any "declare -"
 sync_after_int
 
+assert_complete_any "declare +"
+sync_after_int
+
+assert_complete {BASH_ARGC BASH_ARGV} "declare -p BASH_ARG"
+sync_after_int
+
+assert_complete_any "declare -f _parse_"
+sync_after_int
 
 teardown


### PR DESCRIPTION
* complete variable names when appropriate
* complete more than one var/fun name
* complete `+` options in addition to `-` options
* recognize `-F` in addition to `-f`