### PR TITLE
List held packages in dpkg

### DIFF
--- a/completions/dpkg
+++ b/completions/dpkg
@@ -3,7 +3,7 @@
 _have grep-status && {
 _comp_dpkg_installed_packages()
 {
-    grep-status -P -e "^$1" -a -FStatus 'install ok installed' -n -s Package
+    grep-status -P -e "^$1" -a -FStatus 'ok installed' -n -s Package
 }
 } || {
 _comp_dpkg_installed_packages()
@@ -19,7 +19,7 @@ _comp_dpkg_installed_packages()
 _have grep-status && {
 _comp_dpkg_purgeable_packages()
 {
-    grep-status -P -e "^$1" -a -FStatus 'install ok installed' -o -FStatus 'deinstall ok config-files' -n -s Package
+    grep-status -P -e "^$1" -a -FStatus 'ok installed' -o -FStatus 'ok config-files' -n -s Package
 }
 } || {
 _comp_dpkg_purgeable_packages()


### PR DESCRIPTION
This problem and fix have been reported by Paul Wise in Debian [1].  I have tested that it indeed fixes the problem by reproducing it without his fix, then observing that the problem was gone with the fix.  Steps to reproduced are provided in the original bug report [1].

[1] https://bugs.debian.org/907294