### PR TITLE
Fix __reassemble_comp_words_by_ref with only space after caret

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -433,9 +433,6 @@ __reassemble_comp_words_by_ref()
                 ((i == COMP_CWORD)) && printf -v "$3" %s "$j"
                 # Remove optional whitespace + word separator from line copy
                 line=${line#*"${COMP_WORDS[i]}"}
-                # Start new word if word separator in original line is
-                # followed by whitespace.
-                [[ $line == [[:blank:]]* ]] && ((j++))
                 # Indicate next word if available, else end *both* while and
                 # for loop
                 if ((i < ${#COMP_WORDS[@]} - 1)); then
@@ -443,6 +440,9 @@ __reassemble_comp_words_by_ref()
                 else
                     break 2
                 fi
+                # Start new word if word separator in original line is
+                # followed by whitespace.
+                [[ $line == [[:blank:]]* ]] && ((j++))
             done
             # Append word to current word
             ref="$2[$j]"

--- a/test/t/unit/test_unit_get_cword.py
+++ b/test/t/unit/test_unit_get_cword.py
@@ -153,3 +153,12 @@ class TestUnitGetCword(TestUnitBase):
             ]
         )
         assert got == 1
+
+    def test_25(self, bash):
+        """
+        a b c:| with trailing whitespace after the caret (no more words) and
+        with WORDBREAKS -= : should return c:
+        """
+        assert_bash_exec(bash, "add_comp_wordbreak_char :")
+        output = self._test(bash, "(a b c :)", 3, "a b c: ", 6, arg=":")
+        assert output == "c:"


### PR DESCRIPTION
Without this commit, the cword calculation is done wrongly if there is only whitespace after the caret, but no additional word.

I tried to execute the tests and add a test for this, but unfortunately I was not able to get the test to work properly and didn't really get how to write tests properly in this project.
So it would be nice if the reviewer could execute the tests to see whether my change breaks anything else tested and maybe someone can also add a test for this.