### PR TITLE
mutt: enable completions for neomutt

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -132,6 +132,7 @@
 /msgsnarf
 /muttng
 /ncal
+/neomutt
 /pbzip2
 /pccardctl
 /pdlzip

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -649,6 +649,7 @@ CLEANFILES = \
 	msgsnarf \
 	muttng \
 	ncal \
+	neomutt \
 	pbzip2 \
 	pccardctl \
 	pdlzip \
@@ -894,7 +895,7 @@ symlinks: $(DATA)
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2
 	$(ss) mutt \
-		muttng
+		muttng neomutt
 	$(ss) nslookup \
 		host
 	$(ss) p4 \

--- a/completions/mutt
+++ b/completions/mutt
@@ -155,6 +155,6 @@ _mutt()
             ;;
     esac
 } &&
-    complete -F _mutt -o default mutt muttng
+    complete -F _mutt -o default mutt muttng neomutt
 
 # ex: filetype=sh

--- a/test/t/Makefile.am
+++ b/test/t/Makefile.am
@@ -396,6 +396,7 @@ EXTRA_DIST = \
 	test_mysqladmin.py \
 	test_nc.py \
 	test_ncftp.py \
+	test_neomutt.py \
 	test_nethogs.py \
 	test_netstat.py \
 	test_newgrp.py \

--- a/test/t/test_neomutt.py
+++ b/test/t/test_neomutt.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+class TestNeomutt:
+    @pytest.mark.complete("neomutt -")
+    def test_1(self, completion):
+        assert completion

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -397,6 +397,7 @@ mysql
 mysqladmin
 nc
 ncftp
+neomutt
 nethogs
 netstat
 newgrp


### PR DESCRIPTION
The neomutt package has been in Debian since buster.
