### PR TITLE
Support new GCC --completion option for bash completion

### DIFF
--- a/completions/gcc
+++ b/completions/gcc
@@ -1,50 +1,58 @@
 # gcc(1) completion                                        -*- shell-script -*-
-#
-# The only unusual feature is that we don't parse "gcc --help -v" output
-# directly, because that would include the options of all the other backend
-# tools (linker, assembler, preprocessor, etc) without any indication that
-# you cannot feed such options to the gcc driver directly.  (For example, the
-# linker takes a -z option, but you must type -Wl,-z for gcc.)  Instead, we
-# ask the driver ("g++") for the name of the compiler ("cc1"), and parse the
-# --help output of the compiler.
 
 _gcc()
 {
-    local cur prev words cword
+    local cur prev prev2 words cword argument prefix prefix_length
     _init_completion || return
 
-    local cc backend
+    # Test that GCC is recent enough and if not fallback to
+    # parsing of --completion option.
+    if ! $1 --completion=" " 2>/dev/null; then
+        if [[ "$cur" == -* ]]; then
+            local cc=$($1 -print-prog-name=cc1 2>/dev/null)
+            [[ $cc ]] || return
+            COMPREPLY=($( compgen -W "$($cc --help 2>/dev/null | tr '\t' ' ' |\
+                command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')" -- "$cur" ))
+            [[ $COMPREPLY == *= ]] && compopt -o nospace
+            return
+        else
+            _filedir
+            return
+        fi
+    fi
 
-    case $1 in
-        gcj)
-            backend=jc1
-            ;;
-        gpc)
-            backend=gpc1
-            ;;
-        *77)
-            backend=f771
-            ;;
-        *95)
-            backend=f951
-            ;;
-        *)
-            backend=cc1 # (near-)universal backend
-            ;;
-    esac
+    # extract also for situations like: -fsanitize=add
+    if [[ $cword -gt 2 ]]; then
+        prev2="${COMP_WORDS[$cword - 2]}"
+    fi
 
+    # sample: -fsan
     if [[ "$cur" == -* ]]; then
-        cc=$($1 -print-prog-name=$backend 2>/dev/null)
-        [[ $cc ]] || return
-        # sink stderr:
-        # for C/C++/ObjectiveC it's useless
-        # for FORTRAN/Java it's an error
-        COMPREPLY=( $(compgen -W "$($cc --help 2>/dev/null | tr '\t' ' ' |\
-            command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')" \
-            -- "$cur") )
-        [[ $COMPREPLY == *= ]] && compopt -o nospace
-    else
+        argument=$cur
+        prefix=""
+    # sample: -fsanitize=
+    elif [[ "$cur" == "=" && $prev == -* ]]; then
+        argument=$prev$cur
+        prefix=$prev$cur
+    # sample: -fsanitize=add
+    elif [[ "$prev" == "=" && $prev2 == -* ]]; then
+        argument=$prev2$prev$cur
+        prefix=$prev2$prev
+    # sample: --param lto-
+    elif [[ "$prev" == "--param" ]]; then
+        argument="$prev $cur"
+        prefix="$prev "
+    fi
+
+    if [[ "$argument" == "" ]]; then
         _filedir
