### PR TITLE
Completions for openssl *pkey* commands

### DIFF
--- a/completions/openssl
+++ b/completions/openssl
@@ -50,7 +50,7 @@ _openssl()
         des des-cbc des-cfb des-ecb des-ede des-ede-cbc des-ede-cfb des-ede-ofb
         des-ede3 des-ede3-cbc des-ede3-cfb des-ede3-ofb des-ofb des3 desx rc2
         rc2-40-cbc rc2-64-cbc rc2-cbc rc2-cfb rc2-ecb rc2-ofb rc4 rc4-40
-        sha224 sha256 sha384 sha512 genpkey pkey pkeyparam'
+        sha224 sha256 sha384 sha512 genpkey pkey pkeyparam pkeyutl'
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -W "$commands" -- "$cur" ) )
@@ -59,9 +59,9 @@ _openssl()
         case $prev in
             -CA|-CAfile|-CAkey|-CAserial|-cert|-certfile|-config|-content| \
             -dcert|-dkey|-dhparam|-extfile|-in|-inkey|-kfile|-key|-keyout| \
-            -out|-oid|-paramfile|-prvrify|-rand|-recip|-revoke|-sess_in| \
-            -sess_out|-spkac|-sign|-signkey|-signer|-signature|-ss_cert| \
-            -untrusted|-verify)
+            -out|-oid|-paramfile|-peerkey|-prvrify|-rand|-recip|-revoke| \
+            -sess_in|-sess_out|-spkac|-sigfile|-sign|-signkey|-signer| \
+            -signature|-ss_cert|-untrusted|-verify)
                 _filedir
                 return
                 ;;
@@ -74,7 +74,7 @@ _openssl()
                 return
                 ;;
             -inform|-outform|-keyform|-certform|-CAform|-CAkeyform|-dkeyform|\
-            -dcertform)
+            -dcertform|-peerform)
                 formats='DER PEM'
                 case $command in
                     x509)
@@ -82,6 +82,9 @@ _openssl()
                         ;;
                     smime)
                         formats+=" SMIME"
+                        ;;
+                    pkeyutl)
+                        formats+=" ENGINE"
                         ;;
                 esac
                 COMPREPLY=( $( compgen -W "$formats" -- "$cur" ) )
@@ -169,6 +172,12 @@ _openssl()
                     ;;
                 pkeyparam)
                     options='-in -out -text -noout -engine'
+                    ;;
+                pkeyutl)
+                    options='-in -out -sigfile -inkey -keyform -passin -peerkey
+                        -peerform -pubin -certin -rev -sign -verify
+                        -verifyrecover -encrypt -decrypt -derive -kdf -kdflen
+                        -pkeyopt -hexdump -asn1parse -engine -engine_impl'
                     ;;
                 rand)
                     options='-out -rand -base64'

--- a/completions/openssl
+++ b/completions/openssl
@@ -50,7 +50,7 @@ _openssl()
         des des-cbc des-cfb des-ecb des-ede des-ede-cbc des-ede-cfb des-ede-ofb
         des-ede3 des-ede3-cbc des-ede3-cfb des-ede3-ofb des-ofb des3 desx rc2
         rc2-40-cbc rc2-64-cbc rc2-cbc rc2-cfb rc2-ecb rc2-ofb rc4 rc4-40
-        sha224 sha256 sha384 sha512'
+        sha224 sha256 sha384 sha512 genpkey'
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -W "$commands" -- "$cur" ) )
@@ -59,9 +59,9 @@ _openssl()
         case $prev in
             -CA|-CAfile|-CAkey|-CAserial|-cert|-certfile|-config|-content| \
             -dcert|-dkey|-dhparam|-extfile|-in|-inkey|-kfile|-key|-keyout| \
