### PR TITLE
_longopt: Skip _filedir completion with --no-filename

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1855,8 +1855,11 @@ _longopt()
             return
             ;;
         --*file*|--*path*)
-            _filedir
-            return
+            if [[ ${prev} != "--no-filename" ]]
+            then
+              _filedir
+              return
+            fi
             ;;
         --+([-a-z0-9_]))
             local argtype=$( LC_ALL=C $1 --help 2>&1 | command sed -ne \


### PR DESCRIPTION
The '--no-filename' switch from 'grep' does not expect file and
directory argument.