### PR TITLE
Fix the printf unescaping in "_quote_readline_by_ref"

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -554,7 +554,8 @@ _quote_readline_by_ref()
         if [[ ${!2} == \$\'*\' ]]; then
             local value=${!2:2:-1}      # Strip beginning $' and ending '.
             value=${value//'%'/%%}      # Escape % for printf format.
-            printf -v value %s "$value" # Decode escape sequences of \....
+            # shellcheck disable=SC2059
+            printf -v value "$value"    # Decode escape sequences of \....
             local "$2" && _upvars -v "$2" "$value"
         fi
     fi

--- a/bash_completion
+++ b/bash_completion
@@ -552,10 +552,10 @@ _quote_readline_by_ref()
         # to drop the additional quoting.  See also:
         # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
         if [[ ${!2} == \$\'*\' ]]; then
-            local value=${!2:2:-1}      # Strip beginning $' and ending '.
-            value=${value//'%'/%%}      # Escape % for printf format.
+            local value=${!2:2:-1} # Strip beginning $' and ending '.
+            value=${value//'%'/%%} # Escape % for printf format.
             # shellcheck disable=SC2059
-            printf -v value "$value"    # Decode escape sequences of \....
+            printf -v value "$value" # Decode escape sequences of \....
             local "$2" && _upvars -v "$2" "$value"
         fi
     fi

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -511,7 +511,7 @@ def assert_complete(
         bash.send(cmd + "\t")
         # Sleep a bit if requested, to avoid `.*` matching too early
         time.sleep(kwargs.get("sleep_after_tab", 0))
-        bash.expect_exact(cmd)
+        bash.expect_exact(kwargs.get("rendered_cmd", cmd))
         bash.send(MAGIC_MARK)
         got = bash.expect(
             [

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -93,7 +93,13 @@ class TestUnitQuoteReadline:
         os.mkdir("./alpha\tbeta")
         assert (
             assert_complete(
-                bash, "echo alpha\\\026\tb", rendered_cmd="echo alpha\\   b"
+                # Remark on "rendered_cmd": Bash aligns the last character 'b'
+                # in the rendered cmd to an "8 x n" boundary using spaces.
+                # Here, the command string is assumed to start from column 2
+                # because the width of PS1 (conftest.PS1 = '/@') is 2,
+                bash,
+                "echo alpha\\\026\tb",
+                rendered_cmd="echo alpha\\   b",
             )
             == "eta/"
         )

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -76,7 +76,7 @@ class TestUnitQuoteReadline:
         assert_bash_exec(bash, "quote_readline $'\\'$*' >/dev/null")
 
     def test_github_issue_526_1(self, bash):
-        """Regression tests for unprocessed escape sequences after quotes
+        r"""Regression tests for unprocessed escape sequences after quotes
 
         Ref [1] https://github.com/scop/bash-completion/pull/492#discussion_r637213822
         Ref [2] https://github.com/scop/bash-completion/pull/526
@@ -91,7 +91,13 @@ class TestUnitQuoteReadline:
 
         """
         os.mkdir("./alpha\tbeta")
-        assert assert_complete(bash, "echo alpha\\\026\tb", rendered_cmd="echo alpha\\   b") == "eta/"
+        assert (
+            assert_complete(
+                bash, "echo alpha\\\026\tb", rendered_cmd="echo alpha\\   b"
+            )
+            == "eta/"
+        )
+
 
 @pytest.mark.bashcomp(cmd=None, temp_cwd=True, pre_cmds=("shopt -s failglob",))
 class TestUnitQuoteReadlineWithFailglob:


### PR DESCRIPTION
This is the PR for the fix discussed in the conversation https://github.com/scop/bash-completion/pull/492#discussion_r637213822. We want to revert the following change:

```diff
-          printf -v value "$value" # Decode escape sequences of \....
+            printf -v value %s "$value" # Decode escape sequences of \....
```


I have included the tests along with the fix.

### conftest.py (52814dd4): add an optional argument `rendered_cmd`

Because I need to make a test that involves a TAB character in the filenames, I would like to add this new argument to support command lines in which the actual input sequence and the result rendered to the terminal are different. For example, suppose we think about a command-line string `"echo alpha\\\tb"`:

- A. Inputs from a keyboard would be `"echo alpha\\\026\tb"` i.e., <kbd>e c h o SP a l p h a \ C-v TAB b</kbd>
- B. The internal command-line string becomes `"echo alpha\\\tb"` i.e., <kbd>e c h o SP a l p h a \ TAB b</kbd>
- C. Bash renders the command in the terminal as `"/@echo alpha\\   b"` i.e. <kbd>/ @ e c h o SP a l p h a \ SP SP SP b</kbd> where `/@` is the prompt.

The current problem of the testing framework is that it assumes that `A == C` and just performs `bash.expect_exact` for the input string A. In this commit, I allow users to optionally specify C through the named argument `rendered_cmd="..."`. As I'm not a native English speaker, I don't have a good sense of choosing the argument name. If you have a better idea for the name of the new argument, could you please specify it?

### unit/test_quote_readline.py (608badfa): add a failing test

This tests the completion results for `"echo alpha\\\tb"`.

### bash_completion (ab583900): fix `_quote_readline_by_ref`

This is the suggested change of removing `%s` from `printf`.


