### PR TITLE
Allow completion of farbfeld images in feh

### DIFF
--- a/completions/feh
+++ b/completions/feh
@@ -113,7 +113,7 @@ _feh()
 
     # FIXME: It is hard to determine correct supported extensions.
     # feh can handle any format that imagemagick can plus some others
-    _filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf'
+    _filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)'
 } &&
     complete -F _feh feh
 


### PR DESCRIPTION
Add common file extensions for farbfeld images (*.ff / *.ff.gz / *.ff.bz2) to feh completions