### PR TITLE
ccache: fix completing compiler's flags

### DIFF
--- a/completions/ccache
+++ b/completions/ccache
@@ -5,10 +5,14 @@ _ccache()
     local cur prev words cword split
     _init_completion -s || return
 
-    if [[ $COMP_CWORD -eq 1 && ${COMP_WORDS[COMP_CWORD]} != -* ]]; then
-        _command_offset 1
-        return
-    fi
+    local i
+    for (( i=1; i <= COMP_CWORD; i++ )); do
+        if [[ ${COMP_WORDS[i]} != -* ]]; then
+            _command_offset $i
+            return
+        fi
+        [[ ${COMP_WORDS[i]} == -[oFM] ]] && ((i++))
+    done
 
     case $prev in
         -h|--help|-V|--version|-F|--max-files|-M|--max-size)

--- a/test/lib/completions/ccache.exp
+++ b/test/lib/completions/ccache.exp
@@ -15,4 +15,29 @@ assert_complete_any "ccache -"
 sync_after_int
 
 
+set test "Tab should offer correct options from partial option"
+assert_complete_partial [list "--cleanup" "--clear"] "ccache" "--clea" $test
+sync_after_int
+
+
+set test "Tab should complete a command after ccache"
+assert_complete [list "stty"] "ccache stt" $test
+sync_after_int
+
+
+set test "Tab should complete a command after ccache --FLAG"
+assert_complete [list "stty"] "ccache --zero-stats stt" $test
+sync_after_int
+
+
+set test "Tab should complete a command's flags after ccache"
+assert_complete [list "--help"] "ccache ls --hel" $test
+sync_after_int
+
+
+set test "Tab should complete a command's flags after ccache --FLAG"
+assert_complete [list "--help"] "ccache --zero-stats ls --hel" $test
+sync_after_int
+
+
 teardown


### PR DESCRIPTION
This fixes the ccache completion function so that completing the
compiler’s flags works correctly.

I took the fixes from the sudo completion code, which works fine.