### PR TITLE
Allow pathname completion after equals sign

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2023,9 +2023,9 @@ _completion_loader()
     __load_completion "$cmd" && return 124
 
     # Need to define *something*, otherwise there will be no completion at all.
-    complete -F _minimal -- "$cmd" && return 124
+    complete -o default -F _minimal -- "$cmd" && return 124
 } &&
-complete -D -F _completion_loader
+complete -D -o default -F _completion_loader
 
 # Function for loading and calling functions from dynamically loaded
 # completion files that may not have been sourced yet.


### PR DESCRIPTION
This is useful for things like:

```
./configure --install-dir=<TAB>
```

or

```
bin/rake test TEST=<TAB>
```

Refs: https://alioth.debian.org/tracker/index.php?func=detail&aid=315238&group_id=100114&atid=413095