### PR TITLE
Allow all file types for tshark -r

### DIFF
--- a/completions/tshark
+++ b/completions/tshark
@@ -58,11 +58,8 @@ _tshark()
             [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             return
             ;;
-        -*r)
-            _filedir '@(pcap?(ng)|cap)?(.gz)'
-            return
-            ;;
-        -*H)
+        -*[rH])
+            # -r accepts a lot of different file types
             _filedir
             return
             ;;

--- a/test/t/test_tshark.py
+++ b/test/t/test_tshark.py
@@ -29,3 +29,7 @@ class TestTshark:
     def test_6(self, completion):
         """Test there are no URLs in completions."""
         assert not any("://" in x for x in completion)
+
+    @pytest.mark.complete("tshark -r ")
+    def test_input_files(self, completion):
+        assert completion


### PR DESCRIPTION
The current autocomplete only accepts pcap/pcapng(.gz), but Tshark allows many other [file types](https://www.wireshark.org/docs/wsug_html_chunked/ChIOOpenSection.html#ChIOInputFormatsSection).

I think instead of adding all those types to the pattern, we should just list all files for these reasons:

- Tshark doesn't care about the file extension
- The user typically types a prefix before hitting Tab
- Capture files are typically stored in a directory without many other files