### PR TITLE
test(man): fix skip failure of `test_10`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2369,8 +2369,12 @@ fi
 unset compat_dir i _blacklist_glob
 
 # source user completion file
+#
+# Remark: We explicitly check that $user_completion is not '/dev/null' since
+#   /dev/null may be a regular file in broken systems and can contain arbitrary
+#   garbages of suppressed command outputs.
 user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
-[[ ${BASH_SOURCE[0]} != "$user_completion" && -r $user_completion && -f $user_completion ]] &&
+[[ $user_completion != "${BASH_SOURCE[0]}" && $user_completion != /dev/null && -r $user_completion && -f $user_completion ]] &&
     . $user_completion
 unset user_completion
 

--- a/test/t/test_man.py
+++ b/test/t/test_man.py
@@ -4,6 +4,7 @@ from conftest import (
     assert_bash_exec,
     assert_complete,
     bash_env_saved,
+    is_bash_type,
     prepare_fixture_dir,
 )
 
@@ -105,8 +106,9 @@ class TestMan:
     def test_9(self, bash, completion):
         assert self.assumed_present in completion
 
-    @pytest.mark.complete(require_cmd=True)
     def test_10(self, request, bash, colonpath):
+        if not is_bash_type(bash, "man"):
+            pytest.skip("Command not found")
         with bash_env_saved(bash) as bash_env:
             bash_env.write_env(
                 "MANPATH",


### PR DESCRIPTION
This fixes the test failure of `test_man.py`. `@pytest.mark.complete(require_cmd=True)` is referenced only when the fixture `completion` is requested. Since `completion` is not requested in the new version of `test_10`, `require_cmd=True` is inactive now. This PR explicitly checks the command (non-)existence to properly skip the test.