### PR TITLE
New completion: apt-mark

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -14,6 +14,7 @@ bashcomp_DATA = 2to3 \
 		apt-build \
 		apt-cache \
 		apt-get \
+		apt-mark \
 		aptitude \
 		arch \
 		arp \

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -6,8 +6,8 @@ _apt_mark()
     _init_completion -s || return
 
     local special i
-    for (( i=0; i < ${#words[@]}-1; i++ )); do
-        if [[ ${words[i]} == @(hold|unhold|auto|manual|install|remove|purge|showhold|showauto|showmanual|showinstall|showremove|showpurge|minimize-manual) ]]; then
+    for (( i=1; i < ${#words[@]}-1; i++ )); do
+        if [[ ${words[i]} == @(auto|manual|minimize-manual|showauto|showmanual|hold|unhold|showhold|install|remove|purge|showinstall|showremove|showpurge) ]]; then
             special=${words[i]}
         fi
     done
@@ -18,8 +18,7 @@ _apt_mark()
                 return
                 ;;
             *)
-                COMPREPLY=( $(apt-cache --no-generate pkgnames "$cur" \
-                    2>/dev/null) )
+                COMPREPLY=( $(_xfunc apt-cache _apt_cache_packages) )
                 ;;
         esac
         return
@@ -29,7 +28,11 @@ _apt_mark()
         --help|--version|--option|-!(-*)[hvo])
             return
             ;;
-        --config-file|--file|-!(-*)[cf])
+        --config-file|-!(-*)c)
+            _filedir conf
+            return
+            ;;
+        --file|-!(-*)f)
             _filedir
             return
             ;;
@@ -38,12 +41,10 @@ _apt_mark()
     $split && return
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W '-f --file= --help --version -c --config-file -o --option' -- "$cur") )
+        COMPREPLY=( $(compgen -W '--file= --help --version --config-file --option' -- "$cur") )
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     else
-        COMPREPLY=( $(compgen -W 'hold unhold install remove purge
-            showhold showinstall showremove showpurge showauto showmanual
-            auto manual minimize-manual' -- "$cur") )
+        COMPREPLY=( $(compgen -W 'auto manual minimize-manual showauto showmanual hold unhold showhold install remove purge showinstall showremove showpurge' -- "$cur") )
     fi
 
 } &&

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -7,7 +7,7 @@ _apt_mark()
 
     local special i
     for ((i = 1; i < ${#words[@]} - 1; i++)); do
-        if [[ ${words[i]} == @(auto|manual|minimize-manual|showauto|showmanual|hold|unhold|showhold|install|remove|purge|showinstall|showremove|showpurge) ]]; then
+        if [[ ${words[i]} == @(auto|manual|minimize-manual|showauto|showmanual|hold|unhold|showhold|install|remove|deinstall|purge|showinstall|showremove|showpurge) ]]; then
             special=${words[i]}
         fi
     done

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -15,6 +15,14 @@ _apt_mark()
 
     if [[ -v special ]]; then
         case $special in
+            auto | manual | unhold)
+                local -A showcmds=([auto]=manual [manual]=auto [unhold]=hold)
+                local showcmd=${showcmds[$special]}
+                COMPREPLY=($(
+                    compgen -W "$("$1" show$showcmd 2>/dev/null)" -- "$cur"
+                ))
+                return
+                ;;
             minimize-manual)
                 return
                 ;;

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -1,0 +1,52 @@
+# Debian apt-mark(8) completion                             -*- shell-script -*-
+
+_apt_mark()
+{
+    local cur prev words cword split
+    _init_completion -s || return
+
+    local special i
+    for (( i=0; i < ${#words[@]}-1; i++ )); do
+        if [[ ${words[i]} == @(hold|unhold|auto|manual|install|remove|purge|showhold|showauto|showmanual|showinstall|showremove|showpurge|minimize-manual) ]]; then
+            special=${words[i]}
+        fi
+    done
+
+    if [[ -n $special ]]; then
+        case $special in
+            minimize-manual)
+                return
+                ;;
+            *)
+                COMPREPLY=( $(apt-cache --no-generate pkgnames "$cur" \
+                    2>/dev/null) )
+                ;;
+        esac
+        return
+    fi
+
+    case $prev in
+        --help|--version|--option|-!(-*)[hvo])
+            return
+            ;;
+        --config-file|--file|-!(-*)[cf])
+            _filedir
+            return
+            ;;
+    esac
+
+    $split && return
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W '-f --file= --help --version -c --config-file -o --option' -- "$cur") )
+        [[ $COMPREPLY == *= ]] && compopt -o nospace
+    else
+        COMPREPLY=( $(compgen -W 'hold unhold install remove purge
+            showhold showinstall showremove showpurge showauto showmanual
+            auto manual minimize-manual' -- "$cur") )
+    fi
+
+} &&
+complete -F _apt_mark apt-mark
+
+# ex: filetype=sh

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -6,7 +6,7 @@ _apt_mark()
     _init_completion -s || return
 
     local special i
-    for (( i=1; i < ${#words[@]}-1; i++ )); do
+    for ((i = 1; i < ${#words[@]} - 1; i++)); do
         if [[ ${words[i]} == @(auto|manual|minimize-manual|showauto|showmanual|hold|unhold|showhold|install|remove|purge|showinstall|showremove|showpurge) ]]; then
             special=${words[i]}
         fi
@@ -18,21 +18,21 @@ _apt_mark()
                 return
                 ;;
             *)
-                COMPREPLY=( $(_xfunc apt-cache _apt_cache_packages) )
+                COMPREPLY=($(_xfunc apt-cache _apt_cache_packages))
                 ;;
         esac
         return
     fi
 
     case $prev in
-        --help|--version|--option|-!(-*)[hvo])
+        --help | --version | --option | -!(-*)[hvo])
             return
             ;;
-        --config-file|-!(-*)c)
+        --config-file | -!(-*)c)
             _filedir conf
             return
             ;;
-        --file|-!(-*)f)
+        --file | -!(-*)f)
             _filedir
             return
             ;;
