### PR TITLE
allow autocomplete with serial ports

### DIFF
--- a/completions/screen
+++ b/completions/screen
@@ -25,6 +25,13 @@ _screen()
     local cur prev words cword
     _init_completion || return
 
+    if [[ $cword -eq 1 && $cur == /dev* ]]; then
+        COMPREPLY=( $(compgen -W "$(shopt -s nullglob; printf '%s\n' \
+            /dev/serial/by-id/* /dev/ttyUSB* /dev/ttyACM* 2>/dev/null)" \
+            -- "$cur") )
+        return
+    fi
+
     if ((cword > 2)); then
         case ${words[cword-2]} in
             -*[dD])


### PR DESCRIPTION
an important feature of GNU screen is its usefulness as a serial terminal.  Autocomplete normally does not work with serial devices because they are not real files, so this change autocompletes serial ports after $ screen /dev<TAB>