### PR TITLE
Add support for Include in ssh config (#70)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1533,8 +1533,8 @@ _known_hosts_real()
     fi
 
     # "Include" keyword in config files
-    for i in ${config[@]}; do
-        _included_config_files $i
+    for i in "${config[@]}"; do
+        _included_config_files "$i"
     done
 
     # Known hosts files from configs

--- a/bash_completion
+++ b/bash_completion
@@ -1456,6 +1456,38 @@ _known_hosts()
     _known_hosts_real $options -- "$cur"
 } # _known_hosts()
 
+# Helper function to locate included files in configs
+# This function look for the "Include" keyword in config files and include them
+# recursively adding each result to the config variable
+_included_config_files()
+{
+    [[ $# -lt 1 ]] && echo "error: $FUNCNAME: missing mandatory argument CONFIG"
+    local configfile=$1
+    local included=$( command sed -ne 's/^[[:blank:]]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][[:blank:]]\{1,\}\([^#%]*\)\(#.*\)\{0,1\}$/\1/p' "${configfile}" )
+    for i in ${included[@]}; do
+        # Check the origin of $configfile to complete relative included paths on included
+        # files according to ssh_config(5):
+        #  "[...] Files without absolute paths are assumed to be in ~/.ssh if included in a user
+        #   configuration file or /etc/ssh if included from the system configuration file.[...]"
+        if ! [[ "$i" =~ ^\~.*|^\/.* ]]; then
+            if [[ "$configfile" =~ ^\/etc\/ssh.* ]]; then
+                i="/etc/ssh/$i"
+            else
+                i="$HOME/.ssh/$i"
+            fi
+        fi
+        __expand_tilde_by_ref i
+        # In case the expanded variable contains multiple paths
+        for f in ${i}; do
+            if [ -r $f ]; then
+                config+=( "$f" )
+                # The Included file is processed to look for Included files in itself
+                _included_config_files $f
+            fi
+        done
+    done
+} # _included_config_files()
+
 # Helper function for completing _known_hosts.
 # This function performs host completion based on ssh's config and known_hosts
 # files, as well as hostnames reported by avahi-browse if
@@ -1499,6 +1531,11 @@ _known_hosts_real()
             [[ -r $i ]] && config+=( "$i" )
         done
     fi
+
+    # "Include" keyword in config files
+    for i in ${config[@]}; do
+        _included_config_files $i
+    done
 
     # Known hosts files from configs
     if [[ ${#config[@]} -gt 0 ]]; then

--- a/bash_completion
+++ b/bash_completion
@@ -1462,7 +1462,8 @@ _known_hosts()
 _included_ssh_config_files()
 {
     [[ $# -lt 1 ]] && echo "error: $FUNCNAME: missing mandatory argument CONFIG"
-    local configfile=$1
+    local configfile i f
+    configfile=$1
     local included=$( command sed -ne 's/^[[:blank:]]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][[:blank:]]\{1,\}\([^#%]*\)\(#.*\)\{0,1\}$/\1/p' "${configfile}" )
     for i in ${included[@]}; do
         # Check the origin of $configfile to complete relative included paths on included

--- a/bash_completion
+++ b/bash_completion
@@ -1456,10 +1456,10 @@ _known_hosts()
     _known_hosts_real $options -- "$cur"
 } # _known_hosts()
 
-# Helper function to locate included files in configs
-# This function look for the "Include" keyword in config files and include them
-# recursively adding each result to the config variable
-_included_config_files()
+# Helper function to locate ssh included files in configs
+# This function look for the "Include" keyword in ssh config files and include
+# them recursively adding each result to the config variable
+_included_ssh_config_files()
 {
     [[ $# -lt 1 ]] && echo "error: $FUNCNAME: missing mandatory argument CONFIG"
     local configfile=$1
@@ -1482,11 +1482,11 @@ _included_config_files()
             if [ -r $f ]; then
                 config+=( "$f" )
                 # The Included file is processed to look for Included files in itself
-                _included_config_files $f
+                _included_ssh_config_files $f
             fi
         done
     done
-} # _included_config_files()
+} # _included_ssh_config_files()
 
 # Helper function for completing _known_hosts.
 # This function performs host completion based on ssh's config and known_hosts
@@ -1532,9 +1532,9 @@ _known_hosts_real()
         done
     fi
 
-    # "Include" keyword in config files
+    # "Include" keyword in ssh config files
     for i in "${config[@]}"; do
-        _included_config_files "$i"
+        _included_ssh_config_files "$i"
     done
 
     # Known hosts files from configs

--- a/test/fixtures/_known_hosts_real/.ssh/config_relative_path
+++ b/test/fixtures/_known_hosts_real/.ssh/config_relative_path
@@ -1,0 +1,1 @@
+Host relative_path

--- a/test/fixtures/_known_hosts_real/config_full_path
+++ b/test/fixtures/_known_hosts_real/config_full_path
@@ -1,0 +1,1 @@
+Include ~/config_include_recursion

--- a/test/fixtures/_known_hosts_real/config_include
+++ b/test/fixtures/_known_hosts_real/config_include
@@ -1,0 +1,5 @@
+#$HOME set to fixtures/_known_hosts_real in unit test
+# Include with full path (recursive one)
+Include ~/config_full_path
+# Include with relative path
+Include config_relative_path

--- a/test/fixtures/_known_hosts_real/config_include_recursion
+++ b/test/fixtures/_known_hosts_real/config_include_recursion
@@ -1,0 +1,1 @@
+Host recursion

--- a/test/unit/_known_hosts_real.exp
+++ b/test/unit/_known_hosts_real.exp
@@ -120,4 +120,32 @@ assert_bash_exec "unset -v COMP_KNOWN_HOSTS_WITH_HOSTFILE"
 sync_after_int
 
 
+set test "Included config files should work"
+set hosts [get_hosts -unsorted]
+    # Host 'recursion' is defined in ./fixtures/_known_hosts_real/config_include_recursion
+    # Host 'relative_path' is defined in ./fixtures/_known_hosts_real/.ssh/config_relative_path
+lappend hosts recursion relative_path
+set hosts [join [bash_sort $hosts] "\\s+"]
+    # Setup environment
+    # Redefined HOME to handle relative path inclusions on $HOME/.ssh
+set cmd {OLDHOME=$HOME; HOME="$SRCDIRABS/fixtures/_known_hosts_real"}
+send "$cmd\r"
+expect -ex "$cmd\r\n/@"
+    # Call _known_hosts
+set cmd {unset COMPREPLY; _known_hosts_real -aF fixtures/_known_hosts_real/config_include ''; echo_array COMPREPLY}
+send "$cmd\r"
+expect -ex "$cmd\r\n"
+expect {
+    -re "^$hosts\r\n/@$"  { pass "$test" }
+    default { unresolved "$test" }
+}
+    # Teardown environment
+set cmd {HOME=$OLDHOME}
+send "$cmd\r"
+expect -ex "$cmd\r\n/@"
+
+
+sync_after_int
+
+
 teardown


### PR DESCRIPTION
This patch adds support for the Include directive in _ssh_config_ files (issue #70).
It adds the included (readable) files to the `config` variable to be later processed by the `_known_hosts_real()` function.