### PR TITLE
tshark: speed up tshark -O completion

### DIFF
--- a/completions/tshark
+++ b/completions/tshark
@@ -52,8 +52,10 @@ _tshark()
             ;;
         -*O)
             local prefix=; [[ $cur == *,* ]] && prefix="${cur%,*},"
-            COMPREPLY=( $( compgen -W "$( "$1" -G protocols 2>&1 | cut -f 3 )" \
-                -- "${cur##*,}" ) )
+            [ -n "$_tshark_protocols" ] ||
+                _tshark_protocols="$( "$1" -G protocols 2>&1 | cut -f 3 |
+                    tr '\n' ' ' )"
+            COMPREPLY=( $( compgen -W "$_tshark_protocols" -- "${cur##*,}" ) )
             [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=( ${COMPREPLY/#/$prefix} )
             return
             ;;

--- a/test/t/test_tshark.py
+++ b/test/t/test_tshark.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.bashcomp(ignore_env=r"^\+_tshark_protocols=")
 class TestTshark:
 
     @pytest.mark.complete("tshark -")
@@ -13,4 +14,4 @@ class TestTshark:
 
     @pytest.mark.complete("tshark -O foo,htt")
     def test_3(self, completion):
-        assert completion.list
+        assert "http" in completion.list


### PR DESCRIPTION
Executing tshark can be slow (1 second for an ASAN+Debug build). Just
memoize the output. For tshark v2.9.0rc0-2173-g9fcb4af6b6, this amounts
to 21644 bytes.
___
Note: for effective completion of multiple `-o` options, apply this patch or else the prefix is dropped:
```diff
diff --git a/completions/tshark b/completions/tshark
index 6b226e96..51410791 100644
--- a/completions/tshark
+++ b/completions/tshark
@@ -55,8 +55,7 @@ _tshark()
             [ -n "$_tshark_protocols" ] ||
                 _tshark_protocols="$( "$1" -G protocols 2>&1 | cut -f 3 |
                     tr '\n' ' ' )"
-            COMPREPLY=( $( compgen -W "$_tshark_protocols" -- "${cur##*,}" ) )
-            [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=( ${COMPREPLY/#/$prefix} )
+            COMPREPLY=( $( compgen -P "$prefix" -W "$_tshark_protocols" -- "${cur##*,}" ) )
             return
             ;;
         -*T)
```

With that `-P` patch, completions looks like this:
```
$ tshark -O http,tls,dns<TAB>
http,tls,dns        http,tls,dnsserver  
```
Without that `-P` patch, completion eats the `http,tls,`.