### PR TITLE
test: detect unexpected OLDPWD change

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -433,8 +433,9 @@ def diff_env(before: List[str], after: List[str], ignore: str):
         if not re.search(r"^(---|\+\+\+|@@ )", x)
         # Ignore variables expected to change:
         and not re.search(
-            "^[-+](_|PPID|BASH_REMATCH|_bash_completion_test_[a-zA-Z_0-9]*)=",
+            r"^[-+](_|PPID|BASH_REMATCH|_bash_completion_test_\w+)=",
             x,
+            re.ASCII,
         )
         # Ignore likely completion functions added by us:
         and not re.search(r"^\+declare -f _.+", x)

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -410,7 +410,10 @@ def diff_env(before: List[str], after: List[str], ignore: str):
         # Remove unified diff markers:
         if not re.search(r"^(---|\+\+\+|@@ )", x)
         # Ignore variables expected to change:
-        and not re.search("^[-+](_|PPID|BASH_REMATCH|OLDPWD)=", x)
+        and not re.search(
+            "^[-+](_|PPID|BASH_REMATCH|_bash_completion_test_[a-zA-Z_0-9]*)=",
+            x,
+        )
         # Ignore likely completion functions added by us:
         and not re.search(r"^\+declare -f _.+", x)
         # ...and additional specified things:
