### PR TITLE
chromium-browser: Add support for .mhtml files

### DIFF
--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -42,7 +42,7 @@ _chromium_browser()
         return
     fi
 
-    _filedir "@(?([xs])htm?(l)|pdf)"
+    _filedir "@(?([mxs])htm?(l)|pdf)"
 } &&
 complete -F _chromium_browser chromium-browser google-chrome \
     google-chrome-stable chromium chrome


### PR DESCRIPTION
Chromium can open MHTML documents (single-page html files). This adds support for opening files with the `.mhtm?(l)` file extension.