### PR TITLE
cppcheck: Remove deprecated option 'posix'  for '--std='

### DIFF
--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -52,7 +52,7 @@ _cppcheck()
             ;;
         --std)
             COMPREPLY=( $(compgen -W 'c89 c99 c11 c++03 c++11 c++14 c++17
-                c++20 posix' -- "$cur") )
+                c++20' -- "$cur") )
             return
             ;;
         --platform)


### PR DESCRIPTION
'--std=posix' is deprecated and will be removed.
See this Cppcheck commit:
https://github.com/danmar/cppcheck/commit/cb06aebdab894c2ca767869889df8e1175aeb379