### PR TITLE
_filedir: remove . and .. from suggestions

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -596,6 +596,14 @@ _filedir()
         compopt -o filenames 2>/dev/null
         COMPREPLY+=( "${toks[@]}" )
     fi
+
+    # Remove '.' and '..' from suggestions
+    local i
+    for i in "${!COMPREPLY[@]}" ; do
+        [ "${COMPREPLY[$i]}" = '.' -o "${COMPREPLY[$i]}" = '..' ] && \
+            unset -v 'COMPREPLY[$i]'
+    done
+    COMPREPLY=( "${COMPREPLY[@]}" )
 } # _filedir()
 
 


### PR DESCRIPTION
The title says it all. This is a breaking change, but I would be surprised if anyone entered e.g. the text `..` by typing Ctrl+j twice. This change allows to fully complete a hidden file name when there is only one hidden file besides `.` and `..` (or at least, to benefit from prefix completion, such as with `.git` and `.gitignore`).