### PR TITLE
test_getconf: finish fix to #312 / #333

### DIFF
--- a/test/t/test_getconf.py
+++ b/test/t/test_getconf.py
@@ -2,7 +2,9 @@ import pytest
 
 
 class TestGetconf:
-    @pytest.mark.complete("getconf P")
+    @pytest.mark.complete(
+        "getconf P", xfail="! getconf -a 2>&1 | command grep -q ^POSIX_V"
+    )
     def test_1(self, completion):
         assert completion
 


### PR DESCRIPTION
The first test for getconf also relies on the non-portable `-a` option.
Expect failure on this test as well if it isn't available.

Fixes: 70afc1ed ("test_getconf: skip if -a doesn't output any POSIX_V*")