### PR TITLE
Fix bug in 'make' completion when using BSD sed

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -69,7 +69,7 @@ EOF
     # don't complete with hidden targets unless we are doing a partial completion
     if [[ -z "${prefix_pat}" || "${prefix_pat}" = */ ]]; then
       cat <<EOF
-      /^${prefix_pat}[^a-zA-Z0-9]/d             # convention for hidden tgt
+      /^${prefix_pat}[^a-zA-Z0-9]/d;            # convention for hidden tgt
 EOF
     fi
 


### PR DESCRIPTION
On OSX, using BSD sed, this error occurs when trying to complete a space, this error occurs:
'make sed: 46: /dev/fd/63: extra characters at the end of d command'

This does not occur with the above change or with gsed.