### PR TITLE
make the completion about ip smart

### DIFF
--- a/completions/ip
+++ b/completions/ip
@@ -62,7 +62,7 @@ _ip()
     [[ $subcmd == help ]] && return
 
     case $cmd in
-        l)
+        l*)
             case $subcmd in
                 add)
                     # TODO

--- a/completions/ip
+++ b/completions/ip
@@ -62,7 +62,7 @@ _ip()
     [[ $subcmd == help ]] && return
 
     case $cmd in
-        link)
+        l)
             case $subcmd in
                 add)
                     # TODO
@@ -122,7 +122,7 @@ _ip()
             esac
             ;;
 
-        addr)
+        a*)
             case $subcmd in
                 add|change|replace)
                     if [[ $prev == dev ]]; then
@@ -179,7 +179,7 @@ _ip()
             esac
             ;;
 
-        route)
+        r*)
             case $subcmd in
                 list|flush)
                     if [[ $prev == proto ]]; then


### PR DESCRIPTION
In zsh, I can use ip a[tab] to complement, but in bash, I need to ip addr [tab], I think it which I change can help you to make it better.
Sorry my English is not good. 
Chinese:在zsh里面可以使用ip a [tab]进行补全，但是在bash这样做不行，只能打完addr再[tab]，所以我修改了一下ip的补全，希望可以帮到你更好的完善bash-completion