### PR TITLE
The BitKeeper completion used the wrong set of commands

### DIFF
--- a/completions/bk
+++ b/completions/bk
@@ -7,7 +7,7 @@ _bk()
     _init_completion || return
 
     local BKCMDS="$( bk help topics 2>/dev/null | \
-        awk '/^  bk/ { print $4 }' | xargs printf '%s ' )"
+        awk '/^  bk/ { print $2 }' | xargs printf '%s ' )"
 
     COMPREPLY=( $( compgen -W "$BKCMDS" -- "$cur" ) )
     _filedir


### PR DESCRIPTION
The line didn't correctly parse the 'bk help topics'
manpage.

This is a cheap bugfix that makes this completion function at least do what it was intending.

Later we will suggest a better function, but for now this is much better than the current code.

BTW the output of `bk help topics` is as follows:
```
All(sum)                    BitKeeper User's Manual                   All(sum)

NAME
  All - summary of all commands and topics

COMMANDS
  bk abort - abort a failed pull or push
  bk admin - administer BitKeeper files
  bk alias - manage aliases for lists of components
  bk annotate - provide annotated listings of one or more source files
  bk attach - attach a component repository to a product repository
...
```