### PR TITLE
Add completion for myrepos (mr)

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -229,6 +229,7 @@ bashcomp_DATA = 2to3 \
 		mount \
 		mount.linux \
 		mplayer \
+		mr \
 		msynctool \
 		mtx \
 		munindoc \

--- a/completions/mr
+++ b/completions/mr
@@ -4,9 +4,9 @@ _mr() {
     local cur prev words cword
     _init_completion || return
 
-    local options='-c --config -d --directory -f --force --force-env -i
-    --interactive -j --jobs -k --insecure -m --minimal -n --no-recurse -q
-    --quiet -s --stats -t --trust-all -v --verbose'
+    local options='--config --directory --force --force-env --interactive
+    --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all
+    --verbose'
 
     local commands='bootstrap checkout ci clean co commit config diff fetch
     grep help list log ls offline online push record register remember run

--- a/completions/mr
+++ b/completions/mr
@@ -4,14 +4,11 @@ _mr() {
     local cur prev words cword
     _init_completion || return
 
-    local options="$(PERLDOC=-otext _parse_help "${1}" help)"
-    # Remove short options (all have compatible long options).
-    options="${options//-[a-z]$'\n'/}"
-    # Remove deprecated options.
-    options="${options//--path/}"
+    local help commands options
 
-    local commands="$(PERLDOC_PAGER=/bin/cat PERLDOC=-otext mr help | \
-                      awk '/\[options\]/ { print $3 }')"
+    help="$(PERLDOC_PAGER=cat PERLDOC=-otext "${1}" help)"
+
+    commands="$(awk '/\[options\]/ { print $3 }' <<<"${help}")"
     # Split [online|offline] and remove `action` placeholder.
     commands="${commands//@(action|[\[\|\]])/$'\n'}"
     # Add standard aliases.
@@ -74,6 +71,11 @@ _mr() {
     esac
 
     if [[ $cur == -* ]]; then
+        options="$(_parse_help - <<<"${help}")"
+        # Remove short options (all have compatible long options).
+        options="${options//-[a-z]$'\n'/}"
+        # Remove deprecated options.
+        options="${options//--path/}"
         COMPREPLY=( $( compgen -W "${options}" -- "${cur}" ) )
     else
         COMPREPLY=( $( compgen -W  "${commands}" -- "${cur}" ) )

--- a/completions/mr
+++ b/completions/mr
@@ -4,9 +4,11 @@ _mr() {
     local cur prev words cword
     _init_completion || return
 
-    local options='--config --directory --force --force-env --interactive
-    --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all
-    --verbose'
+    local options="$(PERLDOC=-otext _parse_help "${1}" help)"
+    # Remove short options (all have compatible long options).
+    options="${options//-[a-z]$'\n'/}"
+    # Remove deprecated options.
+    options="${options//--path/}"
 
     local commands='bootstrap checkout ci clean co commit config diff fetch
     grep help list log ls offline online push record register remember run

--- a/completions/mr
+++ b/completions/mr
@@ -32,8 +32,8 @@ _mr() {
         case $cmd in
             bootstrap)
                 _filedir
-                # Also complete stdin (-).
-                if [[ -z "${cur}" ]]; then
+                # Also complete stdin (-) as a potential bootstrap source.
+                if [[ -z "${cur}" || $cur == - ]] && [[ $prev != - ]]; then
                     COMPREPLY+=( - )
                 fi
                 return

--- a/completions/mr
+++ b/completions/mr
@@ -1,0 +1,80 @@
+# mr completion                                            -*- shell-script -*-
+
+_mr() {
+    local cur prev words cword
+    _init_completion || return
+
+    local options='-c --config -d --directory -f --force --force-env -i
+    --interactive -j --jobs -k --insecure -m --minimal -n --no-recurse -q
+    --quiet -s --stats -t --trust-all -v --verbose'
+
+    local commands='bootstrap checkout ci clean co commit config diff fetch
+    grep help list log ls offline online push record register remember run
+    status update'
+
+    # Determine if user has entered an `mr` command. Used to block top-level
+    # (option and command) completions.
+    local cmd i
+    for (( i=0; i < ${#words[@]}-1; i++ )); do
+        if [[ $commands == *"${words[i]}"* ]]; then
+            cmd="${words[i]}"
+            break
+        fi
+    done
+
+    # Complete optiions for specific commands.
+    if [[ -n $cmd ]]; then
+        case $cmd in
+            bootstrap)
+                _filedir
+                # Also complete stdin (-).
+                if [[ -z "${cur}" ]]; then
+                    COMPREPLY+=( - )
+                    return
+                fi
+                return
+                ;;
+            clean)
+                if [[ "${cur}" == -* ]]; then
+                    COMPREPLY=( $( compgen -W '-f' -- "${cur}" ) )
+                fi
+                return
+                ;;
+            commit|ci|record)
+                if [[ "${cur}" == -* ]]; then
+                    COMPREPLY=( $( compgen -W '-m' -- "${cur}" ) )
+                fi
+                return
+                ;;
+            run)
+                COMPREPLY=( $( compgen -c -- "${cur}" ) )
+                return
+                ;;
+            *)
+                # Do not complete any other command.
+                return
+                ;;
+        esac
+    fi
+
+    # Complete top-level options and commands.
+    case $prev in
+        -c|--config)
+            _filedir
+            return
+            ;;
+        -d|--directory)
+            _filedir -d
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=( $( compgen -W "${options}" -- "${cur}" ) )
+    else
+        COMPREPLY=( $( compgen -W  "${commands}" -- "${cur}" ) )
+    fi
+} &&
+complete -F _mr mr
+
+# ex: filetype=sh

