### PR TITLE
Support for python gui source files

### DIFF
--- a/completions/python
+++ b/completions/python
@@ -52,7 +52,7 @@ _python()
     if [[ "${words[@]::$cword}" == *\ -[cm]\ * ]]; then
         _filedir
     elif [[ "$cur" != -* ]]; then
-        _filedir 'py?([coz])'
+        _filedir 'py?([cowz])'
     else
         COMPREPLY=( $( compgen -W '$( _parse_help "$1" -h )' -- "$cur" ) )
     fi


### PR DESCRIPTION
Add support for Python gui source files

Especially in Windows land, the extension ".pyw" is used to indicate a
python file is intended to be launched without a console window. You can
still just run these from python.