### PR TITLE
python: support executables with minor version

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -163,7 +163,9 @@ pydoc3
 pylint-[23]
 pytest-[23]
 python2
+python2.7
 python3
+python3.[345678]
 pypy
 pypy3
 pyvenv-3.[45678]

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -664,7 +664,14 @@ CLEANFILES = \
 	pytest-2 \
 	pytest-3 \
 	python2 \
+	python2.7 \
 	python3 \
+	python3.3 \
+	python3.4 \
+	python3.5 \
+	python3.6 \
+	python3.7 \
+	python3.8 \
 	pyvenv-3.4 \
 	pyvenv-3.5 \
 	pyvenv-3.6 \
@@ -880,7 +887,7 @@ symlinks: $(DATA)
 	$(ss) pylint \
 		pylint-2 pylint-3
 	$(ss) python \
-		micropython pypy pypy3 python2 python3
+		micropython pypy pypy3 python2 python2.7 python3 python3.3 python3.4 python3.5 python3.6 python3.7 python3.8
 	$(ss) pyvenv \
 		pyvenv-3.4 pyvenv-3.5 pyvenv-3.6 pyvenv-3.7 pyvenv-3.8
 	$(ss) qdbus \

--- a/completions/python
+++ b/completions/python
@@ -63,6 +63,6 @@ _python()
         COMPREPLY=( $(compgen -W '$(_parse_help "$1" -h)' -- "$cur") )
     fi
 } &&
-complete -F _python python python2 python3 pypy pypy3 micropython
+complete -F _python python python2 python2.7 python3 python3.{3..8} pypy pypy3 micropython
 
 # ex: filetype=sh


### PR DESCRIPTION
Debian, Ubuntu, and likely other distributions install the Python executable with a minor version (e.g. `python2.7`, `python3.8`) in addition to the major version (`python2`, `python3`) and unversioned (`python`) aliases.  Apply the completion to the minor versioned executables for versions supported in the last 3 years.

Thanks for considering,
Kevin