### PR TITLE
Declare _xspecs as global.

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1891,7 +1891,7 @@ complete -F _longopt a2ps awk base64 bash bc bison cat chroot colordiff cp \
     sed seq sha{,1,224,256,384,512}sum shar sort split strip sum tac tail tee \
     texindex touch tr uname unexpand uniq units vdir wc who
 
-declare -A _xspecs
+declare -Ag _xspecs
 _filedir_xspec()
 {
     local cur prev words cword

--- a/bash_completion
+++ b/bash_completion
@@ -1891,7 +1891,12 @@ complete -F _longopt a2ps awk base64 bash bc bison cat chroot colordiff cp \
     sed seq sha{,1,224,256,384,512}sum shar sort split strip sum tac tail tee \
     texindex touch tr uname unexpand uniq units vdir wc who
 
-declare -Ag _xspecs
+# declare only knows -g in bash >= 4.2.
+if [[ ${BASH_VERSINFO[0]} -ge 4 && ${BASH_VERSINFO[1]} -ge 2 ]]; then
+    declare -Ag _xspecs
+else
+    declare -A _xspecs
+fi
 _filedir_xspec()
 {
     local cur prev words cword

--- a/bash_completion
+++ b/bash_completion
@@ -1892,7 +1892,8 @@ complete -F _longopt a2ps awk base64 bash bc bison cat chroot colordiff cp \
     texindex touch tr uname unexpand uniq units vdir wc who
 
 # declare only knows -g in bash >= 4.2.
-if [[ ${BASH_VERSINFO[0]} -ge 4 && ${BASH_VERSINFO[1]} -ge 2 ]]; then
+if [[ ${BASH_VERSINFO[0]} -gt 4 ||
+      ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 2 ]]; then
     declare -Ag _xspecs
 else
     declare -A _xspecs


### PR DESCRIPTION
By default, associative arrays are local. If bash_completion is sourced from
within a funciton, they won't propagate to the caller, and the system is not
initialized properly. By making this explicitly global, it propagates as
expected.