### PR TITLE
_known_hosts_real: look up _ssh._tcp from avahi, too

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1848,14 +1848,12 @@ _known_hosts_real()
     # Add hosts reported by avahi-browse, if desired and it's available.
     if [[ ${COMP_KNOWN_HOSTS_WITH_AVAHI-} ]] &&
         type avahi-browse &>/dev/null; then
-        # The original call to avahi-browse also had "-k", to avoid lookups
-        # into avahi's services DB. We don't need the name of the service, and
-        # if it contains ";", it may mistify the result. But on Gentoo (at
-        # least), -k wasn't available (even if mentioned in the manpage) some
-        # time ago, so...
+        # Some old versions of avahi-browse reportedly didn't have -k
+        # (even if mentioned in the manpage); those we do not support any more.
         COMPREPLY+=($(compgen -P "$prefix" -S "$suffix" -W \
-            "$(avahi-browse -cpr _workstation._tcp 2>/dev/null |
-                awk -F';' '/^=/ { print $7 }' | sort -u)" -- "$cur"))
+            "$(avahi-browse -cprak 2>/dev/null | awk -F';' \
+                '/^=/ && $5 ~ /^_(ssh|workstation)\._tcp$/ { print $7 }' |
+                sort -u)" -- "$cur"))
     fi
 
     # Add hosts reported by ruptime.


### PR DESCRIPTION
As a side effect, we no longer support avahi-browse versions without -k.

Closes https://github.com/scop/bash-completion/issues/497