### PR TITLE
7z, tar, unace, unrar, unzip, zipinfo: recognize comic book archives

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2180,7 +2180,7 @@ _install_xspec()
 }
 # bzcmp, bzdiff, bz*grep, bzless, bzmore intentionally not here, see Debian: #455510
 _install_xspec '!*.?(t)bz?(2)' bunzip2 bzcat pbunzip2 pbzcat lbunzip2 lbzcat
-_install_xspec '!*.@(zip|[aegjswx]ar|exe|pk3|wsz|zargo|xpi|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|apk|aab|ipa|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|whl)' unzip zipinfo
+_install_xspec '!*.@(zip|[aegjswx]ar|exe|pk3|wsz|zargo|xpi|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|cbz|apk|aab|ipa|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|whl)' unzip zipinfo
 _install_xspec '*.Z' compress znew
 # zcmp, zdiff, z*grep, zless, zmore intentionally not here, see Debian: #455510
 _install_xspec '!*.@(Z|[gGd]z|t[ag]z)' gunzip zcat

--- a/completions/7z
+++ b/completions/7z
@@ -110,7 +110,7 @@ _7z()
         #     (assumption: extensions are all lowercase)
         [[ $mode == w ]] &&
             _filedir '@(7z|bz2|swf|?(g)tar|?(t)[bglx]z|tb?(z)2|wim)' ||
-            _filedir '@(7z|arj|bz2|cab|chm|cpio|deb|dmg|flv|gem|img|iso|lz[ah]|lzma?(86)|msi|pmd|[rx]ar|rpm|sw[fm]|?(g)tar|taz|?(t)[bglx]z|tb?(z)2|vhd|wim|Z)'
+            _filedir '@(7z|arj|bz2|cab|cb7|chm|cpio|deb|dmg|flv|gem|img|iso|lz[ah]|lzma?(86)|msi|pmd|[rx]ar|rpm|sw[fm]|?(g)tar|taz|?(t)[bglx]z|tb?(z)2|vhd|wim|Z)'
     else
         if [[ ${words[1]} == d ]]; then
             local IFS=$'\n'

--- a/completions/tar
+++ b/completions/tar
@@ -422,7 +422,7 @@ __tar_cleanup_prev()
 
 __tar_detect_ext()
 {
-    local tars='@(@(tar|gem|spkg)?(.@(Z|[bgx]z|bz2|lz?(ma|o)|zst))|t@([abglx]z|b?(z)2|zst))'
+    local tars='@(@(tar|gem|spkg)?(.@(Z|[bgx]z|bz2|lz?(ma|o)|zst))|t@([abglx]z|b?(z)2|zst)|cbt)'
     if [[ ${COMP_WORDS[0]} == ?(*/)bsdtar ]]; then
         # https://github.com/libarchive/libarchive/wiki/LibarchiveFormats
         tars=${tars/%\)/|pax|cpio|iso|zip|@(j|x)ar|mtree|a|7z|warc}
@@ -441,7 +441,7 @@ __tar_detect_ext()
             # Should never happen?
             ;;
         ?(-)*[cr]*f)
-            ext='@(tar|gem|spkg)'
+            ext='@(tar|gem|spkg|cbt)'
             case ${words[1]} in
                 *a*) ext="$tars" ;;
                 *z*) ext='t?(ar.)gz' ;;

--- a/completions/unace
+++ b/completions/unace
@@ -11,7 +11,7 @@ _unace()
         if ((cword == 1)); then
             COMPREPLY=($(compgen -W 'e l t v x' -- "$cur"))
         else
-            _filedir ace
+            _filedir '@(ace|cba)'
         fi
     fi
 } &&

--- a/completions/unrar
+++ b/completions/unrar
@@ -13,7 +13,7 @@ _unrar()
         if ((cword == 1)); then
             COMPREPLY=($(compgen -W 'e l lb lt p t v vb vt x' -- "$cur"))
         else
-            _filedir '@(rar|exe)'
+            _filedir '@(rar|exe|cbr)'
         fi
     fi
 


### PR DESCRIPTION
Comic book archives¹ are simply archive files containing images.  While
they are typically treated as e-books and fed to programs that can
handle those, they are also plain archive files and can therefore be
manipulated by the corresponding program.

 ¹ https://en.wikipedia.org/wiki/Comic_book_archive

The following file extension mappings are added:

    .cb7 → 7z
    .cba → unace
    .cbr → unrar
    .cbt → tar
    .cbz → unzip, zipinfo

(Note that .cbt files, unlike .tar files, are never compressed.)