### PR TITLE
Add new ssh -Q completions in OpenSSH 8.2p1

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -4,10 +4,8 @@ _ssh_queries()
 {
     COMPREPLY+=( $(compgen -W \
         "cipher cipher-auth help mac kex key key-cert key-plain key-sig
-         protocol-version compression sig" \
-        -- "$cur") )
-    COMPREPLY+=( $(compgen -W \
-        "ciphers macs kexalgorithms pubkeyacceptedkeytypes
+         protocol-version compression sig
+         ciphers macs kexalgorithms pubkeyacceptedkeytypes
          hostkeyalgorithms hostbasedkeytypes hostbasedacceptedkeytypes" \
         -- "${cur,,}") )
 }

--- a/completions/ssh
+++ b/completions/ssh
@@ -3,8 +3,13 @@
 _ssh_queries()
 {
     COMPREPLY+=( $(compgen -W \
-        "cipher cipher-auth mac kex key key-cert key-plain protocol-version sig" \
+        "cipher cipher-auth help mac kex key key-cert key-plain key-sig
+         protocol-version compression sig" \
         -- "$cur") )
+    COMPREPLY+=( $(compgen -W \
+        "ciphers macs kexalgorithms pubkeyacceptedkeytypes
+         hostkeyalgorithms hostbasedkeytypes hostbasedacceptedkeytypes" \
+        -- "${cur,,}") )
 }
 
 _ssh_query()


### PR DESCRIPTION
Mostly based on the upstream code:

https://github.com/openssh/openssh-portable/blob/master/ssh.c#L738

One place for improvement would be accepting case insensitive aliases, but I was not sure how to do that easily on fast review of the manual pages.