### PR TITLE
test(conftest): check error messages in `assert_complete()`

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -765,6 +765,8 @@ def assert_complete(
                 r"^" + re.escape(MAGIC_MARK),
                 # 2: on same line, result in .match
                 r"^([^\r]+)%s$" % re.escape(MAGIC_MARK),
+                # 3: error messages
+                r"^([^\r].*)%s$" % re.escape(MAGIC_MARK),
                 pexpect.EOF,
                 pexpect.TIMEOUT,
             ]
@@ -777,6 +779,9 @@ def assert_complete(
         elif got == 2:
             output = bash.match.group(1)
             return CompletionResult(output)
+        elif got == 3:
+            output = bash.match.group(1)
+            raise AssertionError("Unexpected output: [%s]" % output)
         else:
             # TODO: warn about EOF/TIMEOUT?
             return CompletionResult()

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -755,12 +755,16 @@ def assert_complete(
         bash.send(cmd + "\t")
         # Sleep a bit if requested, to avoid `.*` matching too early
         time.sleep(kwargs.get("sleep_after_tab", 0))
-        bash.expect_exact(kwargs.get("rendered_cmd", cmd))
+        rendered_cmd = kwargs.get("rendered_cmd", cmd)
+        bash.expect_exact(rendered_cmd)
         bash.send(MAGIC_MARK)
         got = bash.expect(
             [
                 # 0: multiple lines, result in .before
-                r"\r\n" + re.escape(PS1 + cmd) + ".*" + re.escape(MAGIC_MARK),
+                r"\r\n"
+                + re.escape(PS1 + rendered_cmd)
+                + ".*"
+                + re.escape(MAGIC_MARK),
                 # 1: no completion
                 r"^" + re.escape(MAGIC_MARK),
                 # 2: on same line, result in .match

--- a/test/t/test_convert.py
+++ b/test/t/test_convert.py
@@ -6,7 +6,7 @@ class TestConvert:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("convert -format ")
+    @pytest.mark.complete("convert -format ", require_cmd=True)
     def test_2(self, completion):
         assert completion
 


### PR DESCRIPTION
- 2548107a I'd like to let `assert_complete()` check that no error messages are output while the completion. This would be used in the next PR for the fix of the `scp` completion.
- 1c354b3a It detected an error message in `test_2` (`test_convert.py`) that has been missed before.