### PR TITLE
OpenSSH: Allow completition of smart cards related options

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -172,6 +172,10 @@ _ssh()
             _filedir
             return
             ;;
+        -I)
+            _filedir "so"
+            return
+            ;;
         -c)
             _ssh_ciphers "$1"
             return
@@ -208,7 +212,7 @@ _ssh()
             _ip_addresses
             return
             ;;
-        -D|-e|-I|-L|-p|-R|-W)
+        -D|-e|-L|-p|-R|-W)
             return
             ;;
     esac

--- a/completions/ssh-add
+++ b/completions/ssh-add
@@ -6,7 +6,11 @@ _ssh_add()
     _init_completion || return
 
     case $prev in
-        -t|-s|-e)
+        -t)
+            return
+            ;;
+        -s|-e)
+            _filedir "so"
             return
             ;;
     esac

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -6,7 +6,7 @@ _ssh_keygen()
     _init_completion -n = || return
 
     case $prev in
-        -a|-b|-C|-D|-I|-J|-j|-M|-N|-n|-r|-P|-S|-V|-W|-z)
+        -a|-b|-C|-I|-J|-j|-M|-N|-n|-r|-P|-S|-V|-W|-z)
             return
             ;;
         -E)
@@ -16,6 +16,10 @@ _ssh_keygen()
         -F|-R)
             # TODO: trim this down to actual entries in known hosts files
             _known_hosts_real -- "$cur"
+            return
+            ;;
+        -D)
+            _filedir "so"
             return
             ;;
         -f|-G|-K|-s|-T)


### PR DESCRIPTION
For some reason, the completion of smartcard-related options were excluded, even though they accept path to PKCS#11 module (`*.so`) and it was very annoying to write all these paths manually. For example the following commands are completed correctly with this change and complete the files with "`*.so`" extension:
```
ssh -I /usr/lib64/pkcs11/opensc-pkcs11.so
ssh-add -s /usr/lib64/pkcs11/opensc-pkcs11.so
ssh-add -e /usr/lib64/pkcs11/opensc-pkcs11.so
ssh-keygen -D /usr/lib64/pkcs11/opensc-pkcs11.so
```
  