### PR TITLE
ant: parse targets in imported buildfiles

### DIFF
--- a/completions/ant
+++ b/completions/ant
@@ -4,7 +4,8 @@ _ant_parse_targets()
 {
     local line basedir
 
-    basedir=$(dirname "$1")
+    # alternative of "dirname $1" in pure bash
+    basedir=${1%/*}
 
     # parse buildfile for targets
     while read -rd '>' line; do

--- a/completions/ant
+++ b/completions/ant
@@ -1,5 +1,30 @@
 # bash completion for ant and phing                        -*- shell-script -*-
 
+_ant_parse_targets()
+{
+    local line basedir
+
+    basedir=$(dirname "$1")
+
+    # parse buildfile for targets
+    while read -rd '>' line; do
+        if [[ $line =~ \<(target|extension-point)[[:space:]].*name=[\"\']([^\"\']+) ]]; then
+            targets+=" ${BASH_REMATCH[2]}"
+        fi
+    done < $1
+
+    # parse imports
+    while read -rd '>' line; do
+        if [[ $line =~ \<import[[:space:]].*file=[\"\']([^\"\']+) ]]; then
+            local imported_buildfile
+            imported_buildfile="${basedir}/${BASH_REMATCH[1]}"
+            if [[ -f $imported_buildfile ]]; then
+                _ant_parse_targets $imported_buildfile
+            fi
+        fi
+    done < $1
+}
+
 _ant()
 {
     local cur prev words cword
@@ -59,13 +84,11 @@ _ant()
         fi
         [[ ! -f $buildfile ]] && return
 
-        # parse buildfile for targets
-        local line targets
-        while read -rd '>' line; do
-            [[ $line =~ \
-               \<(targe|extension-poin)t[[:space:]].*name=[\"\']([^\"\']+) ]] \
-                && targets+=" ${BASH_REMATCH[2]}"
-        done < $buildfile
+        local targets
+
+        # fill targets
+        _ant_parse_targets $buildfile
+
         COMPREPLY=( $( compgen -W '$targets' -- "$cur" ) )
     fi
 } &&

--- a/test/fixtures/ant/build-with-import.xml
+++ b/test/fixtures/ant/build-with-import.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project default="build-with-import" name="bash-completion">
+    <import file="imported-build.xml" />
+
+    <target name="build-with-import">
+        <!-- ... -->
+    </target>
+</project>

--- a/test/fixtures/ant/imported-build.xml
+++ b/test/fixtures/ant/imported-build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project default="imported-build" name="bash-completion">
+    <target name="imported-build">
+        <!-- ... -->
+    </target>
+</project>

--- a/test/lib/completions/ant.exp
+++ b/test/lib/completions/ant.exp
@@ -26,6 +26,10 @@ assert_complete_dir "named-build" "ant -f named-build.xml " $::srcdir/fixtures/a
 sync_after_int
 
 
+assert_complete_dir "build-with-import imported-build" "ant -f build-with-import.xml " $::srcdir/fixtures/ant
+sync_after_int
+
+
 assert_bash_exec {OLD_ANT_ARGS=$ANT_ARGS; ANT_ARGS="-f named-build.xml"}
 assert_complete_dir "named-build" "ant " $::srcdir/fixtures/ant "ant with buildfile from ANT_ARGS"
 sync_after_int


### PR DESCRIPTION
This PR adds support for `<import>` tags.
It is only basic support as it does not care about `basedir` setting.
