### PR TITLE
test_arp: Skip if ARP tables are empty

### DIFF
--- a/test/t/test_arp.py
+++ b/test/t/test_arp.py
@@ -1,11 +1,8 @@
 import pytest
 
-from conftest import in_docker
-
 
 class TestArp:
-    @pytest.mark.xfail(in_docker(), reason="Probably fails in docker")
-    @pytest.mark.complete("arp ")
+    @pytest.mark.complete("arp ", skipif='test -z "$(arp 2>/dev/null)"')
     def test_1(self, completion):
         assert completion
 


### PR DESCRIPTION
Skip test_arp if 'arp' yields no output.  This e.g. happens when
the host is not networking-enabled.