### PR TITLE
Add version warning

### DIFF
--- a/bash_completion.sh.in
+++ b/bash_completion.sh.in
@@ -11,7 +11,7 @@ if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BASH_COMPLETION_VERSINFO
             . @pkgdatadir@/bash_completion
         fi
     else
-        echo "bash-completion not loaded: bash ${BASH_VERSION} < 4.1"
+        echo "bash-completion not loaded: bash ${BASH_VERSION} < 4.1" >&2
     fi
 
 fi

--- a/bash_completion.sh.in
+++ b/bash_completion.sh.in
@@ -10,6 +10,8 @@ if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BASH_COMPLETION_VERSINFO
             # Source completion code.
             . @pkgdatadir@/bash_completion
         fi
+    else
+        echo "bash-completion not loaded: bash ${BASH_VERSION} < 4.1"
     fi
 
 fi


### PR DESCRIPTION
I spent a good bit of time trying to figure out why bash-completion was not working on my Mac, and it took me a while to realize that it wasn't loading because the stock version of Bash on macOS is ancient. For instance, on macOS Sierra (10.12.6) the version of Bash is 3.2.57. 

This change would simply emit a gentle warning to stderr when the version is less than 4.1, instead of silently doing nothing. My hope is that this would make it faster for people to realize that there's an issue. This will likely only affect Mac users. 