### PR TITLE
Adding a completion for $jarsigner  *.apk files

### DIFF
--- a/completions/jarsigner
+++ b/completions/jarsigner
@@ -25,7 +25,7 @@ _jarsigner()
             return
             ;;
         -signedjar)
-            _filedir jar
+            _filedir '@(jar|apk)'
             return
             ;;
     esac
@@ -33,7 +33,7 @@ _jarsigner()
     # Check if a jar was already given.
     local i jar=false
     for (( i=0; i < ${#words[@]}-1; i++ )) ; do
-        if [[ "${words[i]}" == *.jar && \
+        if [[ "${words[i]}" == *.@(jar|apk) && \
             "${words[i-1]}" != -signedjar ]]; then
             jar=true
             break
@@ -49,7 +49,7 @@ _jarsigner()
                 -protected -providerName -providerClass -providerArg' \
                 -- "$cur") )
         fi
-        _filedir jar
+        _filedir '@(jar|apk)'
     fi
 } &&
 complete -F _jarsigner jarsigner


### PR DESCRIPTION
Adding a completion for `jarsigner` with `*.apk` files. This bug emerged from the downstream Debian bash-completion. The bug identifier is: **Debian Bug report logs - #907635**