### PR TITLE
test(conftest): prevent MAGIC_MARK from history expansions

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -24,7 +24,7 @@ import pexpect  # type: ignore[import]
 import pytest
 
 PS1 = "/@"
-MAGIC_MARK = "__MaGiC-maRKz!__"
+MAGIC_MARK = "__MaGiC-maRKz-NEtXZVZfKC__"
 MAGIC_MARK2 = "Re8SCgEdfN"
 
 


### PR DESCRIPTION
[The failure of Workflow Action `#246`](https://github.com/scop/bash-completion/actions/runs/911061422) is caused by history expansions induced by `MAGIC_MARK = "__MaGiC-maRKz!__"`. In this pull request, we remove `!` from `MAGIC_MARK` to avoid unexpected history expansions. Instead, I appended 10 characters (coming from my machine's entropy, `head -c  10 /dev/urandom | base64`).
