### PR TITLE
make: fix sed error on FreeBSD

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -9,8 +9,14 @@ _make_target_extract_script()
     local prefix_pat=$(command sed 's/[][\,.*^$(){}?+|/]/\\&/g' <<<"$prefix")
     local basename=${prefix##*/}
     local dirname_len=$((${#prefix} - ${#basename}))
+    # Avoid expressions like '\(.\{0\}\)', FreeBSD sed doesn't like them:
+    # > sed: 1: ...: RE error: empty (sub)expression
+    local dirname_re
+    ((dirname_len > 0)) && dirname_re="\(.\{${dirname_len}\}\)"
 
-    if [[ $mode == -d ]]; then
+    if [[ ! -v dirname_re ]]; then
+        local output="\1"
+    elif [[ $mode == -d ]]; then
         # display mode, only output current path component to the next slash
         local output="\2"
     else
@@ -40,7 +46,7 @@ _make_target_extract_script()
     /^$/ {                                      # end of target block
       x;                                        # unhold target
       /^$/d;                                    # dont print blanks
-      s|^\(.\{${dirname_len}\}\)\(.\{${#basename}\}[^:/]*/\{0,1\}\)[^:]*:.*$|${output}|p;
+      s|^${dirname_re-}\(.\{${#basename}\}[^:/]*/\{0,1\}\)[^:]*:.*$|${output}|p;
       d;                                        # hide any bugs
     }
 


### PR DESCRIPTION
FreeBSD sed does not like constructs like '\(.\{0\}\)':
> sed: 1: ...: RE error: empty (sub)expression

Omit such dirname group altogether.

Closes https://github.com/scop/bash-completion/issues/213