### PR TITLE
Add support for .lzo extension (--lzop) to tar

### DIFF
--- a/completions/tar
+++ b/completions/tar
@@ -433,9 +433,9 @@ __tar_cleanup_prev()
 
 __tar_detect_ext()
 {
-    local tars='@(@(tar|gem|spkg)?(.@(Z|[bgx]z|bz2|lz?(ma)))|t@([abglx]z|b?(z)2))'
+    local tars='@(@(tar|gem|spkg)?(.@(Z|[bgx]z|bz2|lz?(ma|o)))|t@([abglx]z|b?(z)2))'
     ext="$tars"
-    regex='\(\(tar\|gem\|spkg\)\(\.\(Z\|[bgx]z\|bz2\|lz\(ma\)\?\)\)\?\|t\([abglx]z\|bz\?2\)\)'
+    regex='\(\(tar\|gem\|spkg\)\(\.\(Z\|[bgx]z\|bz2\|lz\(ma\|o\)\?\)\)\?\|t\([abglx]z\|bz\?2\)\)'
 
     case "$tar_mode_arg" in
         --*)
@@ -453,7 +453,7 @@ __tar_detect_ext()
             ;;
         +([^ZzJjy])f)
             ext="$tars"
-            regex='\(\(tar\|gem\|spkg\)\(\.\(Z\|[bgx]z\|bz2\|lz\(ma\)\?\)\)\?\|t\([abglx]z\|bz\?2\)\)'
+            regex='\(\(tar\|gem\|spkg\)\(\.\(Z\|[bgx]z\|bz2\|lz\(ma\|o\)\?\)\)\?\|t\([abglx]z\|bz\?2\)\)'
             ;;
         *[Zz]*f)
             ext='@(@(t?(ar.)|gem.|spkg.)@(gz|Z)|taz)'


### PR DESCRIPTION
The --lzop option can be used for tar to read lzop-compressed archives, often with the .lzo extension. We extend the regular expression to support completion of .lzo tar files as well.