### PR TITLE
fix(make): fix stripped directory names with `bind 'set show-all-if-ambiguous on'`

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -46,7 +46,7 @@ _make_target_extract_script()
     /^$/ {                                      # end of target block
       x;                                        # unhold target
       /^$/d;                                    # dont print blanks
-      s|^${dirname_re-}\(.\{${#basename}\}[^:/]*/\{0,1\}\)[^:]*:.*$|${output}|p;
+      s|^${dirname_re-}\(.\{${#basename}\}[^:]*\):.*$|${output}|p;
       d;                                        # hide any bugs
     }
 
@@ -85,6 +85,56 @@ EOF
     }
 
 EOF
+}
+
+# Truncate the non-unique filepaths in COMPRELY to only generate unique
+# directories or files.  This function discards the files under subdirectories
+# unless the path is unique under each subdirectory and instead generate the
+# subdirectory path.  For example, when there are two candidates, "abc/def" and
+# "abc/xyz", we generate "abc/" instead of generating both candidates directly.
+# When there is only one candidate "abc/def", we generate the full path
+# "abc/def".
+#
+# @var[in] cur
+# @var[in] mode
+# @var[in,out] COMPREPLY
+_comp_make__truncate_non_unique_paths()
+{
+    local prefix=$cur
+    [[ $mode == -d ]] && prefix=
+    if ((${#COMPREPLY[@]} > 0)); then
+        # collect the possible completions including the directory names in
+        # `paths' and count the number of children of each subdirectory in
+        # `nchild'.
+        local -A paths nchild
+        local target
+        for target in "${COMPREPLY[@]}"; do
+            local path=${target%/}
+            while [[ ! ${paths[$path]+set} ]] &&
+                paths[$path]=1 &&
+                [[ $path == "$prefix"*/* ]]; do
+                path=${path%/*}
+                nchild[$path]=$((${nchild[$path]-0} + 1))
+            done
+        done
+
+        COMPREPLY=()
+        local nreply=0
+        for target in "${!paths[@]}"; do
+            # generate only the paths that do not have a unique child and whose
+            # all parent and ancestor directories have a unique child.
+            ((${nchild[$target]-0} == 1)) && continue
+            local path=$target
+            while [[ $path == "$prefix"*/* ]]; do
+                path=${path%/*}
+                ((${nchild[$path]-0} == 1)) || continue 2
+            done
+
+            # suffix `/' when the target path is a subdiretory, which has
+            # at least one child.
+            COMPREPLY[nreply++]=$target${nchild[$target]+/}
+        done
+    fi
 }
 
 _make()
@@ -171,6 +221,8 @@ _make()
             $1 -npq __BASH_MAKE_COMPLETION__=1 \
             ${makef+"${makef[@]}"} "${makef_dir[@]}" .DEFAULT 2>/dev/null |
             command sed -ne "$script"))
+
+        _comp_make__truncate_non_unique_paths
 
         if [[ $mode != -d ]]; then
             # Completion will occur if there is only one suggestion

--- a/completions/make
+++ b/completions/make
@@ -162,7 +162,7 @@ _make()
         # recognise that possible completions are only going to be displayed
         # so only the base name is shown
         local mode=--
-        if ((COMP_TYPE != 9)); then
+        if ((COMP_TYPE != 9 && COMP_TYPE != 37 && COMP_TYPE != 42)); then
             mode=-d # display-only mode
         fi
 

--- a/completions/make
+++ b/completions/make
@@ -209,12 +209,19 @@ _make()
             fi
         done
 
-        # recognise that possible completions are only going to be displayed
-        # so only the base name is shown
+        # recognise that possible completions are only going to be displayed so
+        # only the base name is shown.
+        #
+        # Note: This is currently turned off because the test suite of
+        # bash-completion conflicts with it; it uses "set show-all-if-ambiguous
+        # on" (causing COMP_TYPE == 37) to retrieve the action completion
+        # results, and also the compact form with only the basenames is not
+        # essentially needed.  To re-enable it, please uncomment the following
+        # if-statement.
         local mode=--
-        if ((COMP_TYPE != 9 && COMP_TYPE != 37 && COMP_TYPE != 42)); then
-            mode=-d # display-only mode
-        fi
+        # if ((COMP_TYPE != 9 && COMP_TYPE != 37 && COMP_TYPE != 42)); then
+        #     mode=-d # display-only mode
+        # fi
 
         local IFS=$' \t\n' script=$(_make_target_extract_script $mode "$cur")
         COMPREPLY=($(LC_ALL=C \

--- a/test/fixtures/make/test2/Makefile
+++ b/test/fixtures/make/test2/Makefile
@@ -1,0 +1,23 @@
+# makefile
+
+all: abc/xyz
+.PHONY: abc/xyz
+abc/xyz 123/xaa 123/xbb:
+	mkdir -p $(@:/%=)
+	date > $@
+
+sub1test/bar/alpha sub1test/bar/beta:
+	mkdir -p $(@:/%=)
+	date > $@
+
+sub2test/bar/alpha:
+	mkdir -p $(@:/%=)
+	date > $@
+
+sub3test/bar/alpha sub3test/foo/alpha:
+	mkdir -p $(@:/%=)
+	date > $@
+
+sub4test/bar/alpha sub4test/bar/beta sub4test2/foo/gamma:
+	mkdir -p $(@:/%=)
+	date > $@

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from conftest import assert_complete
+
 
 class TestMake:
     @pytest.mark.complete("make -f Ma", cwd="make")
@@ -45,3 +47,38 @@ class TestMake:
     @pytest.mark.complete("make -", require_cmd=True)
     def test_9(self, completion):
         assert completion
+
+
+@pytest.mark.bashcomp(require_cmd=True, cwd="make/test2")
+class TestMake2:
+    def test_github_issue_544_1(self, bash):
+        completion = assert_complete(bash, "make ab")
+        assert completion == "c/xyz"
+
+    def test_github_issue_544_2(self, bash):
+        completion = assert_complete(bash, "make 1")
+        assert completion == "23/"
+
+    def test_github_issue_544_3(self, bash):
+        completion = assert_complete(bash, "make 123/")
+        assert completion == ["xaa", "xbb"]
+
+    def test_github_issue_544_4(self, bash):
+        completion = assert_complete(bash, "make 123/xa")
+        assert completion == "a"
+
+    def test_subdir_1(self, bash):
+        completion = assert_complete(bash, "make sub1")
+        assert completion == "test/bar/"
+
+    def test_subdir_2(self, bash):
+        completion = assert_complete(bash, "make sub2")
+        assert completion == "test/bar/alpha"
+
+    def test_subdir_3(self, bash):
+        completion = assert_complete(bash, "make sub3")
+        assert completion == "test/"
+
+    def test_subdir_4(self, bash):
+        completion = assert_complete(bash, "make sub4")
+        assert completion == "sub4test/bar/ sub4test2/foo/gamma".split()

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -18,7 +18,7 @@ class TestMake:
 
     @pytest.mark.complete("make .cache/", cwd="make", require_cmd=True)
     def test_3(self, bash, completion):
-        assert completion == "1 2".split()
+        assert completion == ".cache/1 .cache/2".split()
         os.remove(f"{bash.cwd}/make/extra_makefile")
 
     @pytest.mark.complete("make ", cwd="shared/empty_dir")
@@ -36,7 +36,7 @@ class TestMake:
 
     @pytest.mark.complete("make .cache/.", cwd="make", require_cmd=True)
     def test_7(self, bash, completion):
-        assert completion == ".1 .2".split()
+        assert completion == ".cache/.1 .cache/.2".split()
         os.remove(f"{bash.cwd}/make/extra_makefile")
 
     @pytest.mark.complete("make -C make ", require_cmd=True)
@@ -61,7 +61,7 @@ class TestMake2:
 
     def test_github_issue_544_3(self, bash):
         completion = assert_complete(bash, "make 123/")
-        assert completion == ["xaa", "xbb"]
+        assert completion == ["123/xaa", "123/xbb"]
 
     def test_github_issue_544_4(self, bash):
         completion = assert_complete(bash, "make 123/xa")


### PR DESCRIPTION
Resolve #544 

- Commit 53060e3b: support `@pytest.mark.bashcomp(required_cmd=True)` to skip all the tests in the class.
- Commit eb12832c: add failing test cases to illustrate the problems
- Commit 0ddae4c1: do not strip directory names when `COMP_TYPE=37`. This happens when the user presses <kbd>TAB</kbd> under the readline setting `bind 'set show-all-if-ambiguous on'` is set.
- Commit d5181c55: complete subdirectories as far as the path is unique

## Test suite problem on COMP_TYPE

The test `test_github_issue_544_4` (`test_make.py`) currently fails because of the design of the test suite. The test suite extracts the generated completions by changing the readline settings as

```diff
@@ -22,20 +22,20 @@
 set menu-complete-display-prefix off
 set meta-flag on
 set output-meta on
-set page-completions on
+set page-completions off
 set prefer-visible-bell on
 set print-completions-horizontally off
 set revert-all-at-newline off
-set show-all-if-ambiguous off
+set show-all-if-ambiguous on
 set show-all-if-unmodified off
 set show-mode-in-prompt off
 set skip-completed-text off
 set visible-stats off
-set bell-style audible
+set bell-style none
 set comment-begin #
-set completion-display-width -1
+set completion-display-width 0
 set completion-prefix-display-length 0
-set completion-query-items 100
+set completion-query-items 0
 set editing-mode emacs
 set emacs-mode-string @
 set history-size 100000
```

Under these settings, the completion functions are called with `COMP_TYPE=33` (`!`, show list), which is different from the usual `COMP_TYPE=9` (TAB) or `COMP_TYPE=37` (`%`, menu-complete). The completion for `make` changes the behavior depending on `COMP_TYPE` so that it doesn't produce the expected results in the test suite. Note that `make` completion is the only one that changes its behavior depending on the value of `COMP_TYPE` among the completions in `bash-completion`.

@scop Do you have any thoughts on how we should solve this problem?
- Option 1: Use another approach to get the generated completions if any? I'm not sure if there is any.
- Option 2: Make the completion results independent of `COMP_TYPE`?
- Option 3: Add a special code in `completions/make` that detects the test suite and changes the behavior only in the test suite?
- Option X: any other idea?

## Possibility of using awk

`sed` has been used to extract the target names by `make`. It is difficult to use `sed` to test whether the filenames in subdirectories are unique and to generate the full path only when it is unambiguous. In commit d5181c5, `sed` scripts has been changed so as to always produce the full paths, and instead, the generated results are afterward filtered using Bash code. But, maybe another approach is to rewrite everything using `awk`. It should be more efficient than processing in Bash.
