### PR TITLE
Fix perl completions with a space between option and argument

### DIFF
--- a/completions/perl
+++ b/completions/perl
@@ -27,7 +27,6 @@ _perl()
         optPrefix=-P$prev
         optSuffix=-S/
         prefix=$prev
-    fi
 
     case $prev in
         -*[DeEiFl])
@@ -68,7 +67,23 @@ _perl()
             ;;
     esac
 
-    if [[ "$cur" == -* ]]; then
+    # Unlike other perl options, having a space between the `-e' and
+    # `-E' options and their arguments, e.g. `perl -e "exit 2"', is
+    # valid syntax.  However, the argument is neither a filename nor a
+    # directory, but one line of perl program, thus do not suggest
+    # _filedir completion.
+    elif [[ "$prev" == -e ]] || [[ "$prev" == -E ]]; then
+        return
+
+    # Likewise, `-I' also accepts a space between option and argument
+    # and it takes a directory as value.
+    elif [[ "$prev" == -I ]]; then
+        local IFS=$'\n'
+        compopt -o filenames
+        COMPREPLY=( $(compgen -d $optPrefix $optSuffix -- "$cur") )
+        return
+
+    elif [[ "$cur" == -* ]]; then
         COMPREPLY=( $(compgen -W '-C -s -T -u -U -W -X -h -v -V -c -w -d -D -p
             -n -a -F -l -0 -I -m -M -P -S -x -i -e' -- "$cur") )
     else

--- a/test/t/test_perl.py
+++ b/test/t/test_perl.py
@@ -67,8 +67,8 @@ class TestPerl:
 
     @pytest.mark.complete("perl -x shared/default/b")
     def test_15(self, completion):
-        """-x with space should complete dirs."""
-        assert completion == ["shared/default/bar bar.d/"]
+        """-x with space should complete files+dirs."""
+        assert completion == ["bar", "bar bar.d/"]
 
     @pytest.mark.complete(
         "perl -d:", env=dict(PERL5LIB="$PWD/perl"), require_cmd=True


### PR DESCRIPTION
This patch is highly based on the patch provided in a Debian bug report [1]

The diff is a bit hard to read because of the indentation changes.  Using git's `--ignore-space-changes`, I get the following, easier-to-review diff:

```
$ git diff HEAD~1 --ignore-space-change 
diff --git a/completions/perl b/completions/perl
index 7b91d1b4..7752fee8 100644
--- a/completions/perl
+++ b/completions/perl
@@ -27,7 +27,6 @@ _perl()
         optPrefix=-P$prev
         optSuffix=-S/
         prefix=$prev
-    fi
 
         case $prev in
             -*[DeEiFl])
@@ -68,7 +67,7 @@ _perl()
                 ;;
         esac
 
-    if [[ "$cur" == -* ]]; then
+    elif [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W '-C -s -T -u -U -W -X -h -v -V -c -w -d -D -p
             -n -a -F -l -0 -I -m -M -P -S -x -i -e' -- "$cur" ) )
     else
```
[1] https://bugs.debian.org/614775