### PR TITLE
_known_hosts_real: "Include" directive support in ssh_config

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1523,7 +1523,10 @@ _known_hosts_real()
         [[ -r $configfile ]] && config+=( "$configfile" )
     else
         for i in /etc/ssh/ssh_config ~/.ssh/config ~/.ssh2/config; do
-            [[ -r $i ]] && config+=( "$i" )
+            [[ -r $i ]] && config+=( "$i" ) &&
+              for inc in $(awk '/^Include/{print $2}' $i); do
+                [[ -r $inc ]] && config+=( "$inc" )
+              done
         done
     fi
 


### PR DESCRIPTION
Added support for expanding ssh hosts from configs included in default SSH configs. Useful for ssh configs shared between teammates
You can add next directive into main config:
```bash
user@note ~ $ head ~/.ssh/config 
Include /home/user/git/myrepo/ssh_additional_hosts
```
After that hosts from ssh_additional_hosts also in completion
