### PR TITLE
feat(__load_completion): don't hush errors or output when sourcing files

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2287,7 +2287,9 @@ __load_completion()
         for compfile in "$cmd" "$cmd.bash" "_$cmd"; do
             compfile="$dir/$compfile"
             # Avoid trying to source dirs; https://bugzilla.redhat.com/903540
-            if [[ -f $compfile ]] && . "$compfile" &>/dev/null; then
+            if [[ -d $compfile ]]; then
+                echo "bash_completion: $compfile: is a directory" >&2
+            elif [[ -e $compfile ]] && . "$compfile"; then
                 [[ $backslash ]] && $(complete -p "$cmd") "\\$cmd"
                 return 0
             fi


### PR DESCRIPTION
We follow the message recent bash would output when sourcing a dir
without letting bash to do it; doing so avoids fd leaks on some older
but still supported bash versions. Other than that, let all output from
sourcing the file pass through to ease debugging.

Closes https://github.com/scop/bash-completion/issues/506