### PR TITLE
refactor(slackpkg): deprecate in favor of upstream one in >= 15.0.4

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -382,7 +382,7 @@ bashcomp_DATA = 2to3 \
 		sha256sum \
 		shellcheck \
 		sitecopy \
-		slackpkg \
+		_slackpkg \
 		slapt-get \
 		slapt-src \
 		smartctl \

--- a/completions/_slackpkg
+++ b/completions/_slackpkg
@@ -1,6 +1,9 @@
 # bash completion for slackpkg(8)                          -*- shell-script -*-
 # options list is based on `grep '\-.*\=.*)' /usr/sbin/slackpkg | cut -f1 -d\)`
 
+# Use of this file is deprecated.
+# Upstream completion is available in slackpkg >= 15.0.4, use that instead.
+
 _slackpkg()
 {
     local cur prev words cword


### PR DESCRIPTION
Refs https://github.com/scop/bash-completion/pull/531