### PR TITLE
tar: silence --version's stderr output

### DIFF
--- a/completions/tar
+++ b/completions/tar
@@ -697,7 +697,7 @@ _posix_tar()
 _tar()
 {
     local cmd=${COMP_WORDS[0]} func line
-    read line <<<"$($cmd --version)"
+    read line <<<"$($cmd --version 2>/dev/null)"
     case "$line" in
     *GNU*)
         func=_gtar


### PR DESCRIPTION
Causes an unknown argument error to be output. Tested with busybox tar.