### PR TITLE
tshark: Support preferences (-o) completion with memoization

### DIFF
--- a/completions/tshark
+++ b/completions/tshark
@@ -2,10 +2,34 @@
 
 _tshark()
 {
-    local cur prev words cword
+    local cur prev words cword prefix
     _init_completion -n : || return
 
-    case $prev in
+    case $cur in
+        -o*)
+            prefix=-o
+            ;;
+    esac
+
+    case ${prefix:-$prev} in
+        --*)
+            # Fallback to completion of long options below.
+            ;;
+        -o*)
+            if [[ $cur == *:* ]]; then
+                cur=${cur#*:}
+                _filedir
+            else
+                [ -n "$_tshark_prefs" ] ||
+                    _tshark_prefs="$( "$1" -G defaultprefs | command \
+                        sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
+                        tr '\n' ' ' )"
+                COMPREPLY=( $( compgen -P "$prefix" -W "$_tshark_prefs" \
+                    -- "${cur:${#prefix}}" ) )
+                [[ $COMPREPLY == *: ]] && compopt -o nospace
+            fi
+            return
+            ;;
         -*[fsBDLcRNdCeEzhvoK])
             return
             ;;

--- a/test/t/test_tshark.py
+++ b/test/t/test_tshark.py
@@ -1,6 +1,7 @@
 import pytest
 
 
+@pytest.mark.bashcomp(ignore_env=r"^\+_tshark_prefs=")
 class TestTshark:
 
     @pytest.mark.complete("tshark -")
@@ -14,3 +15,11 @@ class TestTshark:
     @pytest.mark.complete("tshark -O foo,htt")
     def test_3(self, completion):
         assert completion.list
+
+    @pytest.mark.complete("tshark -o tcp")
+    def test_4(self, completion):
+        assert "tcp.desegment_tcp_streams:" in completion.list
+
+    @pytest.mark.complete("tshark -otcp")
+    def test_5(self, completion):
+        assert "-otcp.desegment_tcp_streams:" in completion.list


### PR DESCRIPTION
Support both completion of `-o tcp....` and `-otcp....`. Memoize the
tshark output since it can take 1 second with ASAN+Debug. _tshark_prefs
is 28190 bytes for tshark v2.9.0rc0-2375-gc672124881.