### PR TITLE
ssh: avoid ssh-aliases/functions for remote filename completions

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -345,19 +345,19 @@ _scp_remote_files()
 
     # default to home dir of specified user on remote host
     if [[ -z $path ]]; then
-        path=$(ssh -o 'Batchmode yes' $userhost pwd 2>/dev/null)
+        path=$(command ssh -o 'Batchmode yes' $userhost pwd 2>/dev/null )
     fi
 
     local files
     if [[ $1 == -d ]]; then
         # escape problematic characters; remove non-dirs
-        files=$( ssh -o 'Batchmode yes' $userhost \
+        files=$(command ssh -o 'Batchmode yes' $userhost \
             command ls -aF1dL "$path*" 2>/dev/null | \
             command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e '/[^\/]$/d' )
     else
         # escape problematic characters; remove executables, aliases, pipes
         # and sockets; add space at end of file names
-        files=$( ssh -o 'Batchmode yes' $userhost \
+        files=$(command ssh -o 'Batchmode yes' $userhost \
             command ls -aF1dL "$path*" 2>/dev/null | \
             command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e 's/[*@|=]$//g' \
             -e 's/[^\/]$/& /g' )


### PR DESCRIPTION
    Justification: As a function (_scp) running in the current
    bash-environment, all aliases & functions will be defined in that
    environment. For ssh-aliases/fxns which act as a "hook", this has
    the potential of cluttering $COMP_WORDS, and ruining completion as a
    consequence.
        Alternatives, (e.g. wrapping the function-definition with 'shopt
    -u/s expand_aliases'), are insufficient, because:
        1) aliases still expand in subshells
        2) This still does not prevent function-resolution of functions
        named "ssh".
----
    I have an ssh-hook which was causing issues with `scp` filename completion. I did figure out a better alternative personally that works in the current state of `master`, (I added a condition for the hook which was printing to stdout/err to check that the sdout `[ -t 1 ]` and stderr `[ -t 2 ]` were attached to a terminal, but I thought submitting a simple patch would give better default behavior for users in general. For background, in my hook, I was checking if `stdin` was attached to a terminal, but the way this completion works, `/dev/stdin` is left still-attached to a terminal, while it is only stdout & stderr which are redirected.