### PR TITLE
test: run bash with --norc to avoid system bashrc

### DIFF
--- a/doc/testing.txt
+++ b/doc/testing.txt
@@ -184,7 +184,6 @@ test-run fails.
 set -e  # Exit if simple command fails
 set -u  # Error if variable is undefined
 
-CRON=running
 LOG=/tmp/bash-completion.log~
 
     # Retrieve latest sources

--- a/test/config/bashrc
+++ b/test/config/bashrc
@@ -1,5 +1,8 @@
 # bashrc file for DejaGnu testsuite
 
+# Note that we do some initialization that would be too late to do here in
+# library.exp's start_bash().
+
 	# Use emacs key bindings
 set -o emacs
 	# Use bash strict mode
@@ -7,17 +10,8 @@ set -o posix
 	# Unset `command_not_found_handle' as defined on Debian/Ubuntu, because this
 	# troubles and slows down testing
 unset -f command_not_found_handle
-	# Set fixed prompt `/@'
 TESTDIR=$(pwd)
-export PS1='/@'
 export PS2='> '
-	# Configure readline
-export INPUTRC=$SRCDIR/config/inputrc
-    # When not running via cron, avoid escape junk at beginning of line from
-    # readline, see e.g.  http://bugs.gentoo.org/246091
-[ "$CRON" ] || export TERM=dumb
-	# Ensure enough columns so expect doesn't have to care about line breaks
-stty columns 150
     # Also test completions of system administrator commands, which are
     # installed via the same PATH expansion in `bash_completion.have()'
 export PATH=$PATH:/sbin:/usr/sbin:/usr/local/sbin

--- a/test/lib/library.exp
+++ b/test/lib/library.exp
@@ -991,8 +991,13 @@ proc start_bash {} {
     if {! [info exists TOOL_EXECUTABLE]} {set TOOL_EXECUTABLE bash}
     set env(SRCDIR) $::srcdir
     set env(SRCDIRABS) $::srcdirabs
-    exp_spawn $TOOL_EXECUTABLE --rcfile $::srcdir/config/bashrc
-    assert_bash_exec {} "$TOOL_EXECUTABLE --rcfile $::srcdir/config/bashrc"
+    set env(PS1) "/@"
+    set env(INPUTRC) "$::srcdir/config/inputrc"
+    set env(TERM) "dumb"
+    set stty_init "columns 150"
+    exp_spawn $TOOL_EXECUTABLE --norc
+    assert_bash_exec {} "$TOOL_EXECUTABLE --norc"
+    assert_bash_exec "source $::srcdir/config/bashrc"
 }
 
 

--- a/test/lib/library.exp
+++ b/test/lib/library.exp
@@ -991,10 +991,20 @@ proc start_bash {} {
     if {! [info exists TOOL_EXECUTABLE]} {set TOOL_EXECUTABLE bash}
     set env(SRCDIR) $::srcdir
     set env(SRCDIRABS) $::srcdirabs
+
+    # PS1, INPUTRC, TERM and stty columns must be initialized
+    # *before* starting bash to take proper effect.
+
+    # Set fixed prompt `/@'
     set env(PS1) "/@"
+    # Configure readline
     set env(INPUTRC) "$::srcdir/config/inputrc"
+    # Avoid escape junk at beginning of line from readline,
+    # see e.g.  http://bugs.gentoo.org/246091
     set env(TERM) "dumb"
+    # Ensure enough columns so expect doesn't have to care about line breaks
     set stty_init "columns 150"
+
     exp_spawn $TOOL_EXECUTABLE --norc
     assert_bash_exec {} "$TOOL_EXECUTABLE --norc"
     assert_bash_exec "source $::srcdir/config/bashrc"


### PR DESCRIPTION
When running bash with `--rcfile` it skips loading the user bashrc, but
it doesn't skip loading the system bashrc.

If bash completions is installed and loaded from system bashrc, this
causes an error:
```
FAIL: ERROR Unexpected output from bash command "BASH_COMPLETION_COMPAT_DIR=$(cd "$SRCDIR/.."; pwd)/completions"
FAIL: ERROR executing bash command "BASH_COMPLETION_COMPAT_DIR=$(cd "$SRCDIR/.."; pwd)/completions"
```
In order to avoid that, run bash with the `--norc` option which skips
loading any bashrc, and immediately source our `config/bashrc`.
It is important to set INPUTRC and PS1 before running bash.