### PR TITLE
Update usage message to match reality

### DIFF
--- a/test/run
+++ b/test/run
@@ -9,7 +9,7 @@ usage() {
     echo "Unrecognized options are passed through to dejagnu by default."
     echo
     echo "Interesting options:"
-    echo "  --tool=    Test against a different bash executable."
+    echo "  --tool=         Test against a different bash executable."
     echo "  --buffer-size   Change expect match buffer size from our default of 20000 bytes."
     echo "  --debug         Create a dbg.log in the test directory with detailed expect match information."
     echo "  --timeout       Change expect timeout from the default of 10 seconds."

--- a/test/run
+++ b/test/run
@@ -9,7 +9,7 @@ usage() {
     echo "Unrecognized options are passed through to dejagnu by default."
     echo
     echo "Interesting options:"
-    echo "  --tool_exec=    Test against a different bash executable."
+    echo "  --tool=    Test against a different bash executable."
     echo "  --buffer-size   Change expect match buffer size from our default of 20000 bytes."
     echo "  --debug         Create a dbg.log in the test directory with detailed expect match information."
     echo "  --timeout       Change expect timeout from the default of 10 seconds."


### PR DESCRIPTION
In order to change the tool one has to use `--tool` instead of `--tool_exec`.