### PR TITLE
Distribute test files with make dist

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST = completion \
 	     config \
 	     fixtures \
 	     lib \
+	     t \
 	     unit
 
 all:


### PR DESCRIPTION
Downstream maintainers might want to run the full test suite in their
continuous integration.  For instance, in Debian, it should be possible
to use autopkgtest to run all the test cases under test/t/.  This patch
adds the test cases to the tarball generated with make dist.