@@ -40,14 +40,17 @@ _apt_mark()
 
     $split && return
 
-    if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W '--file= --help --version --config-file --option' -- "$cur") )
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W '--file= --help --version --config-file
+            --option' -- "$cur"))
         [[ $COMPREPLY == *= ]] && compopt -o nospace
     else
-        COMPREPLY=( $(compgen -W 'auto manual minimize-manual showauto showmanual hold unhold showhold install remove purge showinstall showremove showpurge' -- "$cur") )
+        COMPREPLY=($(compgen -W 'auto manual minimize-manual showauto
+            showmanual hold unhold showhold install remove purge
+            showinstall showremove showpurge' -- "$cur"))
     fi
 
 } &&
-complete -F _apt_mark apt-mark
+    complete -F _apt_mark apt-mark
 
 # ex: filetype=sh

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -9,6 +9,7 @@ _apt_mark()
     for ((i = 1; i < ${#words[@]} - 1; i++)); do
         if [[ ${words[i]} == @(auto|manual|minimize-manual|showauto|showmanual|hold|unhold|showhold|install|remove|deinstall|purge|showinstall|showremove|showpurge) ]]; then
             special=${words[i]}
+            break
         fi
     done
 

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -19,7 +19,7 @@ _apt_mark()
                 return
                 ;;
             *)
-                COMPREPLY=($(_xfunc apt-cache _apt_cache_packages))
+                _xfunc apt-get _apt_get_installed_packages
                 ;;
         esac
         return

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -12,7 +12,7 @@ _apt_mark()
         fi
     done
 
-    if [[ -n $special ]]; then
+    if [[ -v special ]]; then
         case $special in
             minimize-manual)
                 return

--- a/test/t/test_apt_mark.py
+++ b/test/t/test_apt_mark.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+@pytest.mark.bashcomp(cmd="apt-mark")
+class TestAptMark:
+    @pytest.mark.complete("apt-mark ")
+    def test_1(self, completion):
+        assert all(x in completion for x in "auto manual remove showinstall showremove \
+        hold minimize-manual showauto showmanual unhold install \
+        purge showhold showpurge".split())
+
+    @pytest.mark.complete("apt-mark minimize-manual ")
+    def test_2(self, completion):
+        assert completion == []
+
+    @pytest.mark.complete("apt-mark --file=", cwd="dpkg")
+    def test_3(self, completion):
+        assert completion == "--file=bash-completion-test-subject.deb"
+
+    @pytest.mark.complete("apt-mark --config-file ", cwd="dpkg")
+    def test_4(self, completion):
+        assert completion == "bash-completion-test-subject.deb"
+
+    @pytest.mark.complete("apt-mark --option ")
+    def test_5(self, completion):
+        assert completion == []
+

--- a/test/t/test_apt_mark.py
+++ b/test/t/test_apt_mark.py
@@ -5,13 +5,14 @@ import pytest
 class TestAptMark:
     @pytest.mark.complete("apt-mark ")
     def test_1(self, completion):
-        assert all(x in completion for x in "auto manual remove showinstall showremove \
-        hold minimize-manual showauto showmanual unhold install \
-        purge showhold showpurge".split())
+        assert all(x in completion for x in (
+        "auto manual remove showinstall showremove "
+        "hold minimize-manual showauto showmanual unhold install "
+        "purge showhold showpurge").split())
 
     @pytest.mark.complete("apt-mark minimize-manual ")
     def test_2(self, completion):
-        assert completion == []
+        assert not completion
 
     @pytest.mark.complete("apt-mark --file=", cwd="dpkg")
     def test_3(self, completion):
@@ -23,5 +24,5 @@ class TestAptMark:
 
     @pytest.mark.complete("apt-mark --option ")
     def test_5(self, completion):
-        assert completion == []
+        assert not completion
 

--- a/test/t/test_apt_mark.py
+++ b/test/t/test_apt_mark.py
@@ -5,10 +5,14 @@ import pytest
 class TestAptMark:
     @pytest.mark.complete("apt-mark ")
     def test_1(self, completion):
-        assert all(x in completion for x in (
-        "auto manual remove showinstall showremove "
-        "hold minimize-manual showauto showmanual unhold install "
-        "purge showhold showpurge").split())
+        assert all(
+            x in completion
+            for x in (
+                "auto manual remove showinstall showremove "
+                "hold minimize-manual showauto showmanual unhold install "
+                "purge showhold showpurge"
+            ).split()
+        )
 
     @pytest.mark.complete("apt-mark minimize-manual ")
     def test_2(self, completion):
@@ -25,4 +29,3 @@ class TestAptMark:
     @pytest.mark.complete("apt-mark --option ")
     def test_5(self, completion):
         assert not completion
-

--- a/test/t/test_apt_mark.py
+++ b/test/t/test_apt_mark.py
@@ -20,7 +20,10 @@ class TestAptMark:
 
     @pytest.mark.complete("apt-mark --file=", cwd="dpkg")
     def test_3(self, completion):
-        assert completion == "--file=bash-completion-test-subject.deb"
+        assert (
+            completion
+            == "bash-completion-test-nonsubject.txt bash-completion-test-subject.deb".split()
+        )
 
     @pytest.mark.complete("apt-mark --config-file ", cwd="apt-mark")
     def test_4(self, completion):

--- a/test/t/test_apt_mark.py
+++ b/test/t/test_apt_mark.py
@@ -18,9 +18,9 @@ class TestAptMark:
     def test_3(self, completion):
         assert completion == "--file=bash-completion-test-subject.deb"
 
-    @pytest.mark.complete("apt-mark --config-file ", cwd="dpkg")
+    @pytest.mark.complete("apt-mark --config-file ", cwd="apt-mark")
     def test_4(self, completion):
-        assert completion == "bash-completion-test-subject.deb"
+        assert completion == "example.conf"
 
     @pytest.mark.complete("apt-mark --option ")
     def test_5(self, completion):

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -19,6 +19,7 @@ appdata-validate
 apt-build
 apt-cache
 apt-get
+apt-mark
 aptitude
 arch
 arp


### PR DESCRIPTION
Mostly borrowed code from `apt-get` completion. I've also added some basic tests for edge case options.
Note that I've implemented the completion to display short options as well, which I could of course remove if they are deemed unnecessary.