### PR TITLE
Fix `man` completion when failglob option is enabled

### DIFF
--- a/completions/man
+++ b/completions/man
@@ -67,8 +67,11 @@ _man()
         manpath="${manpath//://*man$sect/ } ${manpath//://*cat$sect/ }"
     fi
 
+    local reset=$(shopt -p failglob); shopt -u failglob
     # redirect stderr for when path doesn't exist
     COMPREPLY=( $( eval command ls "$manpath" 2>/dev/null ) )
+    $reset
+
     # weed out directory path names and paths to man pages
     COMPREPLY=( ${COMPREPLY[@]##*/?(:)} )
     # strip suffix from man pages


### PR DESCRIPTION
The title says it all.
