### PR TITLE
mkdir: complete also on non dirs

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1892,7 +1892,7 @@ _longopt()
             command sed -ne 's/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p' | sort -u )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
-    elif [[ "$1" == @(@(mk|rm)dir|chroot) ]]; then
+    elif [[ "$1" == @(rmdir|chroot) ]]; then
         _filedir -d
     else
         _filedir

--- a/test/lib/completions/mkdir.exp
+++ b/test/lib/completions/mkdir.exp
@@ -17,17 +17,4 @@ assert_complete_any "mkdir "
 sync_after_int
 
 
-assert_complete {"bar bar.d/" foo.d/} "mkdir $::srcdir/fixtures/shared/default/"
-
-
-sync_after_int
-
-
-# No subdirs in foo.d and should not complete files in it (_longopt()).
-assert_no_complete "mkdir $::srcdir/fixtures/shared/default/foo.d/"
-
-
-sync_after_int
-
-
 teardown


### PR DESCRIPTION
mkdir creates directories that do not exist; there is no reason why the
names may not be derived from non directory files (for example creating
~/.bash_completion.d when ~/.bash_completion exists).

This effectively reverts commit 1b248b55 ("Make mkdir complete only on
dirs.", 2010-10-23).