### PR TITLE
[WIP] Implemented custom auto-completion for Makefiles [Feedback wanted]

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -157,18 +157,41 @@ _make()
             mode=-d # display-only mode
         fi
 
-        local IFS=$' \t\n' script=$(_make_target_extract_script $mode "$cur")
-        COMPREPLY=($(LC_ALL=C \
-            $1 -npq __BASH_MAKE_COMPLETION__=1 \
-            ${makef+"${makef[@]}"} "${makef_dir[@]}" .DEFAULT 2>/dev/null |
-            command sed -ne "$script"))
+        local use_fallback=yes
+        if [[ ${BASH_COMPLETION_MAKE_ENABLE_MAKEFILE_TARGET:=0} == 1 ]]; then
+            local makefile_targets exit_status
+
+            # Execute the makefile target and interpret the output as completion info
+            makefile_targets=$($1 -sS __BASH_MAKE_COMPLETION__=1 \
+                ${makef+"${makef[@]}"} "${makef_dir[@]}" \
+                ${BASH_COMPLETION_MAKE_MAKEFILE_TARGET:=.BASH-COMPLETION} 2>/dev/null)
+            exit_status=$?
+
+            if [[ $exit_status -eq 0 ]]; then
+                use_fallback=no
+
+                local prefix="$2"
+                local prefix_pat=$(command sed 's/[][\,.*^$(){}?+|/]/\\&/g' <<<"$prefix")
+                local filtered_output=$(command grep -E "^${prefix_pat}" <<<"${makefile_targets// /$'\n'}")
+                local IFS=$' \t\n'
+                COMPREPLY=($filtered_output)
+            fi
+        fi
+
+        if [[ $use_fallback == yes ]]; then
+            # Parse the output of "make -npq .DEFAULT" (or similar) command
+            local IFS=$' \t\n' script=$(_make_target_extract_script $mode "$cur")
+            COMPREPLY=($(LC_ALL=C \
+                $1 -npq __BASH_MAKE_COMPLETION__=1 \
+                ${makef+"${makef[@]}"} "${makef_dir[@]}" .DEFAULT 2>/dev/null |
+                command sed -ne "$script"))
+        fi
 
         if [[ $mode != -d ]]; then
             # Completion will occur if there is only one suggestion
             # so set options for completion based on the first one
             [[ ${COMPREPLY-} == */ ]] && compopt -o nospace
         fi
-
     fi
 } &&
     complete -F _make make gmake gnumake pmake colormake bmake


### PR DESCRIPTION
This pull request introduces the ability to have a custom Makefile target that generates auto-completion input for the bash shell.
With this feature it is possible to customize the completion list that is displayed in the shell.

The Makefile target returns a space and newline separated list of custom completion options.
Since the Makefile has full control over the returned list it can add custom build targets which are not directly specified as a Makefile target.
Because this might have some security implications - executing the Makefile target on auto-completion - the feature is disabled by default.

Configuration options:

- BASH_COMPLETION_MAKE_ENABLE_MAKEFILE_TARGET: Enables the feature (Default is "0")
- BASH_COMPLETION_MAKE_MAKEFILE_TARGET: Specifies Makefile target to execute (Default is ".BASH-COMPLETION")

Example Makefile which implements a static list:

```Makefile
.PHONY: .BASH-COMPLETION

.BASH-COMPLETION:
	@echo 'build/debug/AppA build/debug/AppB'
	@echo 'build/release/AppA build/release/AppB'

build/debug/%: %Main.c
	echo "Building $(@F) (Debug)"
	gcc -O1 -g -o $(@F) $^

build/release/%: %Main.c
	echo "Building $(@F) (Release)"
	gcc -O3 -o $(@F) $^
```

Example Makefile which implements an auto-generated list which is fed by bazel:

```Makefile
.PHONY: .BASH-COMPLETION

.BASH-COMPLETION:
	@$(eval $@_BAZEL_TARGETS := $(shell $(BAZEL) query 'kind(rule, //src:*)' 2>/dev/null))
	@$(eval $@_BAZEL_TESTS := $(shell $(BAZEL) query 'kind(rule, //test:*)' 2>/dev/null))
	@echo 'build/debug/* build/release/*'
	@echo 'test/debug/* test/release/*'
	@echo '$(subst //src:,build/debug/,$($@_BAZEL_TARGETS))'
	@echo '$(subst //src:,build/release/,$($@_BAZEL_TARGETS))'
	@echo '$(subst //test:,test/debug/,$($@_BAZEL_TESTS))'
	@echo '$(subst //test:,test/release/,$($@_BAZEL_TESTS))'

build/debug/%:
	echo "Building $(@F) (Debug)"
	bazel build --config=debug //src:$(@F)

build/release/%:
	echo "Building $(@F) (Release)"
	bazel build --config=release //src:$(@F)

test/debug/%:
	echo "Testing $(@F) (Debug)"
	bazel test --config=debug //test:$(@F)

test/release/%:
	echo "Testing $(@F) (Release)"
	bazel test --config=release //test:$(@F)
```

TODO:

- [ ] Add unit tests

Getting feedback if this feature makes sense and about the implementation would be nice.