### PR TITLE
test for _xspecs declaration

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2058,7 +2058,7 @@ __load_completion()
     done
 
     # Look up simple "xspec" completions
-    [[ "${_xspecs[$cmd]}" ]] && complete -F _filedir_xspec "$cmd" && return 0
+    [[ -n ${_xspecs+true} ]] && [[ "${_xspecs[$cmd]}" ]] && complete -F _filedir_xspec "$cmd" && return 0
 
     return 1
 }


### PR DESCRIPTION
Test if \_xspecs is declared before to use xspec completion to avoid syntax error (invalid arithmetic operand) when the command contains non word character ([^a-zA-Z0-9_]). Typically, $cmd with a dot or an hyphen or a non ascii char triggers this syntax error when completing args because if _xspecs is not explicitely declared, ${_xspecs[$cmd]} is interpreted as a simple rather than associative array, and so $cmd in this context has to be a valid variable name rather than a key.
 Test only for declaration, but considered to test for associative array declaration: [[ $(declare -p _xspecs) =~ "declare -A _xspecs"]]