### PR TITLE
Improve test reliability detecting magic mark

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -357,9 +357,12 @@ def assert_complete(
     bash.expect_exact(cmd)
     bash.send(MAGIC_MARK)
     got = bash.expect([
-        r"\r\n" + re.escape(PS1 + cmd),  # 0: multiple lines, result in .before
-        r"^" + MAGIC_MARK,               # 1: no completion
-        r"^([^\r]+)%s$" % MAGIC_MARK,    # 2: on same line, result in .match
+        # 0: multiple lines, result in .before
+        r"\r\n" + re.escape(PS1 + cmd) + ".*" + MAGIC_MARK,
+        # 1: no completion
+        r"^" + MAGIC_MARK,
+        # 2: on same line, result in .match
+        r"^([^\r]+)%s$" % MAGIC_MARK,
         pexpect.EOF,
         pexpect.TIMEOUT,
     ])

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -93,7 +93,6 @@ def bash(request) -> pexpect.spawn:
         BASH_COMPLETION_COMPAT_DIR="%s/fixtures/shared/empty_dir" % testdir,
         LC_COLLATE="C",  # to match Python's default locale unaware sort
     ))
-    # TODO set stty_init "columns 150" --> dimensions? needed in first place?
 
     fixturesdir = os.path.join(testdir, "fixtures")
     os.chdir(fixturesdir)
@@ -106,6 +105,10 @@ def bash(request) -> pexpect.spawn:
         cwd=fixturesdir,
         env=env,
         encoding="utf-8",  # TODO? or native or...?
+        # FIXME: Tests shouldn't depend on dimensions, but it's difficult to
+        # expect robustly enough for Bash to wrap lines anywhere (e.g. inside
+        # MAGIC_MARK).  Increase window width to reduce wrapping.
+        dimensions=(24, 160),
         # TODO? codec_errors="replace",
     )
     bash.expect_exact(PS1)


### PR DESCRIPTION
While working on a completion for `ethtool` (for which I will submit another PR shortly), I encountered some timeout errors in the test suite.  I found that the same race condition as 85275cf5 exists in `assert_complete` for multiple completions (case 0 of the expect matches).  If the magic mark is not included in `expect()`, it may or may not have been written by bash at the point `bash.sendintr()` is called.   If the interrupt is delivered before magic mark has finished printing, it can corrupt the prompt and cause `bash.expect_exact(PS1)` to timeout.

This pull request includes `MAGIC_MARK` in the case 0 regex, which fixes the issue.

It also increases the pty width to 160 columns to avoid corrupting the magic mark due to bash line wrapping, which happens for completed commands where the length of the command + PS1 + magic mark is longer than the terminal width.  It is split into a separate commit.  If you would like me to submit a separate PR for this change, let me know.

Thanks for considering,
Kevin