### PR TITLE
Fix aptitude package completion

### DIFF
--- a/completions/aptitude
+++ b/completions/aptitude
@@ -39,7 +39,7 @@ _aptitude()
            install|hold|markauto|unmarkauto|dist-upgrade|full-upgrade| \
            safe-upgrade|download|show|changelog|why|why-not|build-dep| \
            add-user-tag|remove-user-tag|versions)
-               COMPREPLY=( $( apt-cache pkgnames $cur 2> /dev/null ) )
+               COMPREPLY=( $( apt-cache --no-generate pkgnames $cur 2> /dev/null ) )
                return 0
                ;;
            purge|remove|reinstall|forbid-version)


### PR DESCRIPTION
Without this, there's a very annoying delay when trying to autocomplete
packages for install, for example. I do it just like apt-get does, which
autocompletes fine without delay.

Refs: https://alioth.debian.org/tracker/index.php?func=detail&aid=315216&group_id=100114&atid=413095