### PR TITLE
Allow completing '?' to the latest file in a directory

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -557,6 +557,7 @@ _filedir()
 
     local -a toks
     local x reset
+    local newest=0
 
     reset=$(shopt -po noglob); set -o noglob
     toks=( $(compgen -d -- "$cur") )
@@ -564,6 +565,10 @@ _filedir()
 
     if [[ "$1" != -d ]]; then
         local quoted
+        if [[ "$cur" = "?" ]] || [[ "${cur: -2}" = "/?" ]]; then
+            cur="${cur:0:-1}"
+            newest=1
+        fi
         _quote_readline_by_ref "$cur" quoted
 
         # Munge xspec to contain uppercase version too
@@ -584,7 +589,12 @@ _filedir()
     if [[ ${#toks[@]} -ne 0 ]]; then
         # 2>/dev/null for direct invocation, e.g. in the _filedir unit test
         compopt -o filenames 2>/dev/null
-        COMPREPLY+=( "${toks[@]}" )
+        if [[ $newest -eq 1 ]]; then
+            newest=$(bash -c "ls -tr $cur | tail -n 1")
+            COMPREPLY+=( "$cur$newest" )
+        else
+            COMPREPLY+=( "${toks[@]}" )
+        fi
     fi
 } # _filedir()
 


### PR DESCRIPTION
This completion change allows retrieving the latest file in any
_filedir completion (whether it is the current directory or not).

Examples:
mv ?<TAB> -> mv latest-file.pdf
mv ~/Downloads/?<TAB> -> mv ~/Downloads/latest-file.pdf