### PR TITLE
Makefile: update default compatdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ EXTRA_DIST = CHANGES $(pkgdata_DATA) bash_completion.sh.in .dir-locals.el \
 
 install-data-hook:
 	tmpfile=`mktemp $${TMPDIR:-/tmp}/bash_completion.XXXXXX` && \
-	sed -e 's|=/etc/bash_completion\.d|=$(compatdir)|' \
+	sed -e 's|-/etc/bash_completion\.d|-$(compatdir)|' \
 	    $(DESTDIR)$(pkgdatadir)/bash_completion > $$tmpfile && \
 	cat $$tmpfile > $(DESTDIR)$(pkgdatadir)/bash_completion && \
 	sed -e 's|\$${prefix}|$(prefix)|' \


### PR DESCRIPTION
This was broken in c41a76237bc9dcbfa326eeddd026b66d7646d91d.

Fixes #131.