### PR TITLE
Add sidedoor to _ssh() completion

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -595,6 +595,7 @@ CLEANFILES = \
 	sdptool \
 	setquota \
 	sftp \
+	sidedoor \
 	slogin \
 	smbcacls \
 	smbcquotas \
@@ -910,7 +911,7 @@ symlinks: $(targetdir) $(DATA)
 		rm -f $(targetdir)/$$file && \
 			$(LN_S) sbcl $(targetdir)/$$file ; \
 	done
-	for file in slogin autossh sftp scp ; do \
+	for file in slogin autossh sftp scp sidedoor ; do \
 		rm -f $(targetdir)/$$file && \
 			$(LN_S) ssh $(targetdir)/$$file ; \
 	done

--- a/completions/ssh
+++ b/completions/ssh
@@ -224,7 +224,7 @@ _ssh()
         fi
     fi
 } &&
-shopt -u hostcomplete && complete -F _ssh ssh slogin autossh
+shopt -u hostcomplete && complete -F _ssh ssh slogin autossh sidedoor
 
 # sftp(1) completion
 #


### PR DESCRIPTION
[sidedoor][sidedoor] maintains an SSH connection
and is packaged in Debian. Although its primary use is as a
daemon, it can be invoked like autossh.

[sidedoor]: https://github.com/daradib/sidedoor