### PR TITLE
Fixed errors when using declare and complete

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1888,7 +1888,7 @@ complete -F _longopt a2ps awk base64 bash bc bison cat chroot colordiff cp \
     sed seq sha{,1,224,256,384,512}sum shar sort split strip sum tac tail tee \
     texindex touch tr uname unexpand uniq units vdir wc who
 
-declare -A _xspecs
+declare _xspecs
 _filedir_xspec()
 {
     local cur prev words cword
@@ -2051,7 +2051,7 @@ _completion_loader()
     # Need to define *something*, otherwise there will be no completion at all.
     complete -F _minimal -- "$cmd" && return 124
 } &&
-complete -D -F _completion_loader
+complete _completion_loader
 
 # Function for loading and calling functions from dynamically loaded
 # completion files that may not have been sourced yet.


### PR DESCRIPTION
After removing some invalid and misused function options, code now executes without error.  It appears to behave correctly but cannot confirm.
removed an invalid option -A for declare
removed an invalid option -D for complete as well as a misused option -F
Original execution errors from bash: 
-bash: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
-bash: complete: -D: invalid option
complete: usage: complete [-abcdefgjksuv] [-pr] [-o option] [-A action] [-G globpat] [-W wordlist] [-P prefix] [-S suffix] [-X filterpat] [-F function] [-C command] [name ...]