### PR TITLE
feat(jq): add support for all options, and fix --from-file

### DIFF
--- a/completions/jq
+++ b/completions/jq
@@ -35,7 +35,25 @@ _jq()
         esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        # Get jq's --help output and see whether it mentions --help
+        # jq's --help only shows some of its command-line options; some are not
+        # even listed in the man page!
+        local help_output=$("$1" --help 2>/dev/null)
+
+        if [[ $help_output == *--help* ]]; then
+            # If the output of --help seems complete, use it
+            COMPREPLY=($(compgen -W \
+                '$(printf "%s" "$help_output" | _parse_help -)' -- "$cur"))
+        else
+            # Otherwise, use a hard-coded list of known flags, some of which do
+            # not appear in the output of --help as of jq 1.6.
+            COMPREPLY=($(compgen -W '--version --seq --stream --slurp
+                --raw-input --null-input --compact-output --tab --indent
+                --color-output -monochrome-output --ascii-output --unbuffered
+                --sort-keys --raw-output --join-output --from-file --exit-status
+                --arg --argjson --slurpfile --rawfile --argfile --args
+                --jsonargs --run-tests --help' -- "$cur"))
+        fi
         return
     fi
 


### PR DESCRIPTION
The options are not all listed by --help, so look in the man page to find a
nearly complete list (I hope!). Neither the man page nor --help mentions --help
or --version; I have not looked elsewhere to see if there might be yet more.

The treatment of -f|--from-file was incorrect: that option’s argument is the
filter, so the argument should be counted towards the total number of arguments
so far. Hence, remove --from-file from the list of options whose argument is
counted as an option.