### PR TITLE
Add EC2 host SSH completion

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -172,6 +172,11 @@ _ec2_hosts()
     COMPREPLY+=( $( compgen -W \
         "$(cat "${cache_file}")" -- "${1}" ) )
 
+    # Refresh the cache in the background every time
+    aws ec2 describe-instances | \
+        grep 'TAGS\tName' | \
+        awk '{print $3}' > "${cache_file}" &
+
     return 0
 }
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -172,10 +172,10 @@ _ec2_hosts()
     # Refresh the cache if:
     # - There is no cache
     # - It doesn't contain the search string
-    # - It's more than 5 minutes old
+    # - It's more than 1 day old
     if [ ! -f "${cache_file}" ] || \
         ! grep -q ${1} "${cache_file}" || \
-        test `find "${cache_file}" -mmin +5`; then
+        test `find "${cache_file}" -mmin +1440`; then
         aws ec2 describe-instances | \
             grep 'TAGS\tName' | \
             awk '{print $3}' > "${cache_file}"

--- a/completions/ssh
+++ b/completions/ssh
@@ -238,7 +238,7 @@ _ssh()
         local configfile
         _ssh_configfile
         _known_hosts_real -a -F "$configfile" "$cur"
-        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ]; then
+        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ] && [ $(which aws) ]; then
             _ec2_hosts "$cur"
         fi
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -181,8 +181,7 @@ _ec2_hosts()
             awk '{print $3}' > "${cache_file}"
     fi
 
-    COMPREPLY+=( $( compgen -W \
-        "$(cat "${cache_file}")" -- "${1}" ) )
+    COMPREPLY+=( $( compgen -W "$(cat "${cache_file}")" -- "${1}" ) )
 
     # Refresh the cache in the background every time (Run in a subshell to
     # suppress PID output)

--- a/completions/ssh
+++ b/completions/ssh
@@ -172,10 +172,11 @@ _ec2_hosts()
     COMPREPLY+=( $( compgen -W \
         "$(cat "${cache_file}")" -- "${1}" ) )
 
-    # Refresh the cache in the background every time
-    aws ec2 describe-instances | \
+    # Refresh the cache in the background every time (Run in a subshell to
+    # suppress PID output)
+    (aws ec2 describe-instances | \
         grep 'TAGS\tName' | \
-        awk '{print $3}' > "${cache_file}" &
+        awk '{print $3}' > "${cache_file}" &)
 
     return 0
 }

--- a/completions/ssh
+++ b/completions/ssh
@@ -152,6 +152,18 @@ _ssh_configfile()
     done
 }
 
+_refresh_ec2_hosts_cache()
+{
+    local hosts
+    local cache_file="${1}"
+
+    hosts=`aws ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}'`
+
+    if [ -n "${hosts}" ]; then
+        echo ${hosts} > "${cache_file}"
+    fi
+}
+
 _ec2_hosts()
 {
     # Cache ec2 host names for 1 minute for speed
@@ -174,9 +186,7 @@ _ec2_hosts()
 
     # Refresh the cache in the background every time (Run in a subshell to
     # suppress PID output)
-    (aws ec2 describe-instances | \
-        grep 'TAGS\tName' | \
-        awk '{print $3}' > "${cache_file}" &)
+    (_refresh_ec2_hosts_cache "${cache_file}" &)
 
     return 0
 }

--- a/completions/ssh
+++ b/completions/ssh
@@ -254,7 +254,7 @@ _ssh()
         local configfile
         _ssh_configfile
         _known_hosts_real -a -F "$configfile" "$cur"
-        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ] && [ $(which aws) ]; then
+        if [ $(which aws) ]; then
             _ec2_hosts "$cur"
         fi
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -157,7 +157,7 @@ _refresh_ec2_hosts_cache()
     local hosts
     local cache_file="${1}"
 
-    hosts=`aws ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}'`
+    hosts=$(aws ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}')
 
     if [ -n "${hosts}" ]; then
         echo ${hosts} > "${cache_file}"
@@ -175,7 +175,7 @@ _ec2_hosts()
     # - It's more than 1 day old
     if [ ! -f "${cache_file}" ] || \
         ! grep -q ${1} "${cache_file}" || \
-        test `find "${cache_file}" -mmin +1440`; then
+        test $(find "${cache_file}" -mmin +1440); then
         aws ec2 describe-instances | \
             grep 'TAGS\tName' | \
             awk '{print $3}' > "${cache_file}"

--- a/completions/ssh
+++ b/completions/ssh
@@ -160,7 +160,7 @@ _refresh_ec2_hosts_cache()
     hosts=$(aws --output text ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}')
 
     if [ -n "${hosts}" ]; then
-        echo ${hosts} > "${cache_file}"
+        printf '%s' "${hosts}" > "${cache_file}"
     fi
 }
 
@@ -174,7 +174,7 @@ _ec2_hosts()
     # - It doesn't contain the search string
     # - It's more than 1 day old
     if [ ! -f "${cache_file}" ] || \
-        ! grep -q ${1} "${cache_file}" || \
+        ! command grep -q ${1} "${cache_file}" || \
         test $(find "${cache_file}" -mmin +1440); then
         aws --output text ec2 describe-instances | \
             grep 'TAGS\tName' | \
@@ -254,7 +254,7 @@ _ssh()
         local configfile
         _ssh_configfile
         _known_hosts_real -a -F "$configfile" "$cur"
-        if [ $(which aws) ]; then
+        if type aws >/dev/null 2>&1; then
             _ec2_hosts "$cur"
         fi
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -175,7 +175,7 @@ _ec2_hosts()
     # - It's more than 1 day old
     if [ ! -f "${cache_file}" ] || \
         ! command grep -q ${1} "${cache_file}" || \
-        test $(find "${cache_file}" -mmin +1440); then
+        test $(find "${cache_file}" -mtime +1); then
         aws ec2 --output text describe-instances \
             --query 'Reservations[].Instances[].Tags[?Key==`Name`].Value' > "${cache_file}"
     fi

--- a/completions/ssh
+++ b/completions/ssh
@@ -157,7 +157,7 @@ _refresh_ec2_hosts_cache()
     local hosts
     local cache_file="${1}"
 
-    hosts=$(aws ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}')
+    hosts=$(aws --output text ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}')
 
     if [ -n "${hosts}" ]; then
         echo ${hosts} > "${cache_file}"
@@ -176,7 +176,7 @@ _ec2_hosts()
     if [ ! -f "${cache_file}" ] || \
         ! grep -q ${1} "${cache_file}" || \
         test $(find "${cache_file}" -mmin +1440); then
-        aws ec2 describe-instances | \
+        aws --output text ec2 describe-instances | \
             grep 'TAGS\tName' | \
             awk '{print $3}' > "${cache_file}"
     fi

--- a/completions/ssh
+++ b/completions/ssh
@@ -152,6 +152,29 @@ _ssh_configfile()
     done
 }
 
+_ec2_hosts()
+{
+    # Cache ec2 host names for 1 minute for speed
+    local cache_file="${HOME}/.ec2_node_names"
+
+    # Refresh the cache if:
+    # - There is no cache
+    # - It doesn't contain the search string
+    # - It's more than 5 minutes old
+    if [ ! -f "${cache_file}" ] || \
+        ! grep -q ${1} "${cache_file}" || \
+        test `find "${cache_file}" -mmin +5`; then
+        aws ec2 describe-instances | \
+            grep 'TAGS\tName' | \
+            awk '{print $3}' > "${cache_file}"
+    fi
+
+    COMPREPLY+=( $( compgen -W \
+        "$(cat "${cache_file}")" -- "${1}" ) )
+
+    return 0
+}
+
 _ssh()
 {
     local cur prev words cword
@@ -215,6 +238,7 @@ _ssh()
         local configfile
         _ssh_configfile
         _known_hosts_real -a -F "$configfile" "$cur"
+        _ec2_hosts "$cur"
 
         local args
         _count_args

--- a/completions/ssh
+++ b/completions/ssh
@@ -157,7 +157,7 @@ _refresh_ec2_hosts_cache()
     local hosts
     local cache_file="${1}"
 
-    hosts=$(aws --output text ec2 describe-instances | grep 'TAGS\tName' | awk '{print $3}')
+    hosts=$(aws --output text ec2 describe-instances --query 'Reservations[].Instances[].Tags[?Key==`Name`].Value')
 
     if [ -n "${hosts}" ]; then
         printf '%s' "${hosts}" > "${cache_file}"
@@ -176,9 +176,8 @@ _ec2_hosts()
     if [ ! -f "${cache_file}" ] || \
         ! command grep -q ${1} "${cache_file}" || \
         test $(find "${cache_file}" -mmin +1440); then
-        aws --output text ec2 describe-instances | \
-            grep 'TAGS\tName' | \
-            awk '{print $3}' > "${cache_file}"
+        aws ec2 --output text describe-instances \
+            --query 'Reservations[].Instances[].Tags[?Key==`Name`].Value' > "${cache_file}"
     fi
 
     COMPREPLY+=( $( compgen -W "$(cat "${cache_file}")" -- "${1}" ) )

--- a/completions/ssh
+++ b/completions/ssh
@@ -238,7 +238,9 @@ _ssh()
         local configfile
         _ssh_configfile
         _known_hosts_real -a -F "$configfile" "$cur"
-        _ec2_hosts "$cur"
+        if [ ${AWS_ACCESS_KEY} ] && [ ${AWS_SECRET_KEY} ]; then
+            _ec2_hosts "$cur"
+        fi
 
         local args
         _count_args


### PR DESCRIPTION
From my coworker @eherot who did the original work:

> Not sure if there's any interest in this in the broader project but we needed it internally so I figured I might as well push it up stream:
> 
> This function uses `aws ec2 describe-instances` to do command completion against instance name tags in the user's EC2 cluster, provided it is installed.

It’s up to the operator to have [properly configured the AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