--- a/completions/mr
+++ b/completions/mr
@@ -30,7 +30,6 @@ _mr() {
                 # Also complete stdin (-).
                 if [[ -z "${cur}" ]]; then
                     COMPREPLY+=( - )
-                    return
                 fi
                 return
                 ;;

--- a/completions/mr
+++ b/completions/mr
@@ -10,9 +10,12 @@ _mr() {
     # Remove deprecated options.
     options="${options//--path/}"
 
-    local commands='bootstrap checkout ci clean co commit config diff fetch
-    grep help list log ls offline online push record register remember run
-    status update'
+    local commands="$(PERLDOC_PAGER=/bin/cat PERLDOC=-otext mr help | \
+                      awk '/\[options\]/ { print $3 }')"
+    # Split [online|offline] and remove `action` placeholder.
+    commands="${commands//@(action|[\[\|\]])/$'\n'}"
+    # Add standard aliases.
+    commands="${commands} ci co ls"
 
     # Determine if user has entered an `mr` command. Used to block top-level
     # (option and command) completions.

--- a/completions/mr
+++ b/completions/mr
@@ -27,7 +27,7 @@ _mr() {
         fi
     done
 
-    # Complete optiions for specific commands.
+    # Complete options for specific commands.
     if [[ -n $cmd ]]; then
         case $cmd in
             bootstrap)

--- a/test/completion/mr.exp
+++ b/test/completion/mr.exp
@@ -1,0 +1,1 @@
+assert_source_completions mr

--- a/test/lib/completions/mr.exp
+++ b/test/lib/completions/mr.exp
@@ -1,0 +1,46 @@
+proc setup {} {
+    save_env
+}
+
+
+proc teardown {} {
+    assert_env_unmodified
+}
+
+set commands "bootstrap checkout ci clean co commit config diff fetch grep help list log ls offline online push record register remember run status update"
+set options "-c --config -d --directory -f --force --force-env -i --interactive -j --jobs -k --insecure -m --minimal -n --no-recurse -q --quiet -s --stats -t --trust-all -v --verbose"
+set long_options "--config --directory --force --force-env --interactive --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all --verbose"
+
+setup
+
+assert_complete_any "mr "
+sync_after_int
+
+assert_complete $commands "mr "
+sync_after_int
+
+assert_complete $options "mr -"
+sync_after_int
+
+assert_complete $long_options "mr --"
+sync_after_int
+
+assert_complete {"foo"} "mr -c $::srcdir/fixtures/shared/default/foo.d/"
+sync_after_int
+
+assert_complete {"bar bar.d/" "foo.d/"} "mr -d $::srcdir/fixtures/shared/default/"
+sync_after_int
+
+assert_complete {"bar" "bar bar.d/" "foo" "foo.d/"} "mr bootstrap $::srcdir/fixtures/shared/default/"
+sync_after_int
+
+assert_complete "-f" "mr clean -"
+sync_after_int
+
+assert_complete "-m" "mr commit -"
+sync_after_int
+
+assert_no_complete "mr status "
+sync_after_int
+
+teardown

--- a/test/lib/completions/mr.exp
+++ b/test/lib/completions/mr.exp
@@ -33,4 +33,9 @@ sync_after_int
 assert_no_complete "mr status "
 sync_after_int
 
+# Disabled temporarily: suggesting all commands produces too much output for
+# test suite.
+#assert_complete_any "mr run "
+#sync_after_int
+
 teardown

--- a/test/lib/completions/mr.exp
+++ b/test/lib/completions/mr.exp
@@ -7,14 +7,9 @@ proc teardown {} {
     assert_env_unmodified
 }
 
-set commands "bootstrap checkout ci clean co commit config diff fetch grep help list log ls offline online push record register remember run status update"
-
 setup
 
 assert_complete_any "mr "
-sync_after_int
-
-assert_complete $commands "mr "
 sync_after_int
 
 assert_complete_any "mr --"

--- a/test/lib/completions/mr.exp
+++ b/test/lib/completions/mr.exp
@@ -8,8 +8,7 @@ proc teardown {} {
 }
 
 set commands "bootstrap checkout ci clean co commit config diff fetch grep help list log ls offline online push record register remember run status update"
-set options "-c --config -d --directory -f --force --force-env -i --interactive -j --jobs -k --insecure -m --minimal -n --no-recurse -q --quiet -s --stats -t --trust-all -v --verbose"
-set long_options "--config --directory --force --force-env --interactive --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all --verbose"
+set options "--config --directory --force --force-env --interactive --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all --verbose"
 
 setup
 
@@ -19,10 +18,7 @@ sync_after_int
 assert_complete $commands "mr "
 sync_after_int
 
-assert_complete $options "mr -"
-sync_after_int
-
-assert_complete $long_options "mr --"
+assert_complete $options "mr --"
 sync_after_int
 
 assert_complete {"foo"} "mr -c $::srcdir/fixtures/shared/default/foo.d/"

--- a/test/lib/completions/mr.exp
+++ b/test/lib/completions/mr.exp
@@ -8,7 +8,6 @@ proc teardown {} {
 }
 
 set commands "bootstrap checkout ci clean co commit config diff fetch grep help list log ls offline online push record register remember run status update"
-set options "--config --directory --force --force-env --interactive --jobs --insecure --minimal --no-recurse --quiet --stats --trust-all --verbose"
 
 setup
 
@@ -18,7 +17,7 @@ sync_after_int
 assert_complete $commands "mr "
 sync_after_int
 
-assert_complete $options "mr --"
+assert_complete_any "mr --"
 sync_after_int
 
 assert_complete {"foo"} "mr -c $::srcdir/fixtures/shared/default/foo.d/"


### PR DESCRIPTION
This PR adds completion for [myrepos](https://myrepos.branchable.com/), a tool used to manage multiple local repositories at once.

I'd appreciate some input on the test suite in particular. I'm not sure how to test the following completions:

* `mr run <TAB>` should complete commands
* `mr bootstrap <TAB>` suggests standard input (`-`) to the user along with the normal list of files. Once the user starts typing a filename, `-` should not longer be suggested.

Thanks in advance for your feedback.