### PR TITLE
test suite: Limit number of info matches

### DIFF
--- a/test/lib/completions/info.exp
+++ b/test/lib/completions/info.exp
@@ -11,7 +11,8 @@ proc teardown {} {
 setup
 
 
-assert_complete_any "info "
+# Limit number of patches, assume at least coreutils is there
+assert_complete_any "info c"
 
 
 sync_after_int


### PR DESCRIPTION
info might match a lot of files installed on a system, causing the test to fail as unresolved. Match only info files starting with 't' to reduce that number. 't' is guaranteed to match since it matches texinfo doc.

Log before the fix:
```
Test run by mgorny on Sun Jul  2 09:26:30 2017
Native configuration is x86_64-pc-linux-gnu

		=== completion tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
Using ./config/default.exp as tool-and-target-specific interface file.
Running ./completion/info.exp ...
exp_spawn bash --rcfile ./config/bashrc
/@echo $?
0
/@BASH_COMPLETION_COMPAT_DIR="$SRCDIR/fixtures/shared/empty_dir"
/@echo $?
0
/@source $(cd "$SRCDIR/.."; pwd)/bash_completion
/@echo $?
0
/@printf "%s" "$COMP_WORDBREAKS"
 	
"'><=;|&(:/@echo $?
0
/@printf "%s " "${BASH_VERSINFO[@]}"
4 4 12 1 release x86_64-pc-linux-gnu /@echo $?
0
/@printf "%s" "$BASH_VERSION"
4.4.12(1)-release/@echo $?
0
/@printf "%s" "$TESTDIR"
/home/mgorny/git/bash-completion/test/@echo $?
0
/@eval $(locale); printf "%s" "$LC_CTYPE"
pl_PL.utf8/@echo $?
0
/@exec 6>'xtrace.log'
/@echo $?
0
/@BASH_XTRACEFD=6
/@echo $?
0
/@set -o xtrace
/@echo $?
0
/@type info &> /dev/null && echo -n 0 || echo -n 1
0/@__load_completion info ; complete -p info &> /dev/null && echo -n 0 || echo -n 1
0/@{ (set -o posix ; set); declare -F; shopt -p; set -o; } > "$TESTDIR/tmp/env.env1~"
/@echo $?
0
/@info 
abs_integrate                as                           aspell-dev.info              aspell.info                  assuan.info
autoconf-2.1.info            autoconf-2.69.info           autoconf-archive.info        autoconf-archive.info-1      autoconf-archive.info-2
autoconf-archive.info-3      autoconf-archive.info-4      automake-1.11.info           automake-1.11.info-1         automake-1.11.info-2
automake-1.11.info-3         automake-1.12.info           automake-1.12.info-1         automake-1.12.info-2         automake-1.12.info-3
automake-1.13.info           automake-1.13.info-1         automake-1.13.info-2         automake-1.14.info           automake-1.14.info-1
automake-1.14.info-2         automake-1.15.info           automake-1.15.info-1         automake-1.15.info-2         automake-history-1.12.info
automake-history-1.13.info   automake-history-1.14.info   automake-history-1.15.info   autosprintf.info             bash-3.2.info
bash-4.2.info                bash.info                    bashref-3.2.info             bashref-4.2.info             bashref.info
bc.info                      bfd                          bfd.info                     binutils                     bison.info
boa.info                     cln.info                     coreutils.info               cpio.info                    cpp
cppinternals                 dc.info                      ddrescue.info                dejagnu.info                 diffutils.info
docbook2man-xslt.info        docbook2texi-xslt.info       docbook2X.info               drawutils                    dvipng.info
dvips.info                   ed.info                      fftw3.info                   fftw3.info-1                 fftw3.info-2
find.info                    find.info-1                  find.info-2                  find-maint.info              flex.info
flex.info-1                  flex.info-2                  gawkinet.info                gawk.info                    gcc
gccinstall                   gccint                       gcrypt.info                  gdb.info                     gdb.info-1
gdb.info-2                   gdb.info-3                   gdb.info-4                   gdb.info-5                   gdb.info-6
gdb.info-7                   gdbm.info                    gettext.info                 ginac-examples.info          ginac.info
gmp.info                     gmp.info-1                   gmp.info-2                   gnuchess.info                gnupg.info
gnupg.info-1                 gnupg.info-2                 gperf.info                   gpgme.info                   gpgme.info-1
gpgme.info-2                 gpgrt.info                   gprof                        grep.info                    groff.info
groff.info-1                 groff.info-2                 gsl-ref.info                 gsl-ref.info-1               gsl-ref.info-2
gsl-ref.info-3               gsl-ref.info-4               gsl-ref.info-5               gsl-ref.info-6               gzip.info
heimdal.info                 help2man-de.info             help2man-es.info             help2man-fr.info             help2man.info
help2man-pl.info             help2man-uk.info             help2man-zh_CN.info          history.info                 hx509.info
indent.info                  info-stnd.info               kovacicODE                   kpathsea.info                ksba.info
ld                           libcdio.info                 libc.info                    libc.info-1                  libc.info-10
libc.info-11                 libc.info-12                 libc.info-13                 libc.info-14                 libc.info-15
libc.info-2                  libc.info-3                  libc.info-4                  libc.info-5                  libc.info-6
libc.info-7                  libc.info-8                  libc.info-9                  libffi.info                  libgomp
libidn2.info                 libidn-components            libidn.info                  libitm                       libmicrohttpd.info
libmicrohttpd-tutorial.info  libquadmath                  libtasn1.info                libtool.info                 libtool.info-1
libtool.info-2               libxmi.info                  logic                        lzip.info                    lzlib.info
m4.info                      m4.info-1                    m4.info-2                    make.info                    make.info-1
make.info-2                  maxima                       maxima-index                 mgetty                       mpc.info
mpfr.info                    mtools.info                  netcdf-cxx.info              parted.info                  pinentry.info
plotutils.info               plzip.info                   readline.info                rluserman.info               screen.info
sed.info                     stabs.info                   standards-2.1.info           standards-2.69.info          tar.info
tar.info-1                   tar.info-2                   texi2html.info               texinfo.info                 texinfo.info-1
texinfo.info-2               texinfo.info-3               tlbuild.info                 web2c.info                   wget.info
which.info
/@info UNRESOLVED: info  should show completions at prompt
^C
/@{ (set -o posix ; set); declare -F; shopt -p; set -o; } > "$TESTDIR/tmp/env.env2~"
/@echo $?
0
/@diff_env "$TESTDIR/tmp/env.env1~" "$TESTDIR/tmp/env.env2~" "" LAST-ARG
/@PASS: Environment should not be modified
testcase ./completion/info.exp completed in 1 seconds

		=== completion Summary ===

# of expected passes		1
# of unresolved testcases	1
runtest completed at Sun Jul  2 09:26:32 2017
```