### PR TITLE
man: Improve usage with alternate man implementations

### DIFF
--- a/completions/man
+++ b/completions/man
@@ -58,9 +58,9 @@ _man()
 
     local manpath
     if [[ $OSTYPE == *@(darwin|linux|freebsd|cygwin)* ]] || _userland GNU; then
-        manpath=$( manpath 2>/dev/null || command man -w )
+        manpath=$( manpath 2>/dev/null || command man -w 2>/dev/null || echo "$MANPATH")
     else
-        manpath=$MANPATH
+        manpath="${MANPATH-/usr/share/man:/usr/local/share/man}"
     fi
 
     if [[ -z $manpath ]]; then


### PR DESCRIPTION
This commit sets a fallback MANPATH to use, for man implementations
such as busybox's man, which does not print the MANPATH when just
given `man -w`.