### PR TITLE
test: Support overriding default match buffer size

### DIFF
--- a/test/lib/library.exp
+++ b/test/lib/library.exp
@@ -1023,6 +1023,11 @@ proc start_interactive_test {} {
     if {[info exists OPT_BASH_XTRACE]} {
         init_bash_xtrace
     }
+    global OPT_BUFFER_SIZE
+    if {[info exists OPT_BUFFER_SIZE]} {
+        verbose "Changing default expect match buffer size to $OPT_BUFFER_SIZE"
+        match_max $OPT_BUFFER_SIZE
+    }
     global OPT_TIMEOUT
     if {[info exists OPT_TIMEOUT]} {
         global timeout

--- a/test/run
+++ b/test/run
@@ -10,6 +10,7 @@ usage() {
     echo
     echo "Interesting options:"
     echo "  --tool_exec=    Test against a different bash executable."
+    echo "  --buffer_size   Change expect match buffer size from the default of 2000 bytes."
     echo "  --debug         Create a dbg.log in the test directory with detailed expect match information."
     echo "  --timeout       Change expect timeout from the default of 10 seconds."
     echo "  --debug-xtrace  Create an xtrace.log in the test directory with set -x output."
@@ -39,6 +40,8 @@ args=()
 while [[ $# > 0 ]]; do
     case "$1" in
         --help|--usage) usage; exit 1;;
+        --buffer-size) shift; buffer_size=$1;;
+        --buffer-size=*) buffer_size=${1/--buffer-size=};;
         --debug-xtrace) args+=(OPT_BASH_XTRACE=1);;
         --timeout) shift; timeout=$1;;
         --timeout=*) timeout=${1/--timeout=};;
@@ -54,6 +57,7 @@ while [[ $# > 0 ]]; do
     shift
 done
 
+[[ -n $buffer_size ]] && args+=("OPT_BUFFER_SIZE=$buffer_size")
 [[ -n $timeout ]] && args+=("OPT_TIMEOUT=$timeout")
 [[ -z $tool ]] && { echo "Must specify tool somehow"; exit 1; }
 


### PR DESCRIPTION
Add an option, complementary to --timeout, that can be used to alter
the match buffer size for expect (match_max).