### PR TITLE
Add a postfix opt to _known_hosts_real

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1488,6 +1488,7 @@ _included_ssh_config_files()
 #           -c             Use `:' suffix
 #           -F configfile  Use `configfile' for configuration settings
 #           -p PREFIX      Use PREFIX
+#           -P POSTFIX     Use POSTFIX (Override the -c opt)
 #           -4             Filter IPv6 addresses from results
 #           -6             Filter IPv4 addresses from results
 # Return: Completions, starting with CWORD, are added to COMPREPLY[]
@@ -1500,12 +1501,13 @@ _known_hosts_real()
     # TODO remove trailing %foo from entries
 
     local OPTIND=1
-    while getopts "ac46F:p:" flag "$@"; do
+    while getopts "ac46F:p:P:" flag "$@"; do
         case $flag in
             a) aliases='yes' ;;
             c) suffix=':' ;;
             F) configfile=$OPTARG ;;
             p) prefix=$OPTARG ;;
+            P) suffix=$OPTARG ;;
             4) ipv4=1 ;;
             6) ipv6=1 ;;
         esac


### PR DESCRIPTION
I create an opt like -c because I like develop an ansible bash_completion file. And the colon suffix is required to ansible's inventory opts.