### PR TITLE
chromium-browser: consider chrome and chromium as aliases

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -17,6 +17,8 @@ btdownloadgui.py
 c++
 cc
 cdrecord
+chrome
+chromium
 ci
 ciptool
 civclient

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -481,6 +481,8 @@ CLEANFILES = \
 	c++ \
 	cc \
 	cdrecord \
+	chrome \
+	chromium \
 	ci \
 	ciptool \
 	civclient \
@@ -759,7 +761,7 @@ symlinks: $(targetdir) $(DATA)
 		rm -f $(targetdir)/$$file && \
 			$(LN_S) cardctl $(targetdir)/$$file ; \
 	done
-	for file in google-chrome google-chrome-stable ; do \
+	for file in google-chrome google-chrome-stable chromium chrome; do \
 		rm -f $(targetdir)/$$file && \
 			$(LN_S) chromium-browser $(targetdir)/$$file ; \
 	done

--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -30,6 +30,6 @@ _chromium_browser()
     _filedir "@(?([xs])htm?(l)|pdf)"
 } &&
 complete -F _chromium_browser chromium-browser google-chrome \
-    google-chrome-stable
+    google-chrome-stable chromium chrome
 
 # ex: filetype=sh


### PR DESCRIPTION
Only Ubuntu calls it "chromium-browser", all others (Debian, Arch Linux,
Fedora) call it "chromium". When built from source, the resulting binary
is called "chrome".
___
This will likely not suggest anything because `chromium --help` by default does not contain any options. It is recommended to apply #242 for more helpful completion.

For reference, this is my `chromium --help` output:
```
Chromium launcher v6 -- for Chromium help, see chromium(1)

Custom flags are read from the following file:

  /home/peter/.config/chromium-flags.conf

Arguments contained in that file are split on whitespace and shell quoting
rules apply but no further parsing is performed. Lines starting with a hash
symbol (#) are skipped. Lines with unbalanced quotes are skipped as well.

Currently detected flags:

  --password-store=basic
```

If I remove that file (or set `HOME=/bla`), then no options will be suggested at all.