### PR TITLE
Add support for completion of quoted variables

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -620,13 +620,20 @@ _split_longopt()
 #          False (> 0) if not.
 _variables()
 {
-    if [[ $cur =~ ^(\$(\{[!#]?)?)([A-Za-z0-9_]*)$ ]]; then
+	local suffix=
+	[[ $cur == \"* ]] && suffix=\"
+
+    if [[ $cur =~ ^(\"?\$(\{[!#]?)?)([A-Za-z0-9_]*)$ ]]; then
+		local prefix=${BASH_REMATCH[1]}
+		local var=${BASH_REMATCH[3]}
+
         # Completing $var / ${var / ${!var / ${#var
-        if [[ $cur == \${* ]]; then
+        if [[ $cur =~ ^\"?\$\{ ]]; then
             local arrs vars
-            vars=( $( compgen -A variable -P ${BASH_REMATCH[1]} -S '}' -- ${BASH_REMATCH[3]} ) ) && \
-            arrs=( $( compgen -A arrayvar -P ${BASH_REMATCH[1]} -S '[' -- ${BASH_REMATCH[3]} ) )
-            if [[ ${#vars[@]} -eq 1 && $arrs ]]; then
+            vars=( $( compgen -A variable -P $prefix -S '}'"$suffix" -- $var ) ) && \
+            arrs=( $( compgen -A arrayvar -P $prefix -S '[' -- $var ) )
+            
+            if [[ ${#vars[*]} -eq 1 && $arrs ]]; then
                 # Complete ${arr with ${array[ if there is only one match, and that match is an array variable
                 compopt -o nospace
                 COMPREPLY+=( ${arrs[*]} )
@@ -636,23 +643,23 @@ _variables()
             fi
         else
             # Complete $var with $variable
-            COMPREPLY+=( $( compgen -A variable -P '$' -- "${BASH_REMATCH[3]}" ) )
+            COMPREPLY+=( $( compgen -A variable -P '$' -S "$suffix" -- "$var" ) )
         fi
         return 0
-    elif [[ $cur =~ ^(\$\{[#!]?)([A-Za-z0-9_]*)\[([^]]*)$ ]]; then
+    elif [[ $cur =~ ^(\"?\$\{[#!]?)([A-Za-z0-9_]*)\[([^]]*)$ ]]; then
         # Complete ${array[i with ${array[idx]}
         local IFS=$'\n'
         COMPREPLY+=( $( compgen -W '$(printf %s\\n "${!'${BASH_REMATCH[2]}'[@]}")' \
-            -P "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[" -S ']}' -- "${BASH_REMATCH[3]}" ) )
+            -P "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[" -S ']}'"$suffix" -- "${BASH_REMATCH[3]}" ) )
         # Complete ${arr[@ and ${arr[*
         if [[ ${BASH_REMATCH[3]} == [@*] ]]; then
             COMPREPLY+=( "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[${BASH_REMATCH[3]}]}" )
         fi
         __ltrim_colon_completions "$cur"    # array indexes may have colons
         return 0
-    elif [[ $cur =~ ^\$\{[#!]?[A-Za-z0-9_]*\[.*\]$ ]]; then
+    elif [[ $cur =~ ^\"?\$\{[#!]?[A-Za-z0-9_]*\[.*\]$ ]]; then
         # Complete ${array[idx] with ${array[idx]}
-        COMPREPLY+=( "$cur}" )
+        COMPREPLY+=( "$cur}$suffix" )
         __ltrim_colon_completions "$cur"
         return 0
     else
@@ -676,6 +683,7 @@ _variables()
     fi
     return 1
 }
+
 
 # Initialize completion and deal with various general things: do file
 # and variable completion where appropriate, and adjust prev, words,


### PR DESCRIPTION
Changed function: _variables()
e.g.  foo "${BASH_VERSIO<tab> completes to foo "${BASH_VERSION}" and
foo "$BASH_VERSIO<tab> comletes to foo "$BASH_VERSION"

Note: foo "${BASH_VERSIN<tab> completes to foo "${BASH_VERSINFO[", though additional <tab> deletes the trailing quote, and two more <tab> presses shows the completions with quotes. This is at least when using 4.3.11(1)-release with the updated _variables().