### PR TITLE
screen: Match all files in directories under /dev/serial

### DIFF
--- a/completions/screen
+++ b/completions/screen
@@ -30,7 +30,7 @@ _screen_sessions()
                 COMPREPLY=($(compgen -W "$(
                     shopt -s nullglob
                     printf '%s\n' \
-                        /dev/serial/by-id/* /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
+                        /dev/serial/*/* /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
                 )" \
                     -- "$cur"))
                 return


### PR DESCRIPTION
The original rule didn't complete from `/dev/serial/by-id/`.

It also makes sense to complete from any other directory under `/dev/serial`, as that's a logical place for custom udev rules to add symlinks for meaningful device names.