### PR TITLE
apt-get: fix if the version number contains a colon

### DIFF
--- a/completions/apt-get
+++ b/completions/apt-get
@@ -35,11 +35,12 @@ _apt_get()
                     return
                 elif [[ $cur == *=* ]]; then
                     IFS='=' read -r package cur <<< "$cur"
-                    mapfile -t COMPREPLY < <(compgen -W "$( \
+                    COMPREPLY=($(IFS=$'\n' compgen -W "$( \
+                        apt-cache madison "$package" 2>/dev/null | \
                         while IFS=' |' read -r _ version _; do
                             echo "$version"
-                        done < <(apt-cache madison "$package"))" \
-                        -- "$cur")
+                        done )" \
+                            -- "$cur"))
                     __ltrim_colon_completions "$cur"
                     return
                 fi

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -2,7 +2,7 @@
 
 _apt_get()
 {
-    local cur prev words cword
+    local cur prev words cword package
     _init_completion -n ':=' || return
 
     local special i
@@ -34,7 +34,8 @@ _apt_get()
                     _filedir deb
                     return
                 elif [[ $cur == *=* ]]; then
-                    IFS='=' read -r package cur <<< "$cur"
+                    package="${cur%%=*}"
+                    cur="${cur#*=}"
                     COMPREPLY=($(IFS=$'\n' compgen -W "$( \
                         apt-cache --no-generate madison "$package" 2>/dev/null | \
                         while IFS=' |' read -r _ version _; do

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -3,7 +3,7 @@
 _apt_get()
 {
     local cur prev words cword
-    _init_completion -n = || return
+    _init_completion -n ':=' || return
 
     local special i
     for (( i=0; i < ${#words[@]}-1; i++ )); do
@@ -34,11 +34,13 @@ _apt_get()
                     _filedir deb
                     return
                 elif [[ $cur == *=* ]]; then
-                    COMPREPLY=( $(compgen -W "$(\
-                        apt-cache --no-generate show "${cur%%=*}" 2>/dev/null |
-                        command sed -ne \
-                            's/^Version:[[:space:]]*\([^[:space:]]\)/\1/p')" \
-                        -- "${cur#*=}") )
+                    IFS='=' read -r package cur <<< "$cur"
+                    mapfile -t COMPREPLY < <(compgen -W "$( \
+                        while IFS=' |' read -r _ version _; do
+                            echo "$version"
+                        done < <(apt-cache madison "$package"))" \
+                        -- "$cur")
+                    __ltrim_colon_completions "$cur"
                     return
                 fi
                 ;;&

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -36,7 +36,7 @@ _apt_get()
                 elif [[ $cur == *=* ]]; then
                     IFS='=' read -r package cur <<< "$cur"
                     COMPREPLY=($(IFS=$'\n' compgen -W "$( \
-                        apt-cache madison "$package" 2>/dev/null | \
+                        apt-cache --no-generate madison "$package" 2>/dev/null | \
                         while IFS=' |' read -r _ version _; do
                             echo "$version"
                         done )" \


### PR DESCRIPTION
The output from `apt-cache madison` consist of two lines only and does not require using regular expressions. 
