### PR TITLE
Better completion defaults

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2023,9 +2023,9 @@ _completion_loader()
     __load_completion "$cmd" && return 124
 
     # Need to define *something*, otherwise there will be no completion at all.
-    complete -F _minimal -- "$cmd" && return 124
+    complete -o default -F _minimal -- "$cmd" && return 124
 } &&
-complete -D -F _completion_loader
+complete -D -o default -F _completion_loader
 
 # Function for loading and calling functions from dynamically loaded
 # completion files that may not have been sourced yet.


### PR DESCRIPTION
Falling back to the shell's default completions if our (default) one for
commands we have no specific completion for does not produce anything.

Supersedes https://github.com/scop/bash-completion/pull/34.