### PR TITLE
test/unit: Fix expected values when ${HOME} is overriden

### DIFF
--- a/test/unit/__expand_tilde_by_ref.exp
+++ b/test/unit/__expand_tilde_by_ref.exp
@@ -1,13 +1,16 @@
 # @param string $out  Reference to variable to hold value of bash environment
 #                     variable $HOME.
-proc setup {home user} {
+proc setup {home user userhome} {
     upvar $home _home
     upvar $user _user
+    upvar $userhome _userhome
     save_env
     assert_bash_exec {echo "$HOME"} {} /@ _home
     set _home [string trim $_home]
     assert_bash_exec {id -un 2>/dev/null || echo "$USER"} {} /@ _user
     set _user [string trim $_user]
+    assert_bash_exec {getent passwd $(id -un 2>/dev/null || echo "$USER") | cut -d: -f6} {} /@ _userhome
+    set _userhome [string trim $_userhome]
 }
 
 
@@ -18,12 +21,12 @@ proc teardown {} {
 }
 
 
-setup home user
+setup home user userhome
 
 
-set test "~user should return $home"
+set test "~user should return $userhome"
 set cmd [format {var="~%s"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list "$home" $cmd $test
+assert_bash_list "$userhome" $cmd $test
 sync_after_int
 
 set test "~/foo should return $home/foo"
@@ -31,24 +34,24 @@ set cmd {var='~/foo'; __expand_tilde_by_ref var; printf "%s\n" "$var"}
 assert_bash_list "$home/foo" $cmd $test
 sync_after_int
 
-set test "~user/bar should return $home/bar"
+set test "~user/bar should return $userhome/bar"
 set cmd [format {var="~%s/bar"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list "$home/bar" $cmd $test
+assert_bash_list "$userhome/bar" $cmd $test
 sync_after_int
 
-set test "~user/\$HOME should return $home/\$HOME"
+set test "~user/\$HOME should return $userhome/\$HOME"
 set cmd [format {var="~%s/\$HOME"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list "$home/\$HOME" $cmd $test
+assert_bash_list "$userhome/\$HOME" $cmd $test
 sync_after_int
 
-set test "'~user/a  b' should return '$home/a  b'"
+set test "'~user/a  b' should return '$userhome/a  b'"
 set cmd [format {var="~%s/a  b"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list [list [format {%s/a  b} $home]] $cmd $test
+assert_bash_list [list [format {%s/a  b} $userhome]] $cmd $test
 sync_after_int
 
-set test "~user/* should return $home/*"
+set test "~user/* should return $userhome/*"
 set cmd [format {var="~%s/*"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list "$home/\*" $cmd $test
+assert_bash_list "$userhome/\*" $cmd $test
 sync_after_int
 
 set test "'~user;echo hello' should return '~user;echo hello' (not expanded)"
@@ -56,9 +59,9 @@ set cmd [format {var="~%s;echo hello"; __expand_tilde_by_ref var; printf "%%s\n"
 assert_bash_list [format "~%s;echo hello" $user] $cmd $test
 sync_after_int
 
-set test "'~user/a;echo hello' should return '$home/a;echo hello'"
+set test "'~user/a;echo hello' should return '$userhome/a;echo hello'"
 set cmd [format {var="~%s/a;echo hello"; __expand_tilde_by_ref var; printf "%%s\n" "$var"} $user]
-assert_bash_list "$home/a;echo hello" $cmd $test
+assert_bash_list "$userhome/a;echo hello" $cmd $test
 sync_after_int
 
 

--- a/test/unit/_expand.exp
+++ b/test/unit/_expand.exp
@@ -2,10 +2,10 @@ proc setup {home user} {
     upvar $home _home
     upvar $user _user
     save_env
-    assert_bash_exec {echo "$HOME"} {} /@ _home
-    set _home [string trim $_home]
     assert_bash_exec {id -un 2>/dev/null || echo "$USER"} {} /@ _user
     set _user [string trim $_user]
+    assert_bash_exec {getent passwd $(id -un 2>/dev/null || echo "$USER") | cut -d: -f6} {} /@ _home
+    set _home [string trim $_home]
 }
 
 proc teardown {} {


### PR DESCRIPTION
Tilde substitution '~' respects the value of ${HOME}, while '~user'
always uses home directory from passwd.  Adjust the tests using
the latter to do the same.  This fixes a number of test failures when
${HOME} is set to a temporary directory by the Gentoo build environment.