### PR TITLE
Improve support of make autocompletion for huge Makefiles

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -153,10 +153,72 @@ _make()
         fi
 
         local reset=$( shopt -po posix ); set +o posix # <(...)
-        COMPREPLY=( $( LC_ALL=C \
-            $1 -npq __BASH_MAKE_COMPLETION__=1 \
-                "${makef[@]}" "${makef_dir[@]}" .DEFAULT 2>/dev/null | \
-            command sed -nf <(_make_target_extract_script $mode "$cur") ) )
+
+        # there are two caches:
+        local cache_file=""         # for the output of make
+        local prefix_cache_file=""  # for the output of sed
+
+        # caching settings:
+        local cache_dir="$HOME/.cache_make_bash_completion"
+        local sed_threshold_in_millis="150" # otherwise, do not cache
+        local make_threshold_in_millis="50" # otherwise, do not cache
+
+        # Note:
+        # Caching is currently not implemented if "-C" or "-f" is used.
+        # In principle, there is no reason why it should not work,
+        # but as I do not use these features, I just skip it, here.
+        if [[ -z "${makef[@]}" && -z ${make_dir[@]} && -r "Makefile" ]] ; then
+            local cache_key=$( ( pwd && cat Makefile ) | md5sum | cut -f 1 -d ' ' )
+
+            # Currently, there is no cleanup mechanism, and there might
+            # be a smarter hashing strategy, too.
+            mkdir -p -- "$cache_dir"
+            cache_file="$cache_dir/make-bash-completion-${cache_key}.cache"
+            prefix_cache_file="$cache_dir/make-bash-completion_${cur}_${mode}_${cache_key}.cache"
+        fi
+
+        local prefix_filtered_result
+        if [[ -n "$prefix_cache_file" && -r "$prefix_cache_file" ]] ; then
+            prefix_filtered_result=$(cat -- "$prefix_cache_file")
+        else
+            local make_output
+            if [[ -n "$cache_file" && -r "$cache_file" ]] ; then
+                make_output=$(cat -- "$cache_file")
+            else
+                local before_make_nanos="$(date +%s%N)"
+                make_output="$( LC_ALL=C \
+                                make -npq __BASH_MAKE_COMPLETION__=1 \
+                                "${makef[@]}" "${makef_dir[@]}" .DEFAULT 2>/dev/null )"
+                local after_make_nanos="$(date +%s%N)"
+                if [[ -n "$cache_file" ]] && (( (($after_make_nanos - $before_make_nanos) / 1000000) > $make_threshold_in_millis )) ; then
+                    echo "$make_output" > "$cache_file"
+                fi
+            fi
+
+            local before_sed_nanos="$(date +%s%N)"
+            prefix_filtered_result=$( echo "$make_output" | \
+                                            command sed -nf <(_make_target_extract_script $mode "$cur") )
+            local after_sed_nanos="$(date +%s%N)"
+
+            if [[ -n "$prefix_cache_file" ]] && (( (( ${after_sed_nanos} - ${before_sed_nanos}) / 1000000) > ${sed_threshold_in_millis} )) ; then
+                echo "$prefix_filtered_result" > "$prefix_cache_file"
+            fi
+        fi
+
+        # Filter away all non-binaries and the source files, as
+        # otherwise, it can result in thousands of results,
+        # which are mostly uninteresting.
+        #
+        # Note:
+        # Filtering here with grep is almost certainly a hack.
+        # A better approach could be to change the sed expression
+        # in _make_target_extract_script. Maybe that would simplify
+        # the work that sed has to do and make it run faster
+        # (in my system, sed is the bottleneck).
+        #
+        COMPREPLY=( $( echo "$prefix_filtered_result" | \
+                             egrep -v '\.(o|obj|h|c|cpp)$') )
+
         $reset
 
         if [[ $mode != -d ]]; then


### PR DESCRIPTION
I noticed that if Makefiles become very large, bash completions becomes
very slow. To some degree that cannot be easily avoided, for instance, just the
call to make can take several seconds.

This patch is an attempt to improve the support of huge Makefiles as they are
generated by Automake. I do not expect that you merge it back as it is but
I thought it might be useful for others to see and play around with.
Maybe someone finds a less hacky solution to the underlying problem.

Anyway, here is the idea behind my changes:

If the files get too large (> 50000 lines of code in my example),
the calls to make and sed become very slow (make takes about 4 seconds
while sed takes up to 11 seconds, again in my example).

Additionally, there is a lot of noise in the recommendations.
I get about 2800 results, mostly uninteresting. Instead I am mainly
interested in the binaries or the test commands.

As a hack, I added a simple cache for expensive calls to make and sed, respectively.
I also filter away the search results referencing source files or intermediate files
like ".o" and ".obj" files, thus reducing the number of recommendations to 160.

In sum, it is a "work-for-me" solution, but what I rather want is to encourage a
discussion of a more thoughtful approach:

1. I lack understanding of the sed expression. As it is the biggest bottleneck, it would be interesting to know if it could be improved in terms of performance.
1. So far, I have not seen that bash-completion uses caches. Caches bring extra complexity, of course, so I am not sure whether it is a good idea to go in that direction. A compromise could be to make it an opt-in feature. For instance, it could be disabled unless an environment variable is set.
1. Would you agree that recommended completions for source files and ".o" and ".obj" files should be filtered out? Or are there use cases where you actually want to see them?