### PR TITLE
java -jar completes .war

### DIFF
--- a/completions/java
+++ b/completions/java
@@ -217,7 +217,7 @@ _java()
     else
         if [[ "$prev" == -jar ]]; then
             # jar file completion
-            _filedir jar
+            _filedir @(jar|war)
         else
             # classes completion
             _java_classes

--- a/test/lib/completions/java.exp
+++ b/test/lib/completions/java.exp
@@ -44,7 +44,7 @@ assert_no_complete "java -cp \"\" "
 sync_after_int
 
 
-assert_complete "a/ bashcomp.jar" "java -jar $::srcdir/fixtures/java/"
+assert_complete "a/ bashcomp.jar bashcomp.war" "java -jar $::srcdir/fixtures/java/"
 
 
 sync_after_int


### PR DESCRIPTION
@scop I would like `java -jar` to complete the `.war` files. For example, it is possible to run `java -jar jenkins.war` from the command line. This pull-request makes this possible.