### PR TITLE
7z: add .msi support

### DIFF
--- a/completions/7z
+++ b/completions/7z
@@ -101,7 +101,7 @@ _7z()
         _filedir_xspec unzip
         [[ $mode == w ]] &&
             _filedir '@(7z|bz2|swf|?(g)tar|?(t)[bglx]z|tb?(z)2|wim)' ||
-            _filedir '@(7z|arj|bz2|cab|chm|cpio|deb|dmg|flv|gem|img|iso|lz[ah]|lzma?(86)|pmd|[rx]ar|rpm|sw[fm]|?(g)tar|taz|?(t)[bglx]z|tb?(z)2|vhd|wim|Z)'
+            _filedir '@(7z|arj|bz2|cab|chm|cpio|deb|dmg|flv|gem|img|iso|lz[ah]|lzma?(86)|msi|pmd|[rx]ar|rpm|sw[fm]|?(g)tar|taz|?(t)[bglx]z|tb?(z)2|vhd|wim|Z)'
     else
         if [[ ${words[1]} == d ]]; then
             local IFS=$'\n'


### PR DESCRIPTION
The 7z command line tool supports unpacking `.msi` files. Reference: https://www.7-zip.org/

(I have also tried it personally and noted that bash-completion didn't include these files in its completion.)