### PR TITLE
fix(scp): fix nullglob/failglob errors

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -428,27 +428,27 @@ _scp_remote_files()
 
     # unescape (3 backslashes to 1 for chars we escaped)
     # shellcheck disable=SC2090
-    path=$(command sed -e 's/\\\\\\\('$_scp_path_esc'\)/\\\1/g' <<<"$path")
+    path=$(command sed -e 's/\\\\\\\('"$_scp_path_esc"'\)/\\\1/g' <<<"$path")
 
     # default to home dir of specified user on remote host
     if [[ -z $path ]]; then
-        path=$(ssh -o 'Batchmode yes' $userhost pwd 2>/dev/null)
+        path=$(ssh -o 'Batchmode yes' "$userhost" pwd 2>/dev/null)
     fi
 
     local files
     if [[ ${1-} == -d ]]; then
         # escape problematic characters; remove non-dirs
         # shellcheck disable=SC2090
-        files=$(ssh -o 'Batchmode yes' $userhost \
+        files=$(ssh -o 'Batchmode yes' "$userhost" \
             command ls -aF1dL "$path*" 2>/dev/null |
-            command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e '/[^\/]$/d')
+            command sed -e 's/'"$_scp_path_esc"'/\\\\\\&/g' -e '/[^\/]$/d')
     else
         # escape problematic characters; remove executables, aliases, pipes
         # and sockets; add space at end of file names
         # shellcheck disable=SC2090
-        files=$(ssh -o 'Batchmode yes' $userhost \
+        files=$(ssh -o 'Batchmode yes' "$userhost" \
             command ls -aF1dL "$path*" 2>/dev/null |
-            command sed -e 's/'$_scp_path_esc'/\\\\\\&/g' -e 's/[*@|=]$//g' \
+            command sed -e 's/'"$_scp_path_esc"'/\\\\\\&/g' -e 's/[*@|=]$//g' \
                 -e 's/[^\/]$/& /g')
     fi
     COMPREPLY+=($files)

--- a/test/t/test_scp.py
+++ b/test/t/test_scp.py
@@ -81,3 +81,17 @@ class TestScp:
     @pytest.mark.complete("scp -o Foo=")
     def test_option_arg(self, completion):
         assert not completion  # and no errors either
+
+    @pytest.mark.complete(
+        "scp hostname-not-expected-to-exist-in-known-hosts:",
+        shopt=dict(nullglob=True),
+    )
+    def test_remote_path_with_nullglob(self, completion):
+        assert not completion
+
+    @pytest.mark.complete(
+        "scp hostname-not-expected-to-exist-in-known-hosts:",
+        shopt=dict(failglob=True),
+    )
+    def test_remote_path_with_failglob(self, completion):
+        assert not completion


### PR DESCRIPTION
This is a PR to fix the problem reported at https://github.com/akinomyoga/ble.sh/issues/123

### Problem

With `shopt -s nullglob` or `shopt -u failglob`, the completion for `scp` fails and produces error messages on the command line.

### Fix

Proper quoting is needed. To prepare the corresponding unit tests, I first created a PR #555 to support checks of error messages in `assert_complete()` (`test/t/conftest.py`). I'll open this PR as a Draft PR until #555 is processed.