### PR TITLE
cvs: added support for 'cvs status' completions

### DIFF
--- a/completions/cvs
+++ b/completions/cvs
@@ -268,7 +268,7 @@ _cvs()
         cvsroot)
             _cvs_roots
             ;;
-        diff | log)
+        diff | log | status)
             if [[ $cur == -* ]]; then
                 _cvs_command_options "$1" $mode
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/test/t/test_cvs.py
+++ b/test/t/test_cvs.py
@@ -18,3 +18,24 @@ class TestCvs:
     @pytest.mark.complete("cvs -", require_cmd=True)
     def test_4(self, completion):
         assert completion
+
+    @pytest.mark.complete("cvs update -AdP foo/", cwd="cvs")
+    def test_5(self, completion):
+        assert completion == "bar"
+
+    @pytest.mark.complete("cvs log -v foo/", cwd="cvs")
+    def test_6(self, completion):
+        assert completion == "bar"
+
+    @pytest.mark.complete("cvs diff foo/", cwd="cvs")
+    def test_7(self, completion):
+        assert completion == "bar"
+
+    @pytest.mark.complete("cvs status -v foo/", cwd="cvs")
+    def test_8(self, completion):
+        assert completion == "bar"
+
+    @pytest.mark.complete("cvs status foo/", cwd="cvs")
+    def test_9(self, completion):
+        assert completion == "bar"
+


### PR DESCRIPTION
I noticed 'cvs status' commands were not completing correctly. This change adds the 'status' command to the 'diff' and 'log' command cases. It is very similar to this pull:

https://github.com/scop/bash-completion/pull/194

I also added a few test cases. Thank you!
