### PR TITLE
Don't override any pattern by its repetition in _longopt

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1878,7 +1878,7 @@ _longopt()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W "$( LC_ALL=C $1 --help 2>&1 | \
-            command sed -ne 's/.*\(--[-A-Za-z0-9]\{1,\}=\{0,1\}\).*/\1/p' | sort -u )" \
+            command grep --basic-regexp --only-matching -- '--[-A-Za-z0-9]\{1,\}=\{0,1\}' | sort -u )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     elif [[ "$1" == @(rmdir|chroot) ]]; then

--- a/bash_completion
+++ b/bash_completion
@@ -1878,7 +1878,9 @@ _longopt()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W "$( LC_ALL=C $1 --help 2>&1 | \
-            command grep --basic-regexp --only-matching -- '--[-A-Za-z0-9]\{1,\}=\{0,1\}' | sort -u )" \
+            command grep --basic-regexp --line-number --only-matching -- '--[-A-Za-z0-9]\{1,\}=\{0,1\}' | \
+            mawk -F: '{ if (!options[$1]) options[$1] = $2 } END { for (line in options) printf("%s\n", options[line]);  }' | \
+            sort -u )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     elif [[ "$1" == @(rmdir|chroot) ]]; then

--- a/bash_completion
+++ b/bash_completion
@@ -1878,8 +1878,7 @@ _longopt()
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $( compgen -W "$( LC_ALL=C $1 --help 2>&1 | \
-            command grep --basic-regexp --line-number --only-matching -- '--[-A-Za-z0-9]\{1,\}=\{0,1\}' | \
-            mawk -F: '{ if (!options[$1]) options[$1] = $2 } END { for (line in options) printf("%s\n", options[line]);  }' | \
+            while read -r line; do [[ "$line" =~ --[-A-Za-z0-9]{1,}={0,1} ]] && echo "${BASH_REMATCH[0]}"; done | \
             sort -u )" \
             -- "$cur" ) )
         [[ $COMPREPLY == *= ]] && compopt -o nospace


### PR DESCRIPTION
The option --recursive for `grep` command did not show up
because it was overriden by --directories.