### PR TITLE
_init_completion: set default $IFS

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -688,7 +688,7 @@ _variables()
 #
 _init_completion()
 {
-    local exclude="" flag outx errx inx OPTIND=1
+    local exclude="" flag outx errx inx OPTIND=1 IFS=$' \t\n'
 
     while getopts "n:e:o:i:s" flag "$@"; do
         case $flag in


### PR DESCRIPTION
Many completions expect IFS to be the default value. For example, something like

    compgen -W 'foo bar' -- "$cur"

or

    opts='foo bar'
    for i in $opts; do ...

will not work as expected if IFS is set in the shell to a value that does not contain space.

However, functions don't seem set IFS if they are written to work with the default value. Setting it to the default in `_init_completion` should help ensure they run as expected. Since the variable is `local`, and is being set to the default value this seems quite safe.