### PR TITLE
Adds `cd-shortcuts` a Bash completion function to improve the "cd"

### DIFF
--- a/completions/cd-shortcuts
+++ b/completions/cd-shortcuts
@@ -24,6 +24,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see http://www.gnu.org/licenses/
 #
+
 _cd_shortcuts(){
 
     local let valid_words=0
@@ -47,11 +48,10 @@ _cd_shortcuts(){
             up)
                 # read current path spliting it with '/'
                 local path_temp
-                IFS='/' read -a path_temp <<< "$1"
+                IFS='/' read -a path_temp <<< "${path}"
 
                 # how many levels it can up?
                 local let max_level=$(( ${#path_temp[@]}-1 ))
-
                 if (( level > 0 )) && (( level < max_level )); then
                     # create the tedious <dot><dot><slash> string...
                     for ((i=1; i<=level; i++)); do

--- a/completions/cd-shortcuts
+++ b/completions/cd-shortcuts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+#   cd-shortcuts
+#   Copyright (C) 2019  Giovanni Nunes <giovanni.nunes@gmail.com>
+#
+#   Bash completion function to improve "cd" command adding shortcuts:
+#
+#   - "^<number>" to go _number_ directories beyond from current path.
+#
+#   - "@<directory>" to go to the first _directory_ directory from
+#     right to the left starting to current path.
+#
+#
+#   This program is free software: you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see http://www.gnu.org/licenses/
+#
+_cd_shortcuts(){
+
+    local let valid_words=0
+
+    # discard parameters, count number of arguments and check for shortcut.
+    for word in ${COMP_WORDS[@]}; do
+        i="${word::1}"
+        [[ "$i" != '-' ]] && let valid_words+=1
+        [[ "$i" == '^' ]] && local shortcut='up' && local let level=${word:1}+0
+        [[ "$i" == '@' ]] && local shortcut='at' && local target=${word:1}
+    done
+
+    if (( valid_words == 2 )); then
+
+        # local variables
+        local reply=''
+        local path="$( pwd )"
+
+        # check shortcut...
+        case $shortcut in
+            up)
+                # read current path spliting it with '/'
+                local path_temp
+                IFS='/' read -a path_temp <<< "$1"
+
+                # how many levels it can up?
+                local let max_level=$(( ${#path_temp[@]}-1 ))
+
+                if (( level > 0 )) && (( level < max_level )); then
+                    # create the tedious <dot><dot><slash> string...
+                    for ((i=1; i<=level; i++)); do
+                        reply+='../'
+                    done
+
+                    COMPREPLY="$reply"
+                fi
+                ;;
+
+            at)
+                # go to a specific directory (from the right to the left)...
+                if [[ "${target}" != '' ]] &&\
+                   [[ "$path" == *${target}* ]]; then
+                    new_path="${path%${target}*}$target"
+                    # ...but only if is a valid directory.
+                    [[ -d "$new_path" ]] && COMPREPLY="$new_path"
+                fi
+                ;;
+            *)
+                # there is no shortcuts here, use standard completion
+                _cd
+                ;;
+        esac
+    else
+        # there is no shortcuts here, use standard completion
+        _cd
+    fi
+}
+
+complete -F _cd_shortcuts cd

--- a/completions/cd-shortcuts
+++ b/completions/cd-shortcuts
@@ -1,30 +1,4 @@
-#!/usr/bin/env bash
-#
-#   cd-shortcuts
-#   Copyright (C) 2019  Giovanni Nunes <giovanni.nunes@gmail.com>
-#
-#   Bash completion function to improve "cd" command adding shortcuts:
-#
-#   - "^<number>" to go _number_ directories beyond from current path.
-#
-#   - "@<directory>" to go to the first _directory_ directory from
-#     right to the left starting to current path.
-#
-#
-#   This program is free software: you can redistribute it and/or
-#   modify it under the terms of the GNU General Public License as
-#   published by the Free Software Foundation, either version 3 of the
-#   License, or (at your option) any later version.
-#
-#   This program is distributed in the hope that it will be useful,
-#   but WITHOUT ANY WARRANTY; without even the implied warranty of
-#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#   GNU General Public License for more details.
-#
-#   You should have received a copy of the GNU General Public License
-#   along with this program.  If not, see http://www.gnu.org/licenses/
-#
-
+# cd-shortcuts                                      -*- shell-script -*-
 _cd_shortcuts(){
 
     local let valid_words=0
@@ -81,5 +55,6 @@ _cd_shortcuts(){
         _cd
     fi
 }
-
 complete -F _cd_shortcuts cd
+
+# ex: filetype=sh


### PR DESCRIPTION
`_cd_shortcuts()` is a Bash completion function to improve "cd" command adding two new shortcuts:

#### up : `^{number}`
To go {number} directories up from current path, for example:
```
cd /usr/src/linux-headers-5.0.0-20-generic/arch/x86/kernel
cd ^4<Tab> → cd ../../../../
```
#### at : `@<name>`
To go to first {name} directory from the right to the left starting to current path.
```
cd /usr/src/linux-headers-5.0.0-20-generic/arch/x86/kernel
cd @src<Tab> → cd /usr/src
```
If `^` or `@` are not detected it calls the original completion for "cd". 