### PR TITLE
Make configure fall back to bashdefault and default

### DIFF
--- a/completions/configure
+++ b/completions/configure
@@ -37,6 +37,6 @@ _configure()
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
-    complete -F _configure configure
+    complete -o bashdefault -o default -F _configure configure
 
 # ex: filetype=sh


### PR DESCRIPTION
This is necessary for some configure scripts where the --help
of the configure doesn't describe option arguments accurately.
Qt, for instance, has a configure script where -android-sdk is followed
by a path. The path is not completed because this script doesn't know
how to do that, and this fallback makes it work. It seems reasonable
in general to fall back on default completions if option completions
didn't work.