### PR TITLE
test_rpm2tgz: Fix expected output

### DIFF
--- a/test/t/test_rpm2tgz.py
+++ b/test/t/test_rpm2tgz.py
@@ -12,9 +12,9 @@ class TestRpm2tgz:
     def test_2(self, completion):
         expected = sorted(
             [
-                "%s/"
+                "%s/" % x
                 for x in os.listdir("slackware/home")
-                if os.path.isdir("shared/bin/%s" % x)
+                if os.path.isdir("slackware/home/%s" % x)
             ]
             + [
                 x


### PR DESCRIPTION
Fix typo in path, as well as missing format string argument in rpm2tgz
test.  This resulted in the expected value missing the directory,
causing the test to fail.