### PR TITLE
completions: invoke "cd" as "builtin cd"

### DIFF
--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -38,14 +38,14 @@ _mount()
             ;;
         -L)
             COMPREPLY=($(
-                cd "/dev/disk/by-label/" 2>/dev/null || return
+                command cd "/dev/disk/by-label/" 2>/dev/null || return
                 compgen -f -- "$cur"
             ))
             return
             ;;
         -U)
             COMPREPLY=($(
-                cd "/dev/disk/by-uuid/" 2>/dev/null || return
+                command cd "/dev/disk/by-uuid/" 2>/dev/null || return
                 compgen -f -- "$cur"
             ))
             return

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -86,7 +86,7 @@ _linux_fstab()
             local i
             for i in ${!COMPREPLY[*]}; do
                 [[ ${COMPREPLY[i]} == "$realcur"* ]] &&
-                    COMPREPLY+=($(cd "$dircur" 2>/dev/null &&
+                    COMPREPLY+=($(command cd "$dircur" 2>/dev/null &&
                         compgen -f -d -P "$dircur" \
                             -X "!${COMPREPLY[i]##"$dirrealcur"}" -- "$basecur"))
             done

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -86,7 +86,7 @@ _linux_fstab()
             local i
             for i in ${!COMPREPLY[*]}; do
                 [[ ${COMPREPLY[i]} == "$realcur"* ]] &&
-                    COMPREPLY+=($(command cd "$dircur" 2>/dev/null &&
+                    COMPREPLY+=($(command cd -- "$dircur" 2>/dev/null &&
                         compgen -f -d -P "$dircur" \
                             -X "!${COMPREPLY[i]##"$dirrealcur"}" -- "$basecur"))
             done

--- a/completions/feh
+++ b/completions/feh
@@ -27,13 +27,13 @@ _feh()
             fi
             local font_path
             # font_path="$(imlib2-config --prefix 2>/dev/null)/share/imlib2/data/fonts"
-            # COMPREPLY=( $(command cd "$font_path" 2>/dev/null; compgen -f \
+            # COMPREPLY=( $(command cd -- "$font_path" 2>/dev/null; compgen -f \
             #     -X "!*.@([tT][tT][fF])" -S / -- "$cur") )
             for ((i = ${#words[@]} - 1; i > 0; i--)); do
                 if [[ ${words[i]} == -@(C|-fontpath) ]]; then
                     font_path="${words[i + 1]}"
                     COMPREPLY+=($(
-                        command cd "$font_path" 2>/dev/null
+                        command cd -- "$font_path" 2>/dev/null
                         compgen -f \
                             -X "!*.@([tT][tT][fF])" -S / -- "$cur"
                     ))

--- a/completions/feh
+++ b/completions/feh
@@ -27,13 +27,13 @@ _feh()
             fi
             local font_path
             # font_path="$(imlib2-config --prefix 2>/dev/null)/share/imlib2/data/fonts"
-            # COMPREPLY=( $(cd "$font_path" 2>/dev/null; compgen -f \
+            # COMPREPLY=( $(command cd "$font_path" 2>/dev/null; compgen -f \
             #     -X "!*.@([tT][tT][fF])" -S / -- "$cur") )
             for ((i = ${#words[@]} - 1; i > 0; i--)); do
                 if [[ ${words[i]} == -@(C|-fontpath) ]]; then
                     font_path="${words[i + 1]}"
                     COMPREPLY+=($(
-                        cd "$font_path" 2>/dev/null
+                        command cd "$font_path" 2>/dev/null
                         compgen -f \
                             -X "!*.@([tT][tT][fF])" -S / -- "$cur"
                     ))

--- a/completions/removepkg
+++ b/completions/removepkg
@@ -16,7 +16,7 @@ _removepkg()
 
     local root=${ROOT:-/}
     COMPREPLY=($(
-        cd "$root/var/log/packages" 2>/dev/null || return 1
+        command cd "$root/var/log/packages" 2>/dev/null || return 1
         compgen -f -- "$cur"
     ))
 } &&

--- a/completions/removepkg
+++ b/completions/removepkg
@@ -16,7 +16,7 @@ _removepkg()
 
     local root=${ROOT:-/}
     COMPREPLY=($(
-        command cd "$root/var/log/packages" 2>/dev/null || return 1
+        command cd -- "$root/var/log/packages" 2>/dev/null || return 1
         compgen -f -- "$cur"
     ))
 } &&

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -66,7 +66,7 @@ _sbopkg()
             $REPO_ROOT/$REPO_NAME/$REPO_BRANCH/SLACKBUILDS.TXT
     )
     $(
-        command cd $QUEUEDIR
+        command cd -- $QUEUEDIR
         compgen -f -X "!*.sqf" -- "$cur"
     ))
 } &&

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -66,7 +66,7 @@ _sbopkg()
             $REPO_ROOT/$REPO_NAME/$REPO_BRANCH/SLACKBUILDS.TXT
     )
     $(
-        cd $QUEUEDIR
+        command cd $QUEUEDIR
         compgen -f -X "!*.sqf" -- "$cur"
     ))
 } &&

--- a/completions/slackpkg
+++ b/completions/slackpkg
@@ -63,7 +63,7 @@ _slackpkg()
         install-template | remove-template)
             if [[ -e $confdir/templates ]]; then
                 COMPREPLY=($(
-                    command cd "$confdir/templates"
+                    command cd -- "$confdir/templates"
                     compgen -f -X "!*.template" -- "$cur"
                 ))
                 COMPREPLY=(${COMPREPLY[@]%.template})

--- a/completions/slackpkg
+++ b/completions/slackpkg
@@ -63,7 +63,7 @@ _slackpkg()
         install-template | remove-template)
             if [[ -e $confdir/templates ]]; then
                 COMPREPLY=($(
-                    cd "$confdir/templates"
+                    command cd "$confdir/templates"
                     compgen -f -X "!*.template" -- "$cur"
                 ))
                 COMPREPLY=(${COMPREPLY[@]%.template})
