### PR TITLE
conftest: set HISTFILE=/dev/null in order not to affect user's history

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -191,6 +191,7 @@ def bash(request) -> pexpect.spawn:
             INPUTRC="%s/config/inputrc" % testdir,
             TERM="dumb",
             LC_COLLATE="C",  # to match Python's default locale unaware sort
+            HISTFILE="/dev/null", # not to break the user's history file
         )
     )
 

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -192,7 +192,7 @@ def bash(request) -> pexpect.spawn:
             TERM="dumb",
             LC_COLLATE="C",  # to match Python's default locale unaware sort
             HISTFILE="/dev/null",  # to leave user's history file alone
-         )
+        )
     )
 
     fixturesdir = os.path.join(testdir, "fixtures")

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -191,8 +191,8 @@ def bash(request) -> pexpect.spawn:
             INPUTRC="%s/config/inputrc" % testdir,
             TERM="dumb",
             LC_COLLATE="C",  # to match Python's default locale unaware sort
-            HISTFILE="/dev/null", # not to break the user's history file
-        )
+            HISTFILE="/dev/null",  # to leave user's history file alone
+         )
     )
 
     fixturesdir = os.path.join(testdir, "fixtures")


### PR DESCRIPTION
After running `make check` or `cd test/t; pytest-3 ...`, my command histories in `~/.bash_history` were washed out. I believe we should set `HISTFILE=/dev/null` in `conftest.py` not to affect the users's history.

This time I didn't add the test for this behavior. If you think we need to add tests for tests, please let me know.

**Edit**: Resolve #321