### PR TITLE
mutt: do not lose the + in mutt -f +foo<tab>

### DIFF
--- a/completions/mutt
+++ b/completions/mutt
@@ -114,6 +114,7 @@ _muttfiledir()
         compopt -o filenames
         COMPREPLY=($(compgen -f -- "$folder/${cur:1}"))
         COMPREPLY=(${COMPREPLY[@]#$folder/})
+        [[ $cur == [+]* ]] && COMPREPLY=(${COMPREPLY[@]/#/+})
         return
     elif [[ $cur == !* ]]; then
         spoolfile="$($muttcmd -F "$muttrc" -Q spoolfile 2>/dev/null |


### PR DESCRIPTION
Closes #464.