### PR TITLE
test_chromium_browser: Skip test_2 if 'chromium-browser --help' fails

### DIFF
--- a/test/t/test_chromium_browser.py
+++ b/test/t/test_chromium_browser.py
@@ -7,7 +7,7 @@ class TestChromiumBrowser:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("chromium-browser -")
+    @pytest.mark.complete("chromium-browser -", skipif="! chromium-browser --help &>/dev/null")
     def test_2(self, completion):
         assert completion
         assert not completion.endswith(" ")


### PR DESCRIPTION
Skip test_2 when help for chromium-browser is not available.  Follows
similar logic used in other tests.  Fixes test failure on Gentoo
where the manpage of chromium is missing for some reason.