### PR TITLE
Fix install of declare completion

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -77,6 +77,7 @@ bashcomp_DATA = 2to3 \
 		cvs \
 		cvsps \
 		dd \
+		declare \
 		deja-dup \
 		desktop-file-validate \
 		dhclient \


### PR DESCRIPTION
After https://github.com/scop/bash-completion/commit/3671cee9e0f9981b3452f1d7b459a6f3b0b2f6a2 the `declare` completion and its links were not getting installed.