+    else
+        # In situation like '-fsanitize=add' $cur is equal to last token.
+        # Thus we need to strip the beginning of suggested option.
+        prefix_length=$((${#prefix}+1))
+        local flags=$($1 --completion="$argument" | cut -c $prefix_length-)
+        [[ "${flags}" == "=*" ]] && compopt -o nospace 2>/dev/null
+        COMPREPLY=($(compgen -W "$flags" -- ""))
     fi
 } &&
 complete -F _gcc gcc{,-5,-6,-7,-8} g++{,-5,-6,-7,-8} g77 g95 \

--- a/completions/gcc
+++ b/completions/gcc
@@ -12,13 +12,13 @@ _gcc()
             local cc=$($1 -print-prog-name=cc1 2>/dev/null)
             [[ $cc ]] || return
             COMPREPLY=($( compgen -W "$($cc --help 2>/dev/null | tr '\t' ' ' |\
-                command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')" -- "$cur" ))
+                command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')" \
+                -- "$cur" ))
             [[ $COMPREPLY == *= ]] && compopt -o nospace
-            return
         else
             _filedir
-            return
         fi
+        return
     fi
 
     # extract also for situations like: -fsanitize=add
@@ -39,12 +39,12 @@ _gcc()
         argument=$prev2$prev$cur
         prefix=$prev2$prev
     # sample: --param lto-
-    elif [[ "$prev" == "--param" ]]; then
+    elif [[ "$prev" == --param ]]; then
         argument="$prev $cur"
         prefix="$prev "
     fi
 
-    if [[ "$argument" == "" ]]; then
+    if [[ -z $argument ]]; then
         _filedir
     else
         # In situation like '-fsanitize=add' $cur is equal to last token.
@@ -52,7 +52,7 @@ _gcc()
         prefix_length=$((${#prefix}+1))
         local flags=$($1 --completion="$argument" | cut -c $prefix_length-)
         [[ "${flags}" == "=*" ]] && compopt -o nospace 2>/dev/null
-        COMPREPLY=($(compgen -W "$flags" -- ""))
+        COMPREPLY=( $(compgen -W "$flags" -- "") )
     fi
 } &&
 complete -F _gcc gcc{,-5,-6,-7,-8} g++{,-5,-6,-7,-8} g77 g95 \

--- a/test/t/test_gcc.py
+++ b/test/t/test_gcc.py
@@ -1,7 +1,64 @@
 import pytest
 
+from conftest import assert_bash_exec
+
 
 class TestGcc:
+    @pytest.fixture(scope="class")
+    def gcc_with_completion(self, bash):
+        got = assert_bash_exec(bash,
+                               "gcc --help=common || :",
+                               want_output=True)
+        if '--completion' not in got:
+            pytest.skip("GCC does not support --completion")
+
+    @pytest.fixture(scope="class")
+    def gcc_x86(self, bash):
+        got = assert_bash_exec(bash, "gcc -v || :", want_output=True)
+        if 'Target: x86' not in got:
+            pytest.skip("Not a x86 GCC ")
+
     @pytest.mark.complete("gcc ")
     def test_1(self, completion):
         assert completion
+
+    @pytest.mark.complete("gcc -fsanitize=add")
+    def test_enum_value(self, completion, gcc_with_completion):
+        assert completion == '-fsanitize=address'
+
+    @pytest.mark.complete("gcc -fsanitize=")
+    def test_enum_value_with_eq(self, completion, gcc_with_completion):
+        assert 'address' in completion
+
+    @pytest.mark.complete("gcc -fno-ipa-ic")
+    def test_negative_option(self, completion, gcc_with_completion):
+        assert '-fno-ipa-icf' in completion
+
+    @pytest.mark.complete("gcc -fxyz-abc")
+    def test_no_completion(self, completion, gcc_with_completion):
+        assert len(completion) == 0
+
+    @pytest.mark.complete("gcc --param ")
+    def test_param_with_space(self, completion, gcc_with_completion):
+        assert len(completion) > 50
+        # starting with GCC 10.1 param end with =
+        assert ('lto-partitions' in completion
+                or 'lto-partitions=' in completion)
+
+    @pytest.mark.complete("gcc --param=lto-max-p")
+    def test_param_with_eq(self, completion, gcc_with_completion):
+        # starting with GCC 10.1 param end with =
+        assert (completion == '--param=lto-max-partition' or
+                completion == '--param=lto-max-partition=')
+
+    @pytest.mark.complete("gcc -march=amd")
+    def test_march(self, completion, gcc_with_completion, gcc_x86):
+        assert completion == '-march=amdfam10'
+
+    @pytest.mark.complete("gcc -march=")
+    def test_march_native(self, completion, gcc_with_completion):
+        assert 'native' in completion
+
+    @pytest.mark.complete("gcc -mtune=")
+    def test_mtune_generic(self, completion, gcc_with_completion):
+        assert 'generic' in completion

--- a/test/t/test_gcc.py
+++ b/test/t/test_gcc.py
@@ -35,7 +35,7 @@ class TestGcc:
         assert "-fno-ipa-icf" in completion
 
     @pytest.mark.complete("gcc -fxyz-abc")
-    def test_no_completion(self, completion, gcc_with_completion):
+    def test_no_completion(self, completion):
         assert not completion
 
     @pytest.mark.complete("gcc --param ")

--- a/test/t/test_gcc.py
+++ b/test/t/test_gcc.py
@@ -6,17 +6,17 @@ from conftest import assert_bash_exec
 class TestGcc:
     @pytest.fixture(scope="class")
     def gcc_with_completion(self, bash):
-        got = assert_bash_exec(bash,
-                               "gcc --help=common || :",
-                               want_output=True)
-        if '--completion' not in got:
+        got = assert_bash_exec(
+            bash, "gcc --help=common || :", want_output=True
+        )
+        if "--completion" not in got:
             pytest.skip("GCC does not support --completion")
 
     @pytest.fixture(scope="class")
     def gcc_x86(self, bash):
         got = assert_bash_exec(bash, "gcc -v || :", want_output=True)
-        if 'Target: x86' not in got:
-            pytest.skip("Not a x86 GCC ")
+        if "Target: x86" not in got:
+            pytest.skip("Not a x86 GCC")
 
     @pytest.mark.complete("gcc ")
     def test_1(self, completion):
@@ -24,41 +24,44 @@ class TestGcc:
 
     @pytest.mark.complete("gcc -fsanitize=add")
     def test_enum_value(self, completion, gcc_with_completion):
-        assert completion == '-fsanitize=address'
+        assert completion == "-fsanitize=address"
 
     @pytest.mark.complete("gcc -fsanitize=")
     def test_enum_value_with_eq(self, completion, gcc_with_completion):
-        assert 'address' in completion
+        assert "address" in completion
 
     @pytest.mark.complete("gcc -fno-ipa-ic")
     def test_negative_option(self, completion, gcc_with_completion):
-        assert '-fno-ipa-icf' in completion
+        assert "-fno-ipa-icf" in completion
 
     @pytest.mark.complete("gcc -fxyz-abc")
     def test_no_completion(self, completion, gcc_with_completion):
-        assert len(completion) == 0
+        assert not completion
 
     @pytest.mark.complete("gcc --param ")
     def test_param_with_space(self, completion, gcc_with_completion):
         assert len(completion) > 50
         # starting with GCC 10.1 param end with =
-        assert ('lto-partitions' in completion
-                or 'lto-partitions=' in completion)
+        assert (
+            "lto-partitions" in completion or "lto-partitions=" in completion
+        )
 
     @pytest.mark.complete("gcc --param=lto-max-p")
     def test_param_with_eq(self, completion, gcc_with_completion):
         # starting with GCC 10.1 param end with =
-        assert (completion == '--param=lto-max-partition' or
-                completion == '--param=lto-max-partition=')
+        assert (
+            completion == "--param=lto-max-partition"
+            or completion == "--param=lto-max-partition="
+        )
 
     @pytest.mark.complete("gcc -march=amd")
     def test_march(self, completion, gcc_with_completion, gcc_x86):
-        assert completion == '-march=amdfam10'
+        assert completion == "-march=amdfam10"
 
     @pytest.mark.complete("gcc -march=")
     def test_march_native(self, completion, gcc_with_completion):
-        assert 'native' in completion
+        assert "native" in completion
 
     @pytest.mark.complete("gcc -mtune=")
     def test_mtune_generic(self, completion, gcc_with_completion):
-        assert 'generic' in completion
+        assert "generic" in completion


### PR DESCRIPTION
GCC 9.1 will come up with a new option that will provide option hints. It's more precise that parsing of gcc --help output. First patch does a clean-up where I unified option providing. And I removed legacy compiler binary names.