### PR TITLE
ssh-keygen: support ed25519 keys

### DIFF
--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -34,7 +34,7 @@ _ssh_keygen()
             return
             ;;
         -t)
-            COMPREPLY=( $( compgen -W 'dsa ecdsa rsa rsa1' -- "$cur" ) )
+            COMPREPLY=( $( compgen -W 'dsa ecdsa ed25519 rsa rsa1' -- "$cur" ) )
             return
             ;;
     esac


### PR DESCRIPTION
OpenSSH supports ed25519 since version 6.5 (Jan 2014, http://www.openssh.com/txt/release-6.5), this patch adds a completion for this key type.