### PR TITLE
mysql: enabling nullglob in case no charset/*.xml are available to avoid failglob triggering

### DIFF
--- a/completions/mysql
+++ b/completions/mysql
@@ -20,7 +20,11 @@ _mysql()
             return 0
             ;;
         --default-character-set)
-            local charsets=( $( printf '%s\n' /usr/share/m{ariadb,ysql}/charsets/*.xml ) )
+            local opt_save=$(shopt -p failglob nullglob )
+            shopt -u failglob
+            shopt -s nullglob
+            local -a charsets=( /usr/share/m{ariadb,ysql}/charsets/*.xml )
+            eval "$opt_save"
             charsets=( "${charsets[@]##*/}" )
             charsets=( "${charsets[@]%%?(Index|\*).xml}" utf8 )
             COMPREPLY=( $( compgen -W '${charsets[@]}' -- "$cur" ) )


### PR DESCRIPTION
When failglob is enabled, an error could raised by bash about the /usr/share/m{ariadb,ysql}/charsets/*.xml patterns if either mariadb or mysql is not installed. The proposed change should avoid the error.