### PR TITLE
Fix unintended command execution by "_quote_readline_by_ref"

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -552,10 +552,10 @@ _quote_readline_by_ref()
         # to drop the additional quoting.  See also:
         # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
         if [[ ${!2} == \$\'*\' ]]; then
-          local value=${!2:2:-1}   # Strip beginning $' and ending '.
-          value=${value//'%'/%%}   # Escape % for printf format.
-          printf -v value "$value" # Decode escape sequences of \....
-          local "$2" && _upvars -v "$2" "$value"
+            local value=${!2:2:-1}      # Strip beginning $' and ending '.
+            value=${value//'%'/%%}      # Escape % for printf format.
+            printf -v value %s "$value" # Decode escape sequences of \....
+            local "$2" && _upvars -v "$2" "$value"
         fi
     fi
 } # _quote_readline_by_ref()

--- a/bash_completion
+++ b/bash_completion
@@ -547,12 +547,17 @@ _quote_readline_by_ref()
         printf -v $2 %s "${1:1}"
     else
         printf -v $2 %q "$1"
-    fi
 
-    # If result becomes quoted like this: $'string', re-evaluate in order to
-    # drop the additional quoting.  See also:
-    # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
-    [[ ${!2} == \$* ]] && eval $2=${!2}
+        # If result becomes quoted like this: $'string', re-evaluate in order
+        # to drop the additional quoting.  See also:
+        # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
+        if [[ ${!2} == \$\'*\' ]]; then
+          local value=${!2:2:-1}   # Strip beginning $' and ending '.
+          value=${value//'%'/%%}   # Escape % for printf format.
+          printf -v value "$value" # Decode escape sequences of \....
+          local "$2" && _upvars -v "$2" "$value"
+        fi
+    fi
 } # _quote_readline_by_ref()
 
 # This function performs file and directory completion. It's better than

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -1,7 +1,6 @@
-import pytest
 import os
-import tempfile
-import re
+
+import pytest
 
 from conftest import assert_bash_exec
 
@@ -24,10 +23,10 @@ class TestUnitQuoteReadline:
 
         Syntax error messages should not be shown by completion on the
         following line:
-        
+
           $ ls -- '${[TAB]
           $ rm -- '${[TAB]
-        
+
         """
         assert_bash_exec(bash, "quote_readline $'\\'${' >/dev/null")
 
@@ -36,15 +35,17 @@ class TestUnitQuoteReadline:
 
         Reported at https://github.com/scop/bash-completion/pull/492
 
-        Arbitrary commands could be unintendedly executed by 
-        _quote_readline_by_ref.  In the following example, the command 
+        Arbitrary commands could be unintendedly executed by
+        _quote_readline_by_ref.  In the following example, the command
         "touch 1.txt" would be unintendedly created before the fix.  The file
         "1.txt" should not be created by completion on the following line:
-        
+
           $ echo '$(touch file.txt)[TAB]
 
         """
-        assert_bash_exec(bash, "quote_readline $'\\'$(touch 1.txt)' >/dev/null")
+        assert_bash_exec(
+            bash, "quote_readline $'\\'$(touch 1.txt)' >/dev/null"
+        )
         assert not os.path.exists("./1.txt")
 
     def test_github_issue_492_2(self, bash):
@@ -54,9 +55,9 @@ class TestUnitQuoteReadline:
 
         The file "1.0" should not be created by completion on the following
         line:
-        
+
           $ awk '$1 > 1.0[TAB]
-        
+
         """
         assert_bash_exec(bash, "quote_readline $'\\'$1 > 1.0' >/dev/null")
         assert not os.path.exists("./1.0")
@@ -67,25 +68,25 @@ class TestUnitQuoteReadline:
         When there is a file named "quote=$(COMMAND)" (for _filedir) or
         "ret=$(COMMAND)" (for quote_readline), the completion of the word '$*
         results in the execution of COMMAND.
-        
+
           $ echo '$*[TAB]
-    
+
         """
         os.mkdir("./ret=$(echo injected >&2)")
         assert_bash_exec(bash, "quote_readline $'\\'$*' >/dev/null")
 
+
 @pytest.mark.bashcomp(cmd=None, temp_cwd=True, pre_cmds=("shopt -s failglob",))
 class TestUnitQuoteReadlineWithFailglob:
-
     def test_github_issue_492_4(self, bash):
         """Test error messages through unintended pathname expansions
 
         When "shopt -s failglob" is set by the user, the completion of the word
         containing glob character and special characters (e.g. TAB) results in
         the failure of pathname expansions.
-        
+
           $ shopt -s failglob
           $ echo a\\	b*[TAB]
-        
+
         """
         assert_bash_exec(bash, "quote_readline $'a\\\\\\tb*' >/dev/null")

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -15,25 +15,33 @@ class TestUnitQuoteReadline:
             bash, "foo() { quote_readline meh >/dev/null; }; foo; unset foo"
         )
 
-    # https://github.com/scop/bash-completion/issues/189
-    # Syntax error messages should not be shown by completion on the following
-    # line:
-    #
-    #   $ ls -- '${[TAB]
-    #   $ rm -- '${[TAB]
-    #
     def test_github_issue_189_1(self, bash):
+        """Test error messages on a certain command line
+
+        Reported at https://github.com/scop/bash-completion/issues/189
+
+        Syntax error messages should not be shown by completion on the
+        following line:
+        
+          $ ls -- '${[TAB]
+          $ rm -- '${[TAB]
+        
+        """
         assert_bash_exec(bash, "quote_readline $'\\'${' >/dev/null")
 
-    # https://github.com/scop/bash-completion/pull/492
-    # Arbitrary commands could be unintendedly executed by 
-    # _quote_readline_by_ref.  In the following example, the command 
-    # "touch 1.txt" would be unintendedly created before the fix.  The file
-    # "1.txt" should not be created by completion on the following line:
-    #
-    #   $ echo '$(touch file.txt)[TAB]
-    #
     def test_github_issue_492_1(self, bash):
+        """Test unintended code execution on a certain command line
+
+        Reported at https://github.com/scop/bash-completion/pull/492
+
+        Arbitrary commands could be unintendedly executed by 
+        _quote_readline_by_ref.  In the following example, the command 
+        "touch 1.txt" would be unintendedly created before the fix.  The file
+        "1.txt" should not be created by completion on the following line:
+        
+          $ echo '$(touch file.txt)[TAB]
+
+        """
         if os.path.exists("1.txt"):
             os.remove("1.txt")
         assert_bash_exec(bash, "quote_readline $'\\'$(touch 1.txt)' >/dev/null")
@@ -41,12 +49,17 @@ class TestUnitQuoteReadline:
             os.remove("1.txt")
             assert False
 
-    # https://github.com/scop/bash-completion/pull/492
-    # The file "1.0" should not be created by completion on the following line:
-    #
-    #   $ awk '$1 > 1.0[TAB]
-    #
     def test_github_issue_492_2(self, bash):
+        """Test the file clear by unintended redirection on a certain command line
+
+        Reported at https://github.com/scop/bash-completion/pull/492
+
+        The file "1.0" should not be created by completion on the following
+        line:
+        
+          $ awk '$1 > 1.0[TAB]
+        
+        """
         if os.path.exists("1.0"):
             os.remove("1.0")
         assert_bash_exec(bash, "quote_readline $'\\'$1 > 1.0' >/dev/null")
@@ -54,13 +67,16 @@ class TestUnitQuoteReadline:
             os.remove("1.0")
             assert False
 
-    # When there is a file named "quote=$(COMMAND)" (for _filedir) or
-    # "ret=$(COMMAND)" (for quote_readline), the completion of the word '$*
-    # results in the execution of COMMAND.
-    #
-    #   $ echo '$*[TAB]
-    #
     def test_github_issue_492_3(self, bash):
+        """Test code execution through unintended pathname expansions
+
+        When there is a file named "quote=$(COMMAND)" (for _filedir) or
+        "ret=$(COMMAND)" (for quote_readline), the completion of the word '$*
+        results in the execution of COMMAND.
+        
+          $ echo '$*[TAB]
+    
+        """
         tmpfile = "ret=$(echo injected >&2)"
         with open(tmpfile, 'a'):
             os.utime(tmpfile, None)
@@ -68,12 +84,15 @@ class TestUnitQuoteReadline:
         if os.path.exists(tmpfile):
             os.remove(tmpfile)
 
-    # When "shopt -s failglob" is set by the user, the completion of the word
-    # containing glob character and special characters (e.g. TAB) results in
-    # the failure of pathname expansions.
-    #
-    #   $ shopt -s failglob
-    #   $ echo a\	b*[TAB]
-    #
     def test_github_issue_492_4(self, bash):
+        """Test error messages through unintended pathname expansions
+
+        When "shopt -s failglob" is set by the user, the completion of the word
+        containing glob character and special characters (e.g. TAB) results in
+        the failure of pathname expansions.
+        
+          $ shopt -s failglob
+          $ echo a\	b*[TAB]
+        
+        """
         assert_bash_exec(bash, "(shopt -s failglob;quote_readline $'a\\\\\\tb*' >/dev/null)")

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from conftest import assert_bash_exec
 
@@ -13,3 +14,66 @@ class TestUnitQuoteReadline:
         assert_bash_exec(
             bash, "foo() { quote_readline meh >/dev/null; }; foo; unset foo"
         )
+
+    # https://github.com/scop/bash-completion/issues/189
+    # Syntax error messages should not be shown by completion on the following
+    # line:
+    #
+    #   $ ls -- '${[TAB]
+    #   $ rm -- '${[TAB]
+    #
+    def test_github_issue_189_1(self, bash):
+        assert_bash_exec(bash, "quote_readline $'\\'${' >/dev/null")
+
+    # https://github.com/scop/bash-completion/pull/492
+    # Arbitrary commands could be unintendedly executed by 
+    # _quote_readline_by_ref.  In the following example, the command 
+    # "touch 1.txt" would be unintendedly created before the fix.  The file
+    # "1.txt" should not be created by completion on the following line:
+    #
+    #   $ echo '$(touch file.txt)[TAB]
+    #
+    def test_github_issue_492_1(self, bash):
+        if os.path.exists("1.txt"):
+            os.remove("1.txt")
+        assert_bash_exec(bash, "quote_readline $'\\'$(touch 1.txt)' >/dev/null")
+        if os.path.exists("1.txt"):
+            os.remove("1.txt")
+            assert False
+
+    # https://github.com/scop/bash-completion/pull/492
+    # The file "1.0" should not be created by completion on the following line:
+    #
+    #   $ awk '$1 > 1.0[TAB]
+    #
+    def test_github_issue_492_2(self, bash):
+        if os.path.exists("1.0"):
+            os.remove("1.0")
+        assert_bash_exec(bash, "quote_readline $'\\'$1 > 1.0' >/dev/null")
+        if os.path.exists("1.0"):
+            os.remove("1.0")
+            assert False
+
+    # When there is a file named "quote=$(COMMAND)" (for _filedir) or
+    # "ret=$(COMMAND)" (for quote_readline), the completion of the word '$*
+    # results in the execution of COMMAND.
+    #
+    #   $ echo '$*[TAB]
+    #
+    def test_github_issue_492_3(self, bash):
+        tmpfile = "ret=$(echo injected >&2)"
+        with open(tmpfile, 'a'):
+            os.utime(tmpfile, None)
+        assert_bash_exec(bash, "quote_readline $'\\'$*' >/dev/null")
+        if os.path.exists(tmpfile):
+            os.remove(tmpfile)
+
+    # When "shopt -s failglob" is set by the user, the completion of the word
+    # containing glob character and special characters (e.g. TAB) results in
+    # the failure of pathname expansions.
+    #
+    #   $ shopt -s failglob
+    #   $ echo a\	b*[TAB]
+    #
+    def test_github_issue_492_4(self, bash):
+        assert_bash_exec(bash, "(shopt -s failglob;quote_readline $'a\\\\\\tb*' >/dev/null)")

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -1,5 +1,7 @@
 import pytest
 import os
+import tempfile
+import re
 
 from conftest import assert_bash_exec
 
@@ -14,6 +16,13 @@ class TestUnitQuoteReadline:
         assert_bash_exec(
             bash, "foo() { quote_readline meh >/dev/null; }; foo; unset foo"
         )
+
+    def quote_bash_word(self, s):
+        return "$'" + re.sub(
+            r'[\\\'\000-\037]',
+            lambda m: r'\\' if m.group(0) == '\\'
+            else r'\'' if m.group(0) == "'"
+            else r'\%03o' % ord(m.group(0)), s) + "'"
 
     def test_github_issue_189_1(self, bash):
         """Test error messages on a certain command line
@@ -42,12 +51,9 @@ class TestUnitQuoteReadline:
           $ echo '$(touch file.txt)[TAB]
 
         """
-        if os.path.exists("1.txt"):
-            os.remove("1.txt")
-        assert_bash_exec(bash, "quote_readline $'\\'$(touch 1.txt)' >/dev/null")
-        if os.path.exists("1.txt"):
-            os.remove("1.txt")
-            assert False
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert_bash_exec(bash, "(cd %s; quote_readline $'\\'$(touch 1.txt)' >/dev/null)" % self.quote_bash_word(tmpdir))
+            assert not os.path.exists(os.path.join(tmpdir, "1.txt"))
 
     def test_github_issue_492_2(self, bash):
         """Test the file clear by unintended redirection on a certain command line
@@ -60,12 +66,9 @@ class TestUnitQuoteReadline:
           $ awk '$1 > 1.0[TAB]
         
         """
-        if os.path.exists("1.0"):
-            os.remove("1.0")
-        assert_bash_exec(bash, "quote_readline $'\\'$1 > 1.0' >/dev/null")
-        if os.path.exists("1.0"):
-            os.remove("1.0")
-            assert False
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert_bash_exec(bash, "(cd %s; quote_readline $'\\'$1 > 1.0' >/dev/null)" % self.quote_bash_word(tmpdir))
+            assert not os.path.exists(os.path.join(tmpdir, "1.0"))
 
     def test_github_issue_492_3(self, bash):
         """Test code execution through unintended pathname expansions
@@ -77,12 +80,9 @@ class TestUnitQuoteReadline:
           $ echo '$*[TAB]
     
         """
-        tmpfile = "ret=$(echo injected >&2)"
-        with open(tmpfile, 'a'):
-            os.utime(tmpfile, None)
-        assert_bash_exec(bash, "quote_readline $'\\'$*' >/dev/null")
-        if os.path.exists(tmpfile):
-            os.remove(tmpfile)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(os.path.join(tmpdir, "ret=$(echo injected >&2)"))
+            assert_bash_exec(bash, "(cd %s; quote_readline $'\\'$*' >/dev/null)" % self.quote_bash_word(tmpdir))
 
     def test_github_issue_492_4(self, bash):
         """Test error messages through unintended pathname expansions
@@ -92,7 +92,8 @@ class TestUnitQuoteReadline:
         the failure of pathname expansions.
         
           $ shopt -s failglob
-          $ echo a\	b*[TAB]
+          $ echo a\\	b*[TAB]
         
         """
-        assert_bash_exec(bash, "(shopt -s failglob;quote_readline $'a\\\\\\tb*' >/dev/null)")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            assert_bash_exec(bash, "(cd %s; shopt -s failglob; quote_readline $'a\\\\\\tb*' >/dev/null)" % self.quote_bash_word(tmpdir))


### PR DESCRIPTION
`_quote_readline_by_ref` in `bash_completion` has a problem similar to the code injection vulnerability. This PR solves the problem.

**Edit** (2021-03-16): There was already a related issue #189, so let me mark as [ Fix #189 ].

### Repeat-By

Here I describe a simple reproducer. With the following operation, a command `touch file` is unintendedly executed inside the completion function.

```bash
$ bash --rcfile bash_completion.sh
$ echo '$(touch file)[TAB]
```

In the above code block, `[TAB]` represents pressing <kbd>TAB</kbd> key. When <kbd>TAB</kbd> is pressed, the command `touch file` is executed, which can be confirmed by an unintended new file `file`.

For a more practical example (in which I noticed this problem), a file named `0.0` is created by the following operation:

```bash
awk '$1 > 0.0[TAB]
```

### Investigation

This is caused by the implementation of the function `_quote_readline_by_ref`:

```bash
_quote_readline_by_ref()
{
    if [[ $1 == \'* ]]; then
        # Leave out first character
        printf -v $2 %s "${1:1}"
    else
        printf -v $2 %q "$1"
    fi

    # If result becomes quoted like this: $'string', re-evaluate in order to
    # drop the additional quoting.  See also:
    # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
    [[ ${!2} == \$* ]] && eval $2=${!2}
} # _quote_readline_by_ref()
```

When the completed word has the form `'$...`, a command `cur=$...` is executed. First, inside the completion function, `_quote_readline_by_ref` is called in the following ways:

```bash
_quote_readline_by_ref "'\$(touch file)" cur
_quote_readline_by_ref "'\$1 > 0.0" cur
```

Then, after the first `printf %s` in `_quote_readline_by_ref`, the variable `cur` has the value such like `$(touch file)` or `$1 > 0.0`. Finally, in the last line of `_quote_readline_by_ref`, `cur=$(touch file)` or `cur=$1 > 0.0` is executed.

### Fix

As described in the code comment, the purpose of the last line `[[ ${!2} == \$* ]] && eval $2=${!2}` seems to be the removal of the additional quote of the form `$'string'` which would be only resulted from `printf %q`. Here, I suggest moving the last line inside the `if` statement so that the additional quote removal is only performed for the result of `printf %q`.

Thank you!
