### PR TITLE
fix a minor flaw in option completion for `nmap`

### DIFF
--- a/completions/nmap
+++ b/completions/nmap
@@ -39,7 +39,7 @@ _nmap()
             --ip-options --ttl --spoof-mac --badsum --adler32 -oN -oX -oS -oG
             -oA -v -d --reason --open --packet-trace --iflist --log-errors
             --append-output --resume --stylesheet --webxml --no-stylesheet -6
-            -A --datadir --send-eth --send-ip --privilege--unprivileged -V
+            -A --datadir --send-eth --send-ip --privileged --unprivileged -V
             -h' -- "$cur") )
     else
         _known_hosts_real -- "$cur"


### PR DESCRIPTION
With `nmap`, there's an option `--privilege--unprivileged` being completed; just noticed this by accident :laughing: 

Fun fact: this has been buried in the code since [about a decade](https://github.com/scop/bash-completion/commit/e28d19ef4c413d850dd5a80e2ea3907f50608d70) :wink: 

Thank you and all contributors btw. _Cheers !_
