### PR TITLE
Let find complete with directories after -path option

### DIFF
--- a/completions/find
+++ b/completions/find
@@ -17,6 +17,10 @@ _find()
             _filedir
             return
             ;;
+        -path|-ipath)
+            _filedir -d
+            return
+            ;;
         -fstype)
             _fstypes
             [[ $OSTYPE == *bsd* ]] && \
@@ -50,7 +54,7 @@ _find()
             return
             ;;
         -[acm]min|-[acm]time|-iname|-lname|-wholename|-iwholename|-lwholename|\
-        -ilwholename|-inum|-path|-ipath|-regex|-iregex|-links|-perm|-size|\
+        -ilwholename|-inum|-regex|-iregex|-links|-perm|-size|\
         -used|-printf|-context)
             # do nothing, just wait for a parameter to be given
             return

--- a/test/t/test_find.py
+++ b/test/t/test_find.py
@@ -26,3 +26,7 @@ class TestFind:
     @pytest.mark.complete("find -gid ")
     def test_6(self, completion):
         assert not [x for x in completion if not x.isdigit()]
+
+    @pytest.mark.complete("find -path ba", cwd="shared/default")
+    def test_7(self, completion):
+        assert completion == ["bar bar.d/"]


### PR DESCRIPTION
The argument to find's -path option is supposed to restrict the search
results to items that belong to the specified directory, so let
bash-completion suggest directories to it.

Reported by 積丹尼 Dan Jacobson [1].

[1] https://bugs.debian.org/918430