### PR TITLE
lintian: complete paths for Ubuntu automatic debug symbols and Debian's buildinfo files

### DIFF
--- a/completions/lintian
+++ b/completions/lintian
@@ -136,7 +136,8 @@ _lintian()
             esac
             ;;
         *)
-            _filedir '@(?(u)deb|changes|dsc)'
+            # in Ubuntu, dbgsym packages end in .ddeb, lintian >= 2.57.0 groks
+            _filedir '@(?(u|d)deb|changes|dsc|buildinfo)'
             ;;
     esac
     return 0


### PR DESCRIPTION
In Ubuntu, automatic debug packages use the non-standard .ddeb suffix:

    https://wiki.ubuntu.com/Debug%20Symbol%20Packages

This commit implements path completion for them, and also for Debian's buildinfo files. It was tested locally.
