### PR TITLE
Support completing array variables and expansions

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -623,10 +623,40 @@ _split_longopt()
 #          False (> 0) if not.
 _variables()
 {
-    if [[ $cur =~ ^(\$\{?)([A-Za-z0-9_]*)$ ]]; then
-        [[ $cur == *{* ]] && local suffix=} || local suffix=
-        COMPREPLY+=( $( compgen -P ${BASH_REMATCH[1]} -S "$suffix" -v -- \
-            "${BASH_REMATCH[2]}" ) )
+    if [[ $cur =~ ^(\$(\{[!#]?)?)([A-Za-z0-9_]*)$ ]]; then
+        # Completing $var / ${var / ${!var / ${#var
+        if [[ $cur == \${* ]]; then
+            local arrs vars
+            vars=( $( compgen -A variable -P ${BASH_REMATCH[1]} -S '}' -- ${BASH_REMATCH[3]} ) ) && \
+            arrs=( $( compgen -A arrayvar -P ${BASH_REMATCH[1]} -S '[' -- ${BASH_REMATCH[3]} ) )
+            if [[ ${#vars[@]} -eq 1 && $arrs ]]; then
+                # Complete ${arr with ${array[ if there is only one match, and that match is an array variable
+                compopt -o nospace
+                COMPREPLY+=( ${arrs[*]} )
+            else
+                # Complete ${var with ${variable}
+                COMPREPLY+=( ${vars[*]} )
+            fi
+        else
+            # Complete $var with $variable
+            COMPREPLY+=( $( compgen -A variable -P '$' -- "${BASH_REMATCH[3]}" ) )
+        fi
+        return 0
+    elif [[ $cur =~ ^(\$\{[#!]?)([A-Za-z0-9_]*)\[([^]]*)$ ]]; then
+        # Complete ${array[i with ${array[idx]}
+        local IFS=$'\n'
+        COMPREPLY+=( $( compgen -W '$(printf %s\\n "${!'${BASH_REMATCH[2]}'[@]}")' \
+            -P "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[" -S ']}' -- "${BASH_REMATCH[3]}" ) )
+        # Complete ${arr[@ and ${arr[*
+        if [[ ${BASH_REMATCH[3]} == [@*] ]]; then
+            COMPREPLY+=( "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[${BASH_REMATCH[3]}]}" )
+        fi
+        __ltrim_colon_completions "$cur"    # array indexes may have colons
+        return 0
+    elif [[ $cur =~ ^\$\{[#!]?[A-Za-z0-9_]*\[.*\]$ ]]; then
+        # Complete ${array[idx] with ${array[idx]}
+        COMPREPLY+=( "$cur}" )
+        __ltrim_colon_completions "$cur"
         return 0
     else
         case $prev in

--- a/test/unit/_variables.exp
+++ b/test/unit/_variables.exp
@@ -1,0 +1,39 @@
+proc setup {} {
+    assert_bash_exec { unset assoc1 && declare -A assoc1=([idx]=1)}
+    assert_bash_exec { unset assoc2 && declare -A assoc2=([idx1]=1 [idx2]=2)}
+    assert_bash_exec { unset ${!___v*} && declare ___var='' }
+    save_env
+}
+
+
+proc teardown {} {
+    assert_bash_exec {unset assoc1 assoc2}
+}
+
+
+setup
+
+set test "Complete simple variable names"
+assert_complete "\$___var" ": \$___v" $test
+
+set test "Complete single array index"
+assert_complete "\$\{assoc1\[idx\]\}" ": \$\{assoc1\[" $test
+sync_after_int
+
+set test "Complete closing curly bracket after square bracket"
+assert_complete "\$\{assoc1\[bogus\]\}" ": \$\{assoc1\[bogus\]" $test
+sync_after_int
+
+set test "Complete closing brackets after @ index"
+assert_complete "\$\{assoc1\[@\]\}" ": \$\{assoc1\[@" $test
+sync_after_int
+
+# For some reason -expect-cmd-minus is necessary here
+set test "Complete multiple array indexes"
+assert_complete_partial { \$\{assoc2\[idx1\]\} \$\{assoc2\[idx2\]\} } ":" "\$\{assoc2\[" $test -expect-cmd-minus "\${assoc2\["
+sync_after_int
+
+set test "Complete variables prefixed with #"
+assert_complete "\$\{#___var\}" ": \$\{#___v" $test
+
+teardown


### PR DESCRIPTION
* Complete `${arr[` with `${arr[idx1]} ${arr[idx2]}`, etc ..
* Complete `${arr[idx]` with closing curly brace
* Complete `${ar` with `${arr[` (nospace) if it is the only matching variable
* Complete `${arr[@` with `${arr[@]}` (also for `*`)
* Support completion of `${!var` and `${#var` forms for both regular and array variables