### PR TITLE
Handle ambiguous globs gracefully

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -592,6 +592,11 @@ _filedir()
         # 2>/dev/null for direct invocation, e.g. in the _filedir unit test
         compopt -o filenames 2>/dev/null
         COMPREPLY+=( "${toks[@]}" )
+
+    # Else, fall back to bash's default glob handling (e.g., multiple matches)
+    # See: http://superuser.com/a/1022284/541376
+    else
+        compopt -o bashdefault 2>/dev/null
     fi
 } # _filedir()
 


### PR DESCRIPTION
Fall back to bash's default glob handling (i.e., list multiple matches)
See: http://superuser.com/a/1022284/541376

```diff
    if [[ ${#toks[@]} -ne 0 ]]; then
         # 2>/dev/null for direct invocation, e.g. in the _filedir unit test
         compopt -o filenames 2>/dev/null
         COMPREPLY+=( "${toks[@]}" )
+    else
+        compopt -o bashdefault 2>/dev/null
     fi
```

Adding **compopt -o bashdefault** after failed matches lets you eat your cake and have it, too: you can keep your `shopt -s progcomp` bash_completion AND if that doesn't find a match, it will fall back to bash's default glob handling:

```
prompt% ls ~/.bash*<TAB>      # Bell
prompt% ls ~/.bash*<TAB><TAB>
.bash_alias    .bash_history   .bash_logout   .bash_profile   .bashrc
```