-            -out|-oid|-prvrify|-rand|-recip|-revoke|-sess_in|-sess_out| \
-            -spkac|-sign|-signkey|-signer|-signature|-ss_cert|-untrusted| \
-            -verify)
+            -out|-oid|-paramfile|-prvrify|-rand|-recip|-revoke|-sess_in| \
+            -sess_out|-spkac|-sign|-signkey|-signer|-signature|-ss_cert| \
+            -untrusted|-verify)
                 _filedir
                 return
                 ;;
@@ -150,6 +150,10 @@ _openssl()
                     ;;
                 gendsa)
                     options='-out -des -des3 -idea -rand'
+                    ;;
+                genpkey)
+                    options='-out -outform -pass -cipher -engine -paramfile
+                        -algorithm -pkeyopt -genparam -text'
                     ;;
                 genrsa)
                     options='-out -passout -des -des3 -idea -f4 -3 -rand'

--- a/completions/openssl
+++ b/completions/openssl
@@ -50,7 +50,7 @@ _openssl()
         des des-cbc des-cfb des-ecb des-ede des-ede-cbc des-ede-cfb des-ede-ofb
         des-ede3 des-ede3-cbc des-ede3-cfb des-ede3-ofb des-ofb des3 desx rc2
         rc2-40-cbc rc2-64-cbc rc2-cbc rc2-cfb rc2-ecb rc2-ofb rc4 rc4-40
-        sha224 sha256 sha384 sha512 genpkey pkey'
+        sha224 sha256 sha384 sha512 genpkey pkey pkeyparam'
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -W "$commands" -- "$cur" ) )
@@ -166,6 +166,9 @@ _openssl()
                     options='-inform -outform -in -passin -out -passout
                         -traditional -cipher -text -text_pub -noout -pubin
                         -pubout -engine'
+                    ;;
+                pkeyparam)
+                    options='-in -out -text -noout -engine'
                     ;;
                 rand)
                     options='-out -rand -base64'

--- a/completions/openssl
+++ b/completions/openssl
@@ -50,7 +50,7 @@ _openssl()
         des des-cbc des-cfb des-ecb des-ede des-ede-cbc des-ede-cfb des-ede-ofb
         des-ede3 des-ede3-cbc des-ede3-cfb des-ede3-ofb des-ofb des3 desx rc2
         rc2-40-cbc rc2-64-cbc rc2-cbc rc2-cfb rc2-ecb rc2-ofb rc4 rc4-40
-        sha224 sha256 sha384 sha512 genpkey'
+        sha224 sha256 sha384 sha512 genpkey pkey'
 
     if [[ $cword -eq 1 ]]; then
         COMPREPLY=( $( compgen -W "$commands" -- "$cur" ) )
@@ -161,6 +161,11 @@ _openssl()
                 pkcs7)
                     options='-inform -outform -in -out -print_certs -text
                         -noout'
+                    ;;
+                pkey)
+                    options='-inform -outform -in -passin -out -passout
+                        -traditional -cipher -text -text_pub -noout -pubin
+                        -pubout -engine'
                     ;;
                 rand)
                     options='-out -rand -base64'

--- a/completions/openssl
+++ b/completions/openssl
@@ -103,6 +103,10 @@ _openssl()
                     -- "$cur" ) )
                 return
                 ;;
+            -kdf)
+                COMPREPLY=( $( compgen -W 'TLS1-PRF HKDF' -- "$cur" ) )
+                return
+                ;;
         esac
 
         if [[ "$cur" == -* ]]; then


### PR DESCRIPTION
This patch set adds completion for openssl commands: genpkey, pkey, pkeyparam, and pkeyutl.

They have been requested by a Debian user [1], and, although upstream support was not available, I thought it could be a good learning exercise, since I have never programmed bash-completion.

I split the changes into 5 different patches, one for each openssl command, and a fifth that suggests arguments to the -kdf option.  I'm OK with squashing the changes...  I just split them because I thought it could ease review, specially for the fifth patch (and also because CONTRIBUTING.md suggests small changes...  Maybe it got too small?).

[1] https://bugs.debian.org/779814#10