### PR TITLE
For perltidy, catch *.t test scripts.

### DIFF
--- a/completions/perltidy
+++ b/completions/perltidy
@@ -47,7 +47,7 @@ _perltidy()
         COMPREPLY=( $(compgen -W '$(_parse_help "$1")' -- "$cur") )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     else
-        _filedir 'p[lm]'
+        _filedir 'p[lm]|t'
     fi
 } &&
 complete -F _perltidy perltidy


### PR DESCRIPTION
Lintian enforces `perltidy` in its code base, including test scripts written in Perl. When `perltidy` is invoked, such arguments are not completed. This commit catches test scripts ending in `*.t`.