### PR TITLE
conftest: fix RemovedInPytest4Warning due to use of node.get_marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ standard commands for GNU autotools packages:
 autoreconf -i  # if not installing from prepared release tarball
 ./configure
 make
-make check # optional, requires python3 with pytest and pexpect, dejagnu, and tcllib
+make check # optional, requires python3 with pytest >= 3.6 and pexpect, dejagnu, and tcllib
 make install # as root
 ```
 

--- a/doc/testing.txt
+++ b/doc/testing.txt
@@ -26,7 +26,12 @@ http://wiki.tcl.tk/708[Tcl Style Guide].
 Installing dependencies
 -----------------------
 
-Installing dependencies should be easy using your local package manager.
+Installing dependencies should be easy using your local package manager. Note
+that pytest 3.6 or newer is required, if your distribution lacks this you will
+have to install it through:
+---------------------
+pip install -U pytest
+---------------------
 
 
 Debian/Ubuntu
@@ -36,7 +41,9 @@ On Debian/Ubuntu you can use `apt-get`:
 -------------
 sudo apt-get install python3-pytest python3-pexpect dejagnu tcllib
 -------------
-This should also install the necessary dependencies.
+This should also install the necessary dependencies. Only Debian testing
+(buster) and Ubuntu 18.10 (cosmic) have an appropriate version of pytest in the
+repositories.
 
 Fedora/RHEL/CentOS
 ~~~~~~~~~~~~~~~~~~

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -116,7 +116,7 @@ def bash(request) -> pexpect.spawn:
     # Use command name from marker if set, or grab from test filename
     cmd = None
     cmd_found = False
-    marker = request.node.get_marker("bashcomp")
+    marker = request.node.get_closest_marker("bashcomp")
     if marker:
         cmd = marker.kwargs.get("cmd")
         cmd_found = "cmd" in marker.kwargs
@@ -340,7 +340,7 @@ def assert_complete(
 
 @pytest.fixture(autouse=True)
 def completion(request, bash: pexpect.spawn) -> CompletionResult:
-    marker = request.node.get_marker("complete")
+    marker = request.node.get_closest_marker("complete")
     if not marker:
         return CompletionResult("", [])
     return assert_complete(bash, marker.args[0], **marker.kwargs)


### PR DESCRIPTION
There should only be one marker, so get_closest_marker (introduced with
pytest 3.6.0 (2018-05-23)) is the most accurate replacement.

Fixes the following warning while running tests:

    test/t/conftest.py:155: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
    Please use node.get_closest_marker(name) or node.iter_markers(name).
    Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
___
This reduces noice while running tests with newer pytest versions (locally and with Travis). A documentation update in doc/testing.rst is probably necessary though as only Debian buster and Ubuntu cosmic have the required pytest version. Older distributions have to install a more recent pytest version using pip.