@@ -75,7 +75,7 @@ _slackpkg()
             COMPREPLY+=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
                 xap xfce y' -- "$cur"))
             COMPREPLY+=($(
-                cd /var/log/packages
+                command cd /var/log/packages
                 compgen -f -- "$cur"
             ))
             return

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -70,7 +70,7 @@ _slapt_get()
             ;;
         ins) # --remove|--filelist
             COMPREPLY=($(
-                cd /var/log/packages
+                command cd /var/log/packages
                 compgen -f -- "$cur"
             ))
             return

--- a/test/runLint
+++ b/test/runLint
@@ -42,8 +42,8 @@ gitgrep $cmdstart'[ef]grep\b' \
 # TODO: $ in sed subexpression used as an anchor (POSIX BRE optional, not in
 #       Solaris/FreeBSD)
 
-gitgrep '(?<!command)'$cmdstart'(grep|ls|sed)(\s|$)' \
-    'invoke grep, ls, and sed through "command", e.g. "command grep"'
+gitgrep '(?<!command)'$cmdstart'(grep|ls|sed|cd)(\s|$)' \
+    'invoke grep, ls, sed, and cd through "command", e.g. "command grep"'
 
 gitgrep '<<<' 'herestrings use temp files, use some other way'
 

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -483,7 +483,7 @@ class bash_env_saved:
         if self.cwd:
             self._unprotect_variable("OLDPWD")
             assert_bash_exec(
-                self.bash, "command cd %s" % shlex.quote(str(self.cwd))
+                self.bash, "command cd -- %s" % shlex.quote(str(self.cwd))
             )
             self._protect_variable("OLDPWD")
             self.cwd = None
@@ -507,7 +507,7 @@ class bash_env_saved:
     def chdir(self, path: str):
         self._save_cwd()
         self._unprotect_variable("OLDPWD")
-        assert_bash_exec(self.bash, "command cd %s" % shlex.quote(path))
+        assert_bash_exec(self.bash, "command cd -- %s" % shlex.quote(path))
         self._protect_variable("OLDPWD")
 
     def shopt(self, name: str, value: bool):

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -482,7 +482,9 @@ class bash_env_saved:
         # variables because "cd" affects "OLDPWD".
         if self.cwd:
             self._unprotect_variable("OLDPWD")
-            assert_bash_exec(self.bash, "cd %s" % shlex.quote(str(self.cwd)))
+            assert_bash_exec(
+                self.bash, "command cd %s" % shlex.quote(str(self.cwd))
+            )
             self._protect_variable("OLDPWD")
             self.cwd = None
 
@@ -505,7 +507,7 @@ class bash_env_saved:
     def chdir(self, path: str):
         self._save_cwd()
         self._unprotect_variable("OLDPWD")
-        assert_bash_exec(self.bash, "cd %s" % shlex.quote(path))
+        assert_bash_exec(self.bash, "command cd %s" % shlex.quote(path))
         self._protect_variable("OLDPWD")
 
     def shopt(self, name: str, value: bool):


### PR DESCRIPTION
In searching the uses of `cd` command in completions, I found that `cd` is directly called instead of through `builtin cd`. The builtin `cd` is one of the commands that users define an alias or a function (to save the visited directory, etc.). I suggest prefixing them with `builtin` keyword.

I searched for the policy of `bash-completion` on this kind of treatment and found in `CONTRIBUTING.md` the following item:

> - Use printf(1) instead of echo(1) for portability reasons, and be sure to invoke commands that are often found aliased (such as ls or grep etc) using the `command` (or `builtin`) command as appropriate.

So I think we should also apply this rule to `cd` builtin. (By the way, I found that so far no builtin commands have been prefixed by `builtin` in any completions, so `cd` is the first one).

I have also added a rule to `test/runLint`. There are a few false positives, and many `cd` in test codes. If we should also prefix `cd` in test codes, please let me know. Then, I will add them.

