### PR TITLE
pkg-config: datadir relative variables

### DIFF
--- a/bash-completion.pc.in
+++ b/bash-completion.pc.in
@@ -1,7 +1,8 @@
 prefix=@prefix@
+datadir=@datadir@
 compatdir=@compatdir@
-completionsdir=@datarootdir@/@PACKAGE@/completions
-helpersdir=@datarootdir@/@PACKAGE@/helpers
+completionsdir=${datadir}/@PACKAGE@/completions
+helpersdir=${datadir}/@PACKAGE@/helpers
 
 Name: bash-completion
 Description: programmable completion for the bash shell


### PR DESCRIPTION
Although `datarootdir` is defined as `${prefix}/share`, the user has the possibility to define `datadir` in a different directory.

Due to this `completionsdir` and `helpersdir` that are defined in the generated pkg-config `.pc` file should be relative to `datadir` variable.

This helps any pkg-config user to set these variables to proper directories by using the `define-variable` command line argument.