### PR TITLE
Fix mpv's completion (untested).

### DIFF
--- a/completions/mplayer
+++ b/completions/mplayer
@@ -286,6 +286,6 @@ _mplayer()
 
     return 0
 } &&
-complete -F _mplayer mplayer mplayer2 mencoder gmplayer kplayer
+complete -F _mplayer mplayer mplayer2 mencoder gmplayer kplayer mpv
 
 # ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
Previously, doing «mpv [tab]» in an interactive shell resulted in absolutely
nothing getting completed and "complete | grep -i mpv" returned nothing.
Doing "complete -r -D" made mpv complete on plain pathname completion.

Some testing done by changing the file locally on the /usr filesystem and
trying mpv in a new shell.