### PR TITLE
Fix common typo for paths

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -550,6 +550,10 @@ _filedir()
 {
     local IFS=$'\n'
 
+    if [[ $cur == \~\?* ]]; then
+        cur=$(echo "$cur" | sed -e 's/^\~\?/~\//')
+    fi
+
     _tilde "$cur" || return
 
     local -a toks


### PR DESCRIPTION
Replaces `~?` at the beginning of a path with `~/`, so that further completion can continue.