@@ -496,6 +499,11 @@ def assert_complete(
             pytest.xfail(xfail)
     cwd = kwargs.get("cwd")
     if cwd:
+        assert_bash_exec(
+            bash,
+            "if [[ ${OLDPWD+set} ]]; then _bash_completion_test_OLDPWD=$OLDPWD; else unset -v _bash_completion_test_OLDPWD; fi",
+            want_output=None,
+        )
         assert_bash_exec(bash, "cd '%s'" % cwd)
     env_prefix = "_BASHCOMP_TEST_"
     env = kwargs.get("env", {})
@@ -560,6 +568,11 @@ def assert_complete(
             )
         if cwd:
             assert_bash_exec(bash, "cd - >/dev/null")
+            assert_bash_exec(
+                bash,
+                "if [[ ${_bash_completion_test_OLDPWD+set} ]]; then OLDPWD=$_bash_completion_test_OLDPWD; else unset -v OLDPWD; fi",
+                want_output=None,
+            )
     return result
 
 

--- a/test/t/test_evince.py
+++ b/test/t/test_evince.py
@@ -1,17 +1,12 @@
-import shlex
-from pathlib import Path
-from typing import List, Tuple
-
 import pytest
 
-from conftest import assert_bash_exec, assert_complete, prepare_fixture_dir
+from conftest import assert_complete, create_dummy_filedirs
 
 
+@pytest.mark.bashcomp(temp_cwd=True)
 class TestEvince:
-    @pytest.fixture(scope="class")
-    def setup_fixture(self, request) -> Tuple[Path, List[str], List[str]]:
-        return prepare_fixture_dir(
-            request,
+    def test_1(self, bash):
+        files, dirs = create_dummy_filedirs(
             (
                 ".bmp .BMP .cbr .CBR .cbz .CBZ .djv .DJV .djvu .DJVU .dvi "
                 ".DVI .dvi.bz2 .dvi.BZ2 .DVI.bz2 .DVI.BZ2 .dvi.gz .dvi.GZ "
@@ -27,15 +22,7 @@ class TestEvince:
             "foo".split(),
         )
 
-    def test_1(self, bash, setup_fixture):
-        fixture_dir, files, dirs = setup_fixture
-
-        assert_bash_exec(bash, "cd %s" % shlex.quote(str(fixture_dir)))
-        try:
-            completion = assert_complete(bash, "evince ")
-        finally:
-            assert_bash_exec(bash, "cd -", want_output=None)
-
+        completion = assert_complete(bash, "evince ")
         assert completion == [
             x
             for x in sorted(files + ["%s/" % d for d in dirs])

--- a/test/t/test_kdvi.py
+++ b/test/t/test_kdvi.py
@@ -1,17 +1,12 @@
-import shlex
-from pathlib import Path
-from typing import List, Tuple
-
 import pytest
 
-from conftest import assert_bash_exec, assert_complete, prepare_fixture_dir
+from conftest import assert_complete, create_dummy_filedirs
 
 
+@pytest.mark.bashcomp(temp_cwd=True)
 class TestKdvi:
-    @pytest.fixture(scope="class")
-    def setup_fixture(self, request) -> Tuple[Path, List[str], List[str]]:
-        return prepare_fixture_dir(
-            request,
+    def test_1(self, bash):
+        files, dirs = create_dummy_filedirs(
             (
                 ".dvi .DVI .dvi.bz2 .DVI.bz2 .dvi.gz .DVI.gz .dvi.Z .DVI.Z "
                 ".txt"
@@ -19,15 +14,7 @@ class TestKdvi:
             "foo".split(),
         )
 
-    def test_1(self, bash, setup_fixture):
-        fixture_dir, files, dirs = setup_fixture
-
-        assert_bash_exec(bash, "cd %s" % shlex.quote(str(fixture_dir)))
-        try:
-            completion = assert_complete(bash, "kdvi ")
-        finally:
-            assert_bash_exec(bash, "cd -", want_output=None)
-
+        completion = assert_complete(bash, "kdvi ")
         assert completion == [
             x
             for x in sorted(files + ["%s/" % d for d in dirs])

--- a/test/t/test_kpdf.py
+++ b/test/t/test_kpdf.py
@@ -1,30 +1,17 @@
-import shlex
-from pathlib import Path
-from typing import List, Tuple
-
 import pytest
 
-from conftest import assert_bash_exec, assert_complete, prepare_fixture_dir
+from conftest import assert_complete, create_dummy_filedirs
 
 
+@pytest.mark.bashcomp(temp_cwd=True)
 class TestKpdf:
-    @pytest.fixture(scope="class")
-    def setup_fixture(self, request) -> Tuple[Path, List[str], List[str]]:
-        return prepare_fixture_dir(
-            request,
+    def test_1(self, bash):
+        files, dirs = create_dummy_filedirs(
             ".eps .EPS .pdf .PDF .ps .PS .txt".split(),
             "foo".split(),
         )
 
-    def test_1(self, bash, setup_fixture):
-        fixture_dir, files, dirs = setup_fixture
-
-        assert_bash_exec(bash, "cd %s" % shlex.quote(str(fixture_dir)))
-        try:
-            completion = assert_complete(bash, "kpdf ")
-        finally:
-            assert_bash_exec(bash, "cd -", want_output=None)
-
+        completion = assert_complete(bash, "kpdf ")
         assert completion == [
             x
             for x in sorted(files + ["%s/" % d for d in dirs])

--- a/test/t/test_man.py
+++ b/test/t/test_man.py
@@ -1,6 +1,12 @@
 import pytest
 
-from conftest import assert_bash_exec, assert_complete, prepare_fixture_dir
+from conftest import (
+    assert_bash_exec,
+    assert_complete,
+    bash_restore_variable,
+    bash_save_variable,
+    prepare_fixture_dir,
+)
 
 
 @pytest.mark.bashcomp(
@@ -103,15 +109,12 @@ class TestMan:
 
     @pytest.mark.complete(require_cmd=True)
     def test_10(self, request, bash, colonpath):
-        assert_bash_exec(
-            bash,
-            'manpath=${MANPATH-}; export MANPATH="%s:%s/man"'
-            % (TestMan.manpath, colonpath),
+        bash_save_variable(
+            bash, "MANPATH", "%s:%s/man" % (TestMan.manpath, colonpath)
         )
-        request.addfinalizer(
-            lambda: assert_bash_exec(bash, "MANPATH=$manpath")
-        )
+        assert_bash_exec(bash, "export MANPATH")
         completion = assert_complete(bash, "man Bash::C")
+        bash_restore_variable(bash, "MANPATH")
         assert completion == "ompletion"
 
     @pytest.mark.complete("man -", require_cmd=True)

--- a/test/t/test_tar.py
+++ b/test/t/test_tar.py
@@ -13,10 +13,9 @@ class TestTar:
         if not re.search(r"\bGNU ", got):
             pytest.skip("Not GNU tar")
 
-    @pytest.mark.complete("tar ", pre_cmds=("shopt -s failglob",))
+    @pytest.mark.complete("tar ", shopt=dict(failglob=True))
     def test_1(self, bash, completion):
         assert completion
-        assert_bash_exec(bash, "shopt -u failglob")
 
     # Test "f" when mode is not as first option
     @pytest.mark.complete("tar zfc ", cwd="tar")

--- a/test/t/unit/test_unit_known_hosts_real.py
+++ b/test/t/unit/test_unit_known_hosts_real.py
@@ -143,6 +143,10 @@ class TestUnitKnownHostsReal:
         assert_bash_exec(
             bash, 'OLDHOME="$HOME"; HOME="%s/_known_hosts_real"' % bash.cwd
         )
+        assert_bash_exec(
+            bash,
+            "if [[ ${OLDPWD+set} ]]; then _bash_completion_test_OLDPWD=$OLDPWD; else unset -v _bash_completion_test_OLDPWD; fi",
+        )
         output = assert_bash_exec(
             bash,
             "cd _known_hosts_real; "
@@ -151,6 +155,10 @@ class TestUnitKnownHostsReal:
             r'printf "%s\n" "${COMPREPLY[@]}"; '
             "cd - &>/dev/null",
             want_output=True,
+        )
+        assert_bash_exec(
+            bash,
+            "if [[ ${_bash_completion_test_OLDPWD+set} ]]; then OLDPWD=$_bash_completion_test_OLDPWD; else unset -v OLDPWD; fi",
         )
         assert_bash_exec(bash, 'HOME="$OLDHOME"')
         completion = sorted(set(output.strip().split()))


### PR DESCRIPTION
> *From https://github.com/scop/bash-completion/pull/492#issuecomment-845807416*
> > Changing `OLDPWD` isn't "allowed", changes in its value are just expected as tests may `cd` around. We could remove the special treatment for it if someone wants to land work to make that happen. `pushd` and `popd` could be an alternative.
>
> OK. If it is not too hard, maybe I'll do that after this PR is settled.

I made changes for this one. There were three places where `cd` was used to change the working directory for tests. I separated them into two commits.

### 1. kdvi, kpdf, evince (a22afe02): Use `temp_cwd` (with refactoring `prepare_fixture_dir` -> `create_dummy_filedirs` for dummy files)

One place is the `cd` into the directory created by `prepare_fixture_dir`, which was used in `test_{kdvi,kpdf,evince}`. I changed these tests to use the temporary directory created by `temp_cwd` to reduce the places `cd` is called. Now `test_{kdvi,kpdf,evince}` don't need to change and restore directories by themselves. The dummy files and directories are now created by a new function `create_dummy_filedirs`, which is a refactored version of `prepare_fixture_dir`.

I thought maybe I should apply the same prefix of the temporary directories to `temp_cwd` as `prepare_fixture_dir` but found that it is already applied in `macos-ci` branch 41c6fb8d, so skipped it this time.

I also noticed that the ordering of dummy-file creation and dummy-directory creation was changed on 328287d3, so I followed that ordering in the new `create_dummy_filedirs`.

### 2. conftest (013140cb): save/restore OLDPWD

> `pushd` and `popd` could be an alternative.

The second place is `assert_complete` (`conftest.py`). I tried `pushd` and `popd`, but they turned out to change `OLDPWD` too. So I decided to just continue to use the plain `cd` but save and restore the value of `OLDPWD` in another variable.

The third place is `test/t/unit/test_unit_known_hosts_real.py` where one test `test_no_globbing` is performed in the directory `test/fixtures/_known_hosts_real`. I directly modified this test to save/restore `OLDPWD`.

