### PR TITLE
* man - don't use $MANPATH directly (#160)

### DIFF
--- a/completions/man
+++ b/completions/man
@@ -53,9 +53,7 @@ _man()
         return
     fi
 
-    local manpath="$MANPATH"
-    [[ -z $manpath ]] && \
-        manpath=$( manpath 2>/dev/null || command man -w 2>/dev/null )
+    local manpath=$( manpath 2>/dev/null || command man -w 2>/dev/null )
     [[ -z $manpath ]] && manpath="/usr/share/man:/usr/local/share/man"
 
     # determine manual section to search


### PR DESCRIPTION
`manpath` or `man -w` print out the path based on `$MANPATH`, so it's not needed to be examined directly, otherwise it must be somehow expanded to make sure default man path is included.
