### PR TITLE
Cygwin and MSYS compat for _ncpus

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1093,7 +1093,7 @@ _available_interfaces()
 _ncpus()
 {
     local var=NPROCESSORS_ONLN
-    [[ $OSTYPE == *linux* ]] && var=_$var
+    [[ $OSTYPE == *linux* || $OSTYPE == *msys* || $OSTYPE == *cygwin* ]] && var=_$var
     local n=$(getconf $var 2>/dev/null)
     printf %s ${n:-1}
 }

--- a/bash_completion
+++ b/bash_completion
@@ -1093,7 +1093,7 @@ _available_interfaces()
 _ncpus()
 {
     local var=NPROCESSORS_ONLN
-    [[ $OSTYPE == *linux* || $OSTYPE == *msys* || $OSTYPE == *cygwin* ]] && var=_$var
+    [[ $OSTYPE == *@(linux|msys|cygwin)* ]] && var=_$var
     local n=$(getconf $var 2>/dev/null)
     printf %s ${n:-1}
 }


### PR DESCRIPTION
Cygwin and MSYS2(including Git-for-Windows and MinGW64/32) respectively set `$OSTYPE` to `cygwin` and `msys`, so the current implementation of `_ncpus` calls `getconf NPROCESSORS_ONLN` when using either. However, for both cases, `getconf` only recognizes `_NPROCESSORS_ONLN`, not `NPROCESSORS_ONLN`. This simple change just makes the existing behavior for systems where `$OSTYPE` matches `*linux*` also apply to systems matching the corresponding values for Cygwin and MSYS2.
I did have someone with a Mac check what `getconf` would recognize on their machine, in case `$OSTYPE == *darwin*` should also be included, but oddly it succeeds and returns the same value for both variable names, so I don't know if there's merit in doing anything more.
