### PR TITLE
fix for "bash_completion is a directory" error message

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2182,7 +2182,7 @@ unset compat_dir i _blacklist_glob
 
 # source user completion file
 user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
-[[ ${BASH_SOURCE[0]} != "$user_completion" && -r $user_completion ]] \
+[[ ${BASH_SOURCE[0]} != "$user_completion" && -r $user_completion  && -f "$user_completion" ]] \
     && . $user_completion
 unset user_completion
 


### PR DESCRIPTION
I was getting `~/.bash_completion is a directory` error messages, which I did not like seeing on every ssh login. So I added a `-f` to make sure it's a file, in addition to the other checks.

Perhaps this isn't quite correct; among other things, installing bash_completion and then having a directory called ~/.bash_completion might be a problem. But I thought I'd submit my fix anyway.

Thanks!