### PR TITLE
Fix kldunload on FreeBSD: show modules with digits in their file names

### DIFF
--- a/completions/kldunload
+++ b/completions/kldunload
@@ -7,8 +7,8 @@ _kldunload()
     local cur prev words cword
     _init_completion || return
 
-    COMPREPLY=( $( kldstat | command sed -ne \
-        "s/^.*[[:blank:]]\{1,\}\($cur[a-z_]\{1,\}\).ko$/\1/p" ) )
+    COMPREPLY=( $( compgen -W '$(kldstat)' -X 'kernel' -X '!*ko' -- "$cur" ) )
+    COMPREPLY="${COMPREPLY[@]//.ko/}"
 } &&
 complete -F _kldunload kldunload
 


### PR DESCRIPTION
There were some issues with the sed implementation of kldunload completions. This is a rewrite, which uses compgen.

It fix the issue with not displaying kernel modules with digits inside their names, which means that previously a loaded kernel module called "i915kms" would never be suggested to the user by Bash completions.

Also, thanks to the replacement of sed with compgen, the user will no longer see errors like "RE error: parentheses not balanced" when requesting completion after typing "kldunload /".

---

The patch was tested on FreeBSD 12.0-CURRENT. It should not cause any undesired behaviours. I also check related test files but it seemed to be unnecessary to modify them in this case.