### PR TITLE
lftp: Support ~/.local/... bookmark location

### DIFF
--- a/completions/lftp
+++ b/completions/lftp
@@ -21,7 +21,7 @@ _lftp()
     fi
 
     COMPREPLY=( $( compgen -W \
-        '$( cut -f 1 -s ~/.lftp/bookmarks 2>/dev/null )' -- "$cur" ) )
+        '$( cut -f 1 -s ~/.lftp/bookmarks ${XDG_DATA_HOME:-$HOME/.local/share}/lftp/bookmarks 2>/dev/null )' -- "$cur" ) )
     _known_hosts_real "$cur"
 } &&
 complete -F _lftp lftp


### PR DESCRIPTION
Support the new ~/.local/share/lftp/bookmarks bookmark location. Both locations
are possible, depending on whether ~/.lftp exists.

Bug: https://bugs.gentoo.org/527450
Original-Author: Andrew Petelin <adrianopol@gmail.com>