### PR TITLE
Speed up Python completion

### DIFF
--- a/helpers/python
+++ b/helpers/python
@@ -3,12 +3,20 @@
 import pkgutil
 import sys
 
-# walk_packages() is much slower than iter_modules(), use it only when
-# completing something with a dot in it.
-if len(sys.argv) > 1 and "." in sys.argv[1]:
-    walker = pkgutil.walk_packages
-else:
-    walker = pkgutil.iter_modules
 
-for mod in walker():
+def iter_submodules(pkgname):
+    __import__(pkgname)
+    pkg = sys.modules[pkgname]
+    return pkgutil.walk_packages(
+        pkg.__path__, pkgname + ".", onerror=lambda _: None
+    )
+
+
+if len(sys.argv) > 1 and "." in sys.argv[1]:
+    pkgname = sys.argv[1].rpartition(".")[0]
+    modules = iter_submodules(pkgname)
+else:
+    modules = pkgutil.iter_modules()
+
+for mod in modules:
     print (mod[1])  # noqa: E211

--- a/test/t/test_python.py
+++ b/test/t/test_python.py
@@ -33,3 +33,7 @@ class TestPython:
     @pytest.mark.complete("python -m sy", require_cmd=True)
     def test_8(self, completion):
         assert completion
+
+    @pytest.mark.complete("python -m json.", require_cmd=True)
+    def test_9(self, completion):
+        assert "json.tool" in completion

--- a/test/t/test_python3.py
+++ b/test/t/test_python3.py
@@ -33,3 +33,7 @@ class TestPython3:
     @pytest.mark.complete("python3 -m sy", require_cmd=True)
     def test_8(self, completion):
         assert completion
+
+    @pytest.mark.complete("python3 -m json.", require_cmd=True)
+    def test_9(self, completion):
+        assert "json.tool" in completion


### PR DESCRIPTION
* Make completion of dotted names (e.g. `python -m foo.b`) faster.
* (minor one) Ignore errors in `walk_packages()` so that a package raising an exception does not prevent other modules from being listed.