### PR TITLE
Update bash_completion

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2045,8 +2045,7 @@ _xfunc()
 # source compat completion directory definitions
 if [[ -d $BASH_COMPLETION_COMPAT_DIR && -r $BASH_COMPLETION_COMPAT_DIR && \
     -x $BASH_COMPLETION_COMPAT_DIR ]]; then
-    for i in $(LC_ALL=C command ls "$BASH_COMPLETION_COMPAT_DIR"); do
-        i=$BASH_COMPLETION_COMPAT_DIR/$i
+    for i in "$BASH_COMPLETION_COMPAT_DIR"/*; do
         [[ ${i##*/} != @($_backup_glob|Makefile*|$_blacklist_glob) \
             && -f $i && -r $i ]] && . "$i"
     done


### PR DESCRIPTION
Source compat completion dir: use shell globbing instead of external `ls` command. Cuts bash startup time on Cygwin by 40 ms.