### PR TITLE
pkg-config: Relative paths

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,6 @@ EXTRA_DIST = CHANGES $(pkgdata_DATA) bash_completion.sh.in .dir-locals.el \
 install-data-hook:
 	tmpfile=`mktemp $${TMPDIR:-/tmp}/bash_completion.XXXXXX` && \
 	$(SED) -e 's|-/etc/bash_completion\.d|-$(compatdir)|' \
-	    $(DESTDIR)$(pkgdatadir)/bash_completion >$$tmpfile && \
-	cat $$tmpfile >$(DESTDIR)$(pkgdatadir)/bash_completion && \
+	    $(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion >$$tmpfile && \
+	cat $$tmpfile >$(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion && \
 	rm $$tmpfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = completions doc helpers test
 pkgdata_DATA = bash_completion
 
 # Empty, but here just to get the compat dir created with install
+compatdir = $(sysconfdir)/bash_completion.d
 compat_DATA =
 
 profiledir = $(sysconfdir)/profile.d
@@ -18,8 +19,9 @@ cmakeconfig_DATA = bash-completion-config.cmake \
 %: %.in Makefile
 	$(SED) \
 		-e 's|@prefix[@]|$(prefix)|' \
-		-e 's|@compatdir[@]|$(compatdir)|' \
-		-e 's|@pkgdatadir[@]|$(pkgdatadir)|' \
+		-e 's|@datadir[@]|$(datadir)|' \
+		-e 's|@sysconfdir[@]|$(sysconfdir)|' \
+		-e 's|@PACKAGE[@]|$(PACKAGE)|' \
 		-e 's|@VERSION[@]|$(VERSION)|' \
 		<$(srcdir)/$@.in >$@
 

--- a/bash-completion-config.cmake.in
+++ b/bash-completion-config.cmake.in
@@ -4,8 +4,9 @@
 set (BASH_COMPLETION_VERSION "@VERSION@")
 
 set (BASH_COMPLETION_PREFIX "@prefix@")
-set (BASH_COMPLETION_COMPATDIR "@compatdir@")
-set (BASH_COMPLETION_COMPLETIONSDIR "@pkgdatadir@/completions")
-set (BASH_COMPLETION_HELPERSDIR "@pkgdatadir@/helpers")
+
+set (BASH_COMPLETION_COMPATDIR "@sysconfdir@/bash_completion.d")
+set (BASH_COMPLETION_COMPLETIONSDIR "@datadir@/@PACKAGE@/completions")
+set (BASH_COMPLETION_HELPERSDIR "@datadir@/@PACKAGE@/helpers")
 
 set (BASH_COMPLETION_FOUND "TRUE")

--- a/bash-completion.pc.in
+++ b/bash-completion.pc.in
@@ -1,7 +1,10 @@
 prefix=@prefix@
-compatdir=@compatdir@
-completionsdir=@pkgdatadir@/completions
-helpersdir=@pkgdatadir@/helpers
+datadir=@datadir@
+sysconfdir=@sysconfdir@
+
+compatdir=${sysconfdir}/bash_completion.d
+completionsdir=${datadir}/@PACKAGE@/completions
+helpersdir=${datadir}/@PACKAGE@/helpers
 
 Name: @PACKAGE@
 Description: programmable completion for the bash shell

--- a/bash_completion.sh.in
+++ b/bash_completion.sh.in
@@ -7,9 +7,9 @@ if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BASH_COMPLETION_VERSINFO
        [ "${BASH_VERSINFO[0]}" -eq 4 -a "${BASH_VERSINFO[1]}" -ge 1 ]; then
         [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion" ] && \
             . "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion"
-        if shopt -q progcomp && [ -r @pkgdatadir@/bash_completion ]; then
+        if shopt -q progcomp && [ -r @datadir@/@PACKAGE@/bash_completion ]; then
             # Source completion code.
-            . @pkgdatadir@/bash_completion
+            . @datadir@/@PACKAGE@/bash_completion
         fi
     fi
 

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -1,4 +1,4 @@
-bashcompdir = $(pkgdatadir)/completions
+bashcompdir = $(datadir)/$(PACKAGE)/completions
 bashcomp_DATA = 2to3 \
 		7z \
 		a2x \

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AC_ARG_WITH([pytest],[  --with-pytest=executable],[PYTEST="$withval"])
 if test -z "$PYTEST"; then
     AC_CHECK_PROGS([PYTEST],[pytest pytest-3],[pytest])
 fi
-AC_SUBST(compatdir, $sysconfdir/bash_completion.d)
 AC_CONFIG_FILES([
 Makefile
 completions/Makefile

--- a/helpers/Makefile.am
+++ b/helpers/Makefile.am
@@ -1,4 +1,4 @@
-helpersdir = $(pkgdatadir)/helpers
+helpersdir = $(datadir)/$(PACKAGE)/helpers
 helpers_DATA = perl python
 
 EXTRA_DIST = $(helpers_DATA)


### PR DESCRIPTION
Using `pkg-config` options the user has the possibility to redefine key values present in the `.pc` files.

Due to this `compatdir`, `completionsdir` and `helpersdir` that are defined in the generated pkg-config `.pc` file should be relative paths.

This helps any pkg-config user to set these variables to proper directories by using the `define-variable` command line argument.