### PR TITLE
Support pod document files for perldoc

### DIFF
--- a/completions/perl
+++ b/completions/perl
@@ -15,6 +15,14 @@ _perlfunctions()
         -- "$cur" ) )
 }
 
+_perldocs()
+{
+    COMPREPLY=( $( compgen -P "$prefix" -W \
+        "$( ${1:-perl} ${BASH_SOURCE[0]%/*}/../helpers/perl perldocs $cur )" \
+        -- "$cur" ) )
+    __ltrim_colon_completions "$prefix$cur"
+}
+
 _perl()
 {
     local cur prev words cword
@@ -121,7 +129,7 @@ _perldoc()
     else
         # return available modules (unless it is clearly a file)
         if [[ "$cur" != @(*/|[.~])* ]]; then
-            _perlmodules $perl
+            _perldocs $perl
             if [[ $cur == p* ]]; then
                 COMPREPLY+=( $( compgen -W \
                     '$( PERLDOC_PAGER=/bin/cat "$1" -u perl |  \

--- a/helpers/perl
+++ b/helpers/perl
@@ -8,7 +8,7 @@ use File::Spec::Functions;
 my %seen;
 
 sub print_modules_real {
-    my ($base, $dir, $word) = @_;
+    my ($base, $dir, $word, $include_pod) = @_;
 
     # return immediately if potential completion doesn't match current word
     # a double comparison is used to avoid dealing with string lengths
@@ -24,8 +24,9 @@ sub print_modules_real {
     chdir($dir) or return;
 
     # print each file
-    foreach my $file (glob('*.pm')) {
-        $file =~ s/\.pm$//;
+    foreach my $file (sort(glob('*.pm'),glob('*.pod'))) {
+        next if ($file =~ /\.pod$/ and not $include_pod);
+        $file =~ s/\.(?:pm|pod)$//;
         my $module = $base . $file;
         next if $module !~ /^\Q$word/;
         next if $seen{$module}++;
@@ -37,20 +38,20 @@ sub print_modules_real {
         my $subdir = $dir . '/' . $directory;
         if ($directory =~ /^(?:[.\d]+|$Config{archname}|auto)$/) {
             # exclude subdirectory name from base
-            print_modules_real(undef, $subdir, $word);
+            print_modules_real(undef, $subdir, $word, $include_pod);
         } else {
             # add subdirectory name to base
-            print_modules_real($base . $directory . '::', $subdir, $word);
+            print_modules_real($base . $directory . '::', $subdir, $word, $include_pod);
         }
     }
 }
 
 sub print_modules {
-    my ($word) = @_;
+    my ($word, $include_pod) = @_;
 
     my $origdir = getcwd;
     foreach my $directory (@INC) {
-        print_modules_real(undef, $directory, $word);
+        print_modules_real(undef, $directory, $word, $include_pod);
         chdir $origdir;
     }
 }
@@ -89,4 +90,7 @@ if ($type eq 'functions') {
     print_functions($word);
 } elsif ($type eq 'modules') {
     print_modules($word);
+} elsif ($type eq 'perldocs') {
+    print_modules($word, 1);
 }
+


### PR DESCRIPTION
Extend the perl helper to optionally include *.pod files, then include those only for perldoc completions.

For example, this allows the completion of `perl -MMoose::M` to continue to show only actual perl modules than can be loaded, while allowing the completion of `perldoc Moose::M` to include the Moose::Manual* documentation.
