### PR TITLE
Check that ruptime is present before calling

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1685,9 +1685,11 @@ _known_hosts_real()
     fi
 
     # Add hosts reported by ruptime.
-    COMPREPLY+=( $(compgen -W \
-        "$(ruptime 2>/dev/null | awk '!/^ruptime:/ { print $1 }')" \
-        -- "$cur") )
+    if type ruptime &>/dev/null; then
+        COMPREPLY+=( $(compgen -W \
+            "$(ruptime 2>/dev/null | awk '!/^ruptime:/ { print $1 }')" \
+            -- "$cur") )
+    fi
 
     # Add results of normal hostname completion, unless
     # `COMP_KNOWN_HOSTS_WITH_HOSTFILE' is set to an empty value.


### PR DESCRIPTION
Avoids calling command_not_found_handle which might take considerable
time.

---

For instance on my system command_not_found_handle takes more than 200ms. I don't want this delay every time I complete hostname!