### PR TITLE
ip: add support for netns (based on #21)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -932,13 +932,6 @@ _configured_interfaces()
     fi
 }
 
-# This function completes on available netns
-#
-_available_netns()
-{
-   COMPREPLY=( $( compgen -W '$( command ls /var/run/netns )' -- "$cur" ) )
-}
-
 # Local IP addresses.
 # -4: IPv4 addresses only (default)
 # -6: IPv6 addresses only

--- a/bash_completion
+++ b/bash_completion
@@ -932,6 +932,13 @@ _configured_interfaces()
     fi
 }
 
+# This function completes on available netns
+#
+_available_netns()
+{
+   COMPREPLY=( $( compgen -W '$( command ls /var/run/netns )' -- "$cur" ) )
+}
+
 # Local IP addresses.
 # -4: IPv4 addresses only (default)
 # -6: IPv6 addresses only
@@ -956,13 +963,6 @@ _ip_addresses()
 _kernel_versions()
 {
     COMPREPLY=( $(compgen -W '$(command ls /lib/modules)' -- "$cur") )
-}
-
-# This function completes on available netns
-#
-_available_netns()
-{
-   COMPREPLY=( $( compgen -W '$( command ls /var/run/netns )' -- "$cur" ) )
 }
 
 # This function completes on all available network interfaces

--- a/bash_completion
+++ b/bash_completion
@@ -958,6 +958,13 @@ _kernel_versions()
     COMPREPLY=( $(compgen -W '$(command ls /lib/modules)' -- "$cur") )
 }
 
+# This function completes on available netns
+#
+_available_netns()
+{
+   COMPREPLY=( $( compgen -W '$( command ls /var/run/netns )' -- "$cur" ) )
+}
+
 # This function completes on all available network interfaces
 # -a: restrict to active interfaces only
 # -w: restrict to wireless interfaces only

--- a/completions/ip
+++ b/completions/ip
@@ -327,8 +327,7 @@ _ip()
                     ;;
                 delete|exec|pids|set)
                     [[ $prev == $subcmd ]] && \
-                        COMPREPLY=( $(compgen -W "$( command \
-                            $1 netns list )" -- "$cur") )
+                        COMPREPLY=( $(compgen -W "$($1 netns list)" -- "$cur") )
                     ;;
                 *)
                     [[ $cword -eq $subcword ]] && \

--- a/completions/ip
+++ b/completions/ip
@@ -320,10 +320,10 @@ _ip()
 
         netns)
             case $subcmd in
-                list|add|identify|pids|monitor)
+                list|list-id|add|identify|monitor)
                     # TODO
                     ;;
-                add|delete|exec|pids)
+                delete|exec|pids|set)
                      _available_netns
                     ;;
                 *)
@@ -341,8 +341,8 @@ _ip()
                     ;;
                 *)
                     [[ $cword -eq $subcword ]] && \
-                        COMPREPLY=( $(compgen -W 'state policy monitor' \
-                        -- "$cur") )
+                        COMPREPLY=( $( compgen -W 'help list add delete \
+                        identify pids exec monitor' -- "$cur" ) )
                     ;;
             esac
             ;;

--- a/completions/ip
+++ b/completions/ip
@@ -320,16 +320,18 @@ _ip()
 
         netns)
             case $subcmd in
-                list|list-id|add|identify|monitor)
+                add|identify|list|list-id|monitor)
                     # TODO
                     ;;
                 delete|exec|pids|set)
-                     _available_netns
+                    [[ $prev == $subcmd ]] && \
+                        COMPREPLY=( $( compgen -W '$( command \
+                        ls /var/run/netns 2>/dev/null )' -- "$cur" ) )
                     ;;
                 *)
                     [[ $cword -eq $subcword ]] && \
-                        COMPREPLY=( $( compgen -W 'help list add delete identify
-                               pids exec monitor' -- "$cur" ) )
+                        COMPREPLY=( $( compgen -W 'help add delete exec
+                        identify list list-id monitor pids set' -- "$cur" ) )
                     ;;
             esac
             ;;
@@ -341,8 +343,8 @@ _ip()
                     ;;
                 *)
                     [[ $cword -eq $subcword ]] && \
-                        COMPREPLY=( $( compgen -W 'help list add delete \
-                        identify pids exec monitor' -- "$cur" ) )
+                        COMPREPLY=( $(compgen -W 'state policy monitor' \
+                        -- "$cur") )
                     ;;
             esac
             ;;

--- a/completions/ip
+++ b/completions/ip
@@ -320,18 +320,20 @@ _ip()
 
         netns)
             case $subcmd in
-                add|identify|list|list-id|monitor)
+                list|monitor)
+                    ;;
+                add|identify|list-id)
                     # TODO
                     ;;
                 delete|exec|pids|set)
                     [[ $prev == $subcmd ]] && \
-                        COMPREPLY=( $( compgen -W '$( command \
-                        ls /var/run/netns 2>/dev/null )' -- "$cur" ) )
+                        COMPREPLY=( $(compgen -W "$( command \
+                            $1 netns list )" -- "$cur") )
                     ;;
                 *)
                     [[ $cword -eq $subcword ]] && \
-                        COMPREPLY=( $( compgen -W 'help add delete exec
-                        identify list list-id monitor pids set' -- "$cur" ) )
+                        COMPREPLY=( $(compgen -W 'help add delete exec
+                            identify list list-id monitor pids set' -- "$cur") )
                     ;;
             esac
             ;;

--- a/completions/ip
+++ b/completions/ip
@@ -318,6 +318,22 @@ _ip()
             esac
             ;;
 
+        netns)
+            case $subcmd in
+                list|add|identify|pids|monitor)
+                    # TODO
+                    ;;
+                add|delete|exec|pids)
+                     _available_netns
+                    ;;
+                *)
+                    [[ $cword -eq $subcword ]] && \
+                        COMPREPLY=( $( compgen -W 'help list add delete identify
+                               pids exec monitor' -- "$cur" ) )
+                    ;;
+            esac
+            ;;
+
         xfrm)
             case $subcmd in
                 state|policy|monitor)


### PR DESCRIPTION
The original PR looks like abandoned. I added some improvements and hopefully addressed the issues mentioned there.

- Embed the available netns part inside completion
- Add 2>/dev/null for ls command
- Add missing subcommands
- Only complete the netns name once after subcmd