### PR TITLE
Tshark completion updates and fixes

### DIFF
--- a/completions/tshark
+++ b/completions/tshark
@@ -58,13 +58,15 @@ _tshark()
             return
             ;;
         -*T)
-            # TODO: could be parsed from "-T ." output
-            COMPREPLY=( $( compgen -W 'ps text pdml psml fields' -- "$cur" ) )
+            # Parse from: tshark -T . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
+            COMPREPLY=( $( compgen -W \
+                'pdml ps psml json jsonraw ek tabs text fields' -- "$cur" ) )
             return
             ;;
         -*t)
-            # TODO: could be parsed from "-t ." output
-            COMPREPLY=( $( compgen -W 'ad a r d dd e' -- "$cur" ) )
+            # Parse from: tshark -t . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
+            COMPREPLY=( $( compgen -W \
+                'a ad adoy d dd e r u ud udoy' -- "$cur" ) )
             return
             ;;
         -*u)

--- a/completions/tshark
+++ b/completions/tshark
@@ -33,7 +33,7 @@ _tshark()
             return
             ;;
         -*r)
-            _filedir 'pcap?(ng)'
+            _filedir '@(pcap?(ng)|cap)?(.gz)'
             return
             ;;
         -*H)

--- a/completions/tshark
+++ b/completions/tshark
@@ -89,7 +89,7 @@ _tshark()
             return
             ;;
         -*G)
-            COMPREPLY=( $( compgen -W "$( "$1" -G ? 2>/dev/null | \
+            COMPREPLY=( $( compgen -W "$( "$1" -G \? 2>/dev/null | \
                 awk '/^[ \t]*-G / \
                     { sub("^[[]","",$2); sub("[]]$","",$2); print $2 }' )" \
                 -- "$cur" ) )


### PR DESCRIPTION
A couple of updates and fixes:

* tshark: update -T and -t completions
  The new -t values are available since 1.12 while the the most recent -T
  value was added in 2.4. Current as of v2.9.0rc0-2173-g9fcb4af6b6.
  Hardcode options as executing tshark can be slow while the options do
  not change that option.
* tshark: prevent a single-character file from breaking -G completion
* tshark: support .gz and .cap files for -r expansion
  Wireshark performs content sniffing to recognize the file type, so
  perhaps the extension filter should be removed completely. Until that
  happens, let's recognize .gz-compressed captures and .cap files too.

As for further improvements, executing an non-optimized debug build of `tshark` is slow (for `-O`, `-G`, etc.). Are there any standard methods for memoization that can be used?