### PR TITLE
fix(misc): fix bugs and errors found by tests

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1233,7 +1233,7 @@ else
     # @param $1 if -s, don't try to avoid truncated command names
     _pnames()
     {
-        local -a procs
+        local -a procs=()
         if [[ ${1-} == -s ]]; then
             procs=($(command ps ax -o comm | command sed -e 1d))
         else
@@ -1277,7 +1277,8 @@ else
                 done
             fi
         fi
-        COMPREPLY=($(compgen -X "<defunct>" -W '${procs[@]}' -- "$cur"))
+        ((${#procs[@]})) &&
+            COMPREPLY=($(compgen -X "<defunct>" -W '"${procs[@]}"' -- "$cur"))
     }
 fi
 
@@ -1324,7 +1325,7 @@ _xinetd_services()
         local -a svcs=($xinetddir/!($_backup_glob))
         $reset
         ((!${#svcs[@]})) ||
-            COMPREPLY+=($(compgen -W '${svcs[@]#$xinetddir/}' -- "${cur-}"))
+            COMPREPLY+=($(compgen -W '"${svcs[@]#$xinetddir/}"' -- "${cur-}"))
     fi
 }
 
@@ -1882,7 +1883,7 @@ _known_hosts_real()
         local -a hosts=($(command sed -ne 's/^[[:blank:]]*[Hh][Oo][Ss][Tt][[:blank:]=]\{1,\}\(.*\)$/\1/p' "${config[@]}"))
         if ((${#hosts[@]} != 0)); then
             COMPREPLY+=($(compgen -P "$prefix" \
-                -S "$suffix" -W '${hosts[@]%%[*?%]*}' -X '\!*' -- "$cur"))
+                -S "$suffix" -W '"${hosts[@]%%[*?%]*}"' -X '\!*' -- "$cur"))
         fi
     fi
 

--- a/bash_completion
+++ b/bash_completion
@@ -718,15 +718,17 @@ _comp_delimited()
         # delimiter so we get space appended.
         [[ ! $cur || $cur == *"$delimiter" ]] || unset "existing[${#existing[@]}-1]"
         IFS=$ifs
-        for x in ${existing+"${existing[@]}"}; do
-            for i in "${!COMPREPLY[@]}"; do
-                if [[ $x == "${COMPREPLY[i]}" ]]; then
-                    unset "COMPREPLY[i]"
-                    continue 2 # assume no dupes in COMPREPLY
-                fi
+        if ((${#COMPREPLY[@]})); then
+            for x in ${existing+"${existing[@]}"}; do
+                for i in "${!COMPREPLY[@]}"; do
+                    if [[ $x == "${COMPREPLY[i]}" ]]; then
+                        unset "COMPREPLY[i]"
+                        continue 2 # assume no dupes in COMPREPLY
+                    fi
+                done
             done
-        done
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "${cur##*$delimiter}"))
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "${cur##*$delimiter}"))
+        fi
     else
         COMPREPLY=($(compgen "$@" -- "${cur##*$delimiter}"))
     fi
@@ -760,16 +762,18 @@ _comp_variable_assignments()
         TZ)
             cur=/usr/share/zoneinfo/$cur
             _filedir
-            for i in "${!COMPREPLY[@]}"; do
-                if [[ ${COMPREPLY[i]} == *.tab ]]; then
-                    unset 'COMPREPLY[i]'
-                    continue
-                elif [[ -d ${COMPREPLY[i]} ]]; then
-                    COMPREPLY[i]+=/
-                    compopt -o nospace
-                fi
-                COMPREPLY[i]=${COMPREPLY[i]#/usr/share/zoneinfo/}
-            done
+            if ((${#COMPREPLY[@]})); then
+                for i in "${!COMPREPLY[@]}"; do
+                    if [[ ${COMPREPLY[i]} == *.tab ]]; then
+                        unset 'COMPREPLY[i]'
+                        continue
+                    elif [[ -d ${COMPREPLY[i]} ]]; then
+                        COMPREPLY[i]+=/
+                        compopt -o nospace
+                    fi
+                    COMPREPLY[i]=${COMPREPLY[i]#/usr/share/zoneinfo/}
+                done
+            fi
             ;;
         TERM)
             _terms
@@ -1036,7 +1040,8 @@ _mac_addresses()
     COMPREPLY+=($(command sed -ne \
         "s/^[[:space:]]*\($re\)[[:space:]].*/\1/p" /etc/ethers 2>/dev/null))
 
-    COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
     __ltrim_colon_completions "$cur"
 }
 
@@ -1115,7 +1120,8 @@ _available_interfaces()
     } 2>/dev/null | awk \
         '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }'))
 
-    COMPREPLY=($(compgen -W '${COMPREPLY[@]/%[[:punct:]]/}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]/%[[:punct:]]/}"' -- "$cur"))
 }
 
 # Echo number of CPUs, falling back to 1 on failure.
@@ -1345,7 +1351,8 @@ _services()
         COMPREPLY+=($(initctl list 2>/dev/null | cut -d' ' -f1))
     fi
 
-    COMPREPLY=($(compgen -W '${COMPREPLY[@]#${sysvdirs[0]}/}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]#${sysvdirs[0]}/}"' -- "$cur"))
 }
 
 # This completes on a list of all available service scripts for the
@@ -1424,7 +1431,8 @@ _usergroup()
             local IFS=$'\n'
             COMPREPLY=($(compgen -g -- "$mycur"))
         fi
-        COMPREPLY=($(compgen -P "$prefix" -W "${COMPREPLY[@]}"))
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -P "$prefix" -W '"${COMPREPLY[@]}"'))
     elif [[ $cur == *:* ]]; then
         # Completing group after 'user:gr<TAB>'.
         # Reply with a list of unprefixed groups since readline with split on :
@@ -1844,7 +1852,8 @@ _known_hosts_real()
                     IFS=$ifs
                 done <"$i"
             done
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
         fi
         if ((${#khd[@]} > 0)); then
             # Needs to look for files called
@@ -1861,9 +1870,11 @@ _known_hosts_real()
         fi
 
         # apply suffix and prefix
-        for i in ${!COMPREPLY[*]}; do
-            COMPREPLY[i]=$prefix${COMPREPLY[i]}$suffix
-        done
+        if ((${#COMPREPLY[@]})); then
+            for i in ${!COMPREPLY[*]}; do
+                COMPREPLY[i]=$prefix${COMPREPLY[i]}$suffix
+            done
+        fi
     fi
 
     # append any available aliases from ssh config files
@@ -1903,16 +1914,18 @@ _known_hosts_real()
     IFS=$' \t\n'
     $reset
 
-    if [[ -v ipv4 ]]; then
-        COMPREPLY=("${COMPREPLY[@]/*:*$suffix/}")
-    fi
-    if [[ -v ipv6 ]]; then
-        COMPREPLY=("${COMPREPLY[@]/+([0-9]).+([0-9]).+([0-9]).+([0-9])$suffix/}")
-    fi
-    if [[ -v ipv4 || -v ipv6 ]]; then
-        for i in "${!COMPREPLY[@]}"; do
-            [[ ${COMPREPLY[i]} ]] || unset -v "COMPREPLY[i]"
-        done
+    if ((${#COMPREPLY[@]})); then
+        if [[ -v ipv4 ]]; then
+            COMPREPLY=("${COMPREPLY[@]/*:*$suffix/}")
+        fi
+        if [[ -v ipv6 ]]; then
+            COMPREPLY=("${COMPREPLY[@]/+([0-9]).+([0-9]).+([0-9]).+([0-9])$suffix/}")
+        fi
+        if [[ -v ipv4 || -v ipv6 ]]; then
+            for i in "${!COMPREPLY[@]}"; do
+                [[ ${COMPREPLY[i]} ]] || unset -v "COMPREPLY[i]"
+            done
+        fi
     fi
 
     __ltrim_colon_completions "$prefix$cur"

--- a/bash_completion
+++ b/bash_completion
@@ -1313,7 +1313,7 @@ _xinetd_services()
     if [[ -d $xinetddir ]]; then
         local IFS=$' \t\n' reset=$(shopt -p nullglob)
         shopt -s nullglob
-        local -a svcs=($(printf '%s\n' $xinetddir/!($_backup_glob)))
+        local -a svcs=($xinetddir/!($_backup_glob))
         $reset
         ((!${#svcs[@]})) ||
             COMPREPLY+=($(compgen -W '${svcs[@]#$xinetddir/}' -- "${cur-}"))

--- a/bash_completion
+++ b/bash_completion
@@ -515,10 +515,12 @@ _get_pword()
 #
 __ltrim_colon_completions()
 {
+    local i=${#COMPREPLY[*]}
+    ((i == 0)) && return 0
     if [[ $1 == *:* && $COMP_WORDBREAKS == *:* ]]; then
         # Remove colon-word prefix from COMPREPLY items
         local colon_word=${1%"${1##*:}"}
-        local i=${#COMPREPLY[*]}
+        COMPREPLY=("${COMPREPLY[@]}")
         while ((i-- > 0)); do
             COMPREPLY[i]=${COMPREPLY[i]#"$colon_word"}
         done

--- a/completions/_adb
+++ b/completions/_adb
@@ -42,7 +42,8 @@ _adb()
             tmp+=($($1 help 2>&1 | awk '$1 == "adb" { print $2 }'))
             tmp+=(devices connect disconnect sideload)
         fi
-        COMPREPLY=($(compgen -W '${tmp[@]}' -- "$cur"))
+        ((${#tmp[@]})) &&
+            COMPREPLY=($(compgen -W '"${tmp[@]}"' -- "$cur"))
         return
     fi
 

--- a/completions/_rtcwake
+++ b/completions/_rtcwake
@@ -18,7 +18,8 @@ _rtcwake()
             ;;
         --device | -d)
             COMPREPLY=($(command ls -d /dev/rtc?* 2>/dev/null))
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]#/dev/}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]#/dev/}"' -- "$cur"))
             return
             ;;
     esac

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -104,7 +104,8 @@ _aptitude()
             esac
         done
 
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
     else
         COMPREPLY=($(compgen -W 'update upgrade safe-upgrade forget-new
             clean autoclean install reinstall remove hold unhold purge markauto

--- a/completions/aspell
+++ b/completions/aspell
@@ -5,7 +5,7 @@ _aspell_dictionary()
     local datadir aspell=${1:-aspell}
     datadir=$($aspell config data-dir 2>/dev/null || echo /usr/lib/aspell)
     # First, get aliases (dicts dump does not list them)
-    COMPREPLY=($(printf '%s\n' $datadir/*.alias))
+    COMPREPLY=($datadir/*.alias)
     COMPREPLY=("${COMPREPLY[@]%.alias}")
     COMPREPLY=("${COMPREPLY[@]#$datadir/}")
     # Then, add the canonical dicts

--- a/completions/aspell
+++ b/completions/aspell
@@ -6,11 +6,14 @@ _aspell_dictionary()
     datadir=$($aspell config data-dir 2>/dev/null || echo /usr/lib/aspell)
     # First, get aliases (dicts dump does not list them)
     COMPREPLY=($datadir/*.alias)
-    COMPREPLY=("${COMPREPLY[@]%.alias}")
-    COMPREPLY=("${COMPREPLY[@]#$datadir/}")
+    if ((${#COMPREPLY[@]})); then
+        COMPREPLY=("${COMPREPLY[@]%.alias}")
+        COMPREPLY=("${COMPREPLY[@]#$datadir/}")
+    fi
     # Then, add the canonical dicts
     COMPREPLY+=($($aspell dicts 2>/dev/null))
-    COMPREPLY=($(compgen -X '\*' -W '${COMPREPLY[@]}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -X '\*' -W '"${COMPREPLY[@]}"' -- "$cur"))
 }
 
 _aspell()

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -8,7 +8,8 @@ _chronyc_command_args()
     case $args in
         \<address\>) _known_hosts_real -- "$cur" ;;
         \<*) ;;
-        *) COMPREPLY+=($(compgen -W '${args[@]}' -- "$cur")) ;;
+        *) ((${#args[@]})) &&
+            COMPREPLY+=($(compgen -W '"${args[@]}"' -- "$cur")) ;;
     esac
 }
 

--- a/completions/complete
+++ b/completions/complete
@@ -30,7 +30,8 @@ _complete()
             ;;
         -*p | -*r)
             COMPREPLY=($(complete -p | command sed -e 's|.* ||'))
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
     esac

--- a/completions/curl
+++ b/completions/curl
@@ -71,7 +71,8 @@ _curl()
             ;;
         --dns-servers | --noproxy)
             _known_hosts_real -- "${cur##*,}"
-            _comp_delimited , -W '${COMPREPLY[@]}'
+            ((${#COMPREPLY[@]})) &&
+                _comp_delimited , -W '"${COMPREPLY[@]}"'
             return
             ;;
         --engine)

--- a/completions/curl
+++ b/completions/curl
@@ -106,11 +106,13 @@ _curl()
                 $("$1" --help non-existent-category 2>&1 |
                     awk '/^[[:space:]]/ {print $1}')
             )
-            for x in "${categories[@]}"; do
-                # Looks like an option? Likely no --help category support
-                [[ $x != -* ]] || return
-            done
-            COMPREPLY=($(compgen -W '${categories[@]}' -- "$cur"))
+            if ((${#categories[@]})); then
+                for x in "${categories[@]}"; do
+                    # Looks like an option? Likely no --help category support
+                    [[ $x != -* ]] || return
+                done
+                COMPREPLY=($(compgen -W '${categories[@]}' -- "$cur"))
+            fi
             return
             ;;
         --krb)

--- a/completions/cvs
+++ b/completions/cvs
@@ -226,7 +226,8 @@ _cvs()
                 [[ ! -v cvsroot ]] && cvsroot=${CVSROOT-}
                 COMPREPLY=($(cvs -d "$cvsroot" co -c 2>/dev/null |
                     awk '{print $1}'))
-                COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+                ((${#COMPREPLY[@]})) &&
+                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             else
                 _cvs_command_options "$1" $mode
             fi
@@ -304,7 +305,8 @@ _cvs()
             if [[ $cur != -* ]]; then
                 [[ ! -v cvsroot ]] && cvsroot=${CVSROOT-}
                 COMPREPLY=($(cvs -d "$cvsroot" co -c | awk '{print $1}'))
-                COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+                ((${#COMPREPLY[@]})) &&
+                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             else
                 _cvs_command_options "$1" $mode
             fi
@@ -332,7 +334,9 @@ _cvs()
                 fi
                 pwd=$(pwd)
                 pwd=${pwd##*/}
-                COMPREPLY=($(compgen -W '${COMPREPLY[@]} $pwd' -- "$cur"))
+                [[ $pwd ]] && COMPREPLY+=("$pwd")
+                ((${#COMPREPLY[@]})) &&
+                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             else
                 _cvs_command_options "$1" $mode
             fi

--- a/completions/cvs
+++ b/completions/cvs
@@ -158,7 +158,7 @@ _cvs()
                 for i in "${!files[@]}"; do
                     if [[ ${files[i]} == ?(*/)CVS ]]; then
                         unset 'files[i]'
-                    else
+                    elif ((${#entries[@]})); then
                         for f in "${entries[@]}"; do
                             if [[ ${files[i]} == "$f" && ! -d $f ]]; then
                                 unset 'files[i]'
@@ -167,8 +167,9 @@ _cvs()
                         done
                     fi
                 done
-                COMPREPLY=($(compgen -X "$_backup_glob" -W '${files[@]}' \
-                    -- "$cur"))
+                ((${#files[@]})) &&
+                    COMPREPLY=($(compgen -X "$_backup_glob" -W '"${files[@]}"' \
+                        -- "$cur"))
             else
                 _cvs_command_options "$1" $mode
             fi
@@ -193,7 +194,8 @@ _cvs()
                 _cvs_command_options "$1" $mode
             else
                 _cvs_entries
-                COMPREPLY=($(compgen -W '${entries[@]}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             fi
             ;;
         annotate)
@@ -203,7 +205,8 @@ _cvs()
                 _cvs_command_options "$1" $mode
             else
                 _cvs_entries
-                COMPREPLY=($(compgen -W '${entries[@]}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             fi
             ;;
         checkout)
@@ -256,11 +259,14 @@ _cvs()
                         command sed -ne 's/^Files [^ ]* and \([^ ]*\) differ$/\1/p'))
                     newremoved=($(cvs -q diff --brief 2>&1 |
                         command sed -ne 's/^cvs diff: \([^ ]*\) .*, no comparison available$/\1/p'))
-                    COMPREPLY=($(compgen -W '${changed[@]:-} \
-                        ${newremoved[@]:-}' -- "$cur"))
+                    ((${#changed[@]})) && COMPREPLY+=("${changed[@]}")
+                    ((${#newremoved[@]})) && COMPREPLY+=("${newremoved[@]}")
+                    ((${#COMPREPLY[@]})) &&
+                        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
                 else
                     _cvs_entries
-                    COMPREPLY=($(compgen -W '${entries[@]}' -- "$cur"))
+                    ((${#entries[@]})) &&
+                        COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
                 fi
             else
                 _cvs_command_options "$1" $mode
@@ -275,7 +281,8 @@ _cvs()
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             else
                 _cvs_entries
-                COMPREPLY=($(compgen -W '${entries[@]:-}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             fi
             ;;
         editors | watchers)
@@ -283,7 +290,8 @@ _cvs()
                 _cvs_command_options "$1" $mode
             else
                 _cvs_entries
-                COMPREPLY=($(compgen -W '${entries[@]}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             fi
             ;;
         export)
@@ -350,7 +358,8 @@ _cvs()
                         [[ -r ${entries[i]} ]] && unset 'entries[i]'
                     done
                 fi
-                COMPREPLY=($(compgen -W '${entries[@]:-}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             else
                 _cvs_command_options "$1" $mode
             fi
@@ -371,7 +380,8 @@ _cvs()
                 _cvs_command_options "$1" $mode
             else
                 _cvs_entries
-                COMPREPLY=($(compgen -W '${entries[@]}' -- "$cur"))
+                ((${#entries[@]})) &&
+                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
             fi
             ;;
         "")

--- a/completions/dot
+++ b/completions/dot
@@ -14,13 +14,15 @@ _dot()
         -T*)
             local langs=($("$1" -TNON_EXISTENT 2>&1 |
                 command sed -ne 's/.*one of://p'))
-            COMPREPLY=($(compgen -P -T -W '${langs[@]}' -- "${cur#-T}"))
+            ((${#langs[@]})) &&
+                COMPREPLY=($(compgen -P -T -W '"${langs[@]}"' -- "${cur#-T}"))
             return
             ;;
         -K*)
             local layouts=($("$1" -KNON_EXISTENT 2>&1 |
                 command sed -ne 's/.*one of://p'))
-            COMPREPLY=($(compgen -P -K -W '${layouts[@]}' -- "${cur#-K}"))
+            ((${#layouts[@]})) &&
+                COMPREPLY=($(compgen -P -K -W '"${layouts[@]}"' -- "${cur#-K}"))
             return
             ;;
         -o*)

--- a/completions/dot
+++ b/completions/dot
@@ -26,7 +26,8 @@ _dot()
         -o*)
             cur=${cur#-o}
             _filedir
-            COMPREPLY=($(compgen -P -o -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -P -o -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
     esac

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -132,7 +132,7 @@ _dpkg_reconfigure()
 
     case $prev in
         --frontend | -!(-*)f)
-            opt=($(printf '%s\n' /usr/share/perl5/Debconf/FrontEnd/*))
+            opt=(/usr/share/perl5/Debconf/FrontEnd/*)
             opt=(${opt[@]##*/})
             opt=(${opt[@]%.pm})
             COMPREPLY=($(compgen -W '${opt[@]}' -- "$cur"))

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -133,9 +133,11 @@ _dpkg_reconfigure()
     case $prev in
         --frontend | -!(-*)f)
             opt=(/usr/share/perl5/Debconf/FrontEnd/*)
-            opt=(${opt[@]##*/})
-            opt=(${opt[@]%.pm})
-            COMPREPLY=($(compgen -W '${opt[@]}' -- "$cur"))
+            if ((${#opt[@]})); then
+                opt=(${opt[@]##*/})
+                opt=(${opt[@]%.pm})
+                COMPREPLY=($(compgen -W '${opt[@]}' -- "$cur"))
+            fi
             return
             ;;
         --priority | -!(-*)p)

--- a/completions/gdb
+++ b/completions/gdb
@@ -30,7 +30,7 @@ _gdb()
                 command sed -e 's/:\{2,\}/:/g' -e 's/^://' -e 's/:$//' <<<"$PATH"
             ))
             IFS=$'\n'
-            COMPREPLY=($(compgen -d -W '$(find "${path_array[@]}" . \
+            COMPREPLY=($(compgen -d -W '$(find ${path_array[@]+"${path_array[@]}"} . \
                 -mindepth 1 -maxdepth 1 -not -type d -executable \
                 -printf "%f\\n" 2>/dev/null)' -- "$cur"))
         fi

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -354,7 +354,7 @@ _hciattach()
         _count_args
         case $args in
             1)
-                COMPREPLY=($(printf '%s\n' /dev/tty*))
+                COMPREPLY=(/dev/tty*)
                 COMPREPLY=($(compgen -W '${COMPREPLY[@]}
                     ${COMPREPLY[@]#/dev/}' -- "$cur"))
                 ;;

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -355,8 +355,9 @@ _hciattach()
         case $args in
             1)
                 COMPREPLY=(/dev/tty*)
-                COMPREPLY=($(compgen -W '${COMPREPLY[@]}
-                    ${COMPREPLY[@]#/dev/}' -- "$cur"))
+                ((${#COMPREPLY[@]})) &&
+                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"
+                        "${COMPREPLY[@]#/dev/}"' -- "$cur"))
                 ;;
             2)
                 COMPREPLY=($(compgen -W 'any ericsson digi xircom csr bboxes

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -14,11 +14,13 @@ _hunspell()
             shopt -s nullglob
             local -a dicts=(/usr/share/hunspell/*.dic
                 /usr/local/share/hunspell/*.dic)
-            dicts=("${dicts[@]##*/}")
-            dicts=("${dicts[@]%.dic}")
             $reset
-            IFS=$'\n'
-            COMPREPLY=($(compgen -W '${dicts[@]}' -- "$cur"))
+            if ((${#dicts[@]})); then
+                dicts=("${dicts[@]##*/}")
+                dicts=("${dicts[@]%.dic}")
+                IFS=$'\n'
+                COMPREPLY=($(compgen -W '${dicts[@]}' -- "$cur"))
+            fi
             return
             ;;
         -i)

--- a/completions/ifup
+++ b/completions/ifup
@@ -31,7 +31,8 @@ _ifupdown()
 
     if ((args == 1)); then
         _configured_interfaces
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
     fi
 } &&
     complete -F _ifupdown ifup ifdown ifquery ifstatus

--- a/completions/info
+++ b/completions/info
@@ -66,7 +66,8 @@ _info()
     done
     # strip suffix from info pages
     COMPREPLY=(${COMPREPLY[@]%.@(gz|bz2|xz|lzma)})
-    COMPREPLY=($(compgen -W '${COMPREPLY[@]%.*}' -- "${cur//\\\\/}"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
 
 } &&
     complete -F _info info pinfo

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -23,7 +23,10 @@ _invoke_rc_d()
                 command sed -ne "/$(command sed 's/ /\\|/g' <<<"${options[*]}")/p" |
                 sort | uniq -u
         ))
-        COMPREPLY=($(compgen -W '${valid_options[@]} ${services[@]}' -- "$cur"))
+        ((${#valid_options[@]})) && COMPREPLY+=("${valid_options[@]}")
+        ((${#services[@]})) && COMPREPLY+=("${services[@]}")
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
     elif [[ -x $sysvdir/$prev ]]; then
         COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}\"]*\).*$/\1/p" \

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -12,7 +12,7 @@ _invoke_rc_d()
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
 
-    services=($(printf '%s ' $sysvdir/!(README*|*.sh|$_backup_glob)))
+    services=($sysvdir/!(README*|*.sh|$_backup_glob))
     services=(${services[@]#$sysvdir/})
     options=(--help --quiet --force --try-anyway --disclose-deny --query
         --no-fallback)

--- a/completions/ip
+++ b/completions/ip
@@ -314,9 +314,10 @@ _ip()
                 show)
                     if [[ $cword -eq $subcword+1 || $prev == dev ]]; then
                         _available_interfaces
-                        [[ $prev != dev ]] &&
-                            COMPREPLY=($(compgen -W '${COMPREPLY[@]} dev' \
-                                -- "$cur"))
+                        if [[ $prev != dev ]]; then
+                            COMPREPLY+=(dev)
+                            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                        fi
                     fi
                     ;;
                 *)

--- a/completions/ipsec
+++ b/completions/ipsec
@@ -10,7 +10,8 @@ _ipsec_connections()
         if [[ $keyword == [#]* ]]; then continue; fi
         [[ $keyword == conn && $name != '%default' ]] && COMPREPLY+=("$name")
     done
-    COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
 }
 
 _ipsec_freeswan()

--- a/completions/man
+++ b/completions/man
@@ -58,7 +58,17 @@ _man()
     fi
 
     local manpath=$(manpath 2>/dev/null || command man -w 2>/dev/null)
-    [[ -z $manpath ]] && manpath="/usr/share/man:/usr/local/share/man"
+    if [[ -z $manpath ]]; then
+        # Note: Both "manpath" and "man -w" may be unavailable, in
+        # which case we determine the man paths based on the
+        # environment variable MANPATH.
+        manpath=:${MANPATH-}:
+        # Note: An empty path (represented by two consecutive colons
+        # or a preceding/trailing colon) represents the system man
+        # paths.
+        manpath=${manpath//::/':/usr/share/man:/usr/local/share/man:'}
+        manpath=${manpath:1:-1}
+    fi
 
     # determine manual section to search
     local sect

--- a/completions/man
+++ b/completions/man
@@ -84,8 +84,10 @@ _man()
         # weed out directory path names and paths to man pages
         COMPREPLY=(${COMPREPLY[@]##*/?(:)})
         # strip suffix from man pages
-        COMPREPLY=(${COMPREPLY[@]%$comprsuffix})
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]%.*}' -- "${cur//\\\\/}"))
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=(${COMPREPLY[@]%$comprsuffix})
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
     fi
 
     # shellcheck disable=SC2053

--- a/completions/minicom
+++ b/completions/minicom
@@ -16,8 +16,9 @@ _minicom()
             ;;
         --ptty | -!(-*)p)
             COMPREPLY=(/dev/tty*)
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]} ${COMPREPLY[@]#/dev/}' \
-                -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}}' \
+                    -- "$cur"))
             return
             ;;
     esac

--- a/completions/minicom
+++ b/completions/minicom
@@ -15,7 +15,7 @@ _minicom()
             return
             ;;
         --ptty | -!(-*)p)
-            COMPREPLY=($(printf '%s\n' /dev/tty*))
+            COMPREPLY=(/dev/tty*)
             COMPREPLY=($(compgen -W '${COMPREPLY[@]} ${COMPREPLY[@]#/dev/}' \
                 -- "$cur"))
             return

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -58,10 +58,12 @@ _mplayer()
         -subcp | -msgcharset)
             local cp
             cp=($(iconv --list 2>/dev/null | command sed -e "s@//@@;" 2>/dev/null))
-            if [[ $cur == "${cur,,}" ]]; then
-                COMPREPLY=($(compgen -W '${cp[@],,}' -- "$cur"))
-            else
-                COMPREPLY=($(compgen -W '${cp[@]^^}' -- "$cur"))
+            if ((${#cp[@]})); then
+                if [[ $cur == "${cur,,}" ]]; then
+                    COMPREPLY=($(compgen -W '${cp[@],,}' -- "$cur"))
+                else
+                    COMPREPLY=($(compgen -W '${cp[@]^^}' -- "$cur"))
+                fi
             fi
             return
             ;;

--- a/completions/mysql
+++ b/completions/mysql
@@ -6,9 +6,11 @@ _mysql_character_sets()
     shopt -u failglob
     local -a charsets=(/usr/share/m{ariadb,ysql}/charsets/*.xml)
     $reset
-    charsets=("${charsets[@]##*/}")
-    charsets=("${charsets[@]%%?(Index|\*).xml}" utf8)
-    COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
+    if ((${#charsets[@]})); then
+        charsets=("${charsets[@]##*/}")
+        charsets=("${charsets[@]%%?(Index|\*).xml}" utf8)
+        COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
+    fi
 }
 
 _mysql()

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -39,7 +39,8 @@ _pgrep()
                     command sed -ne \
                         "s/^[[:space:]]*Available namespaces://p")' \
                     -- "${cur##*,}"))
-            _comp_delimited , -W '${COMPREPLY[@]}'
+            ((${#COMPREPLY[@]})) &&
+                _comp_delimited , -W '"${COMPREPLY[@]}"'
             return
             ;;
     esac

--- a/completions/ps
+++ b/completions/ps
@@ -43,8 +43,9 @@ _comp_cmd_ps()
                 shopt -s nullglob
                 printf '%s\n' /dev/tty*
             ))
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]} ${COMPREPLY[@]#/dev/}' \
-                -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"' \
+                    -- "$cur"))
             return
             ;;
         ?(-)U | [^-]*U | -u | --[Uu]ser)

--- a/completions/pylint
+++ b/completions/pylint
@@ -43,7 +43,8 @@ _pylint()
             ;;
         --load-plugins | --deprecated-modules)
             cur="${cur##*,}" _xfunc python _python_modules $python
-            _comp_delimited , -W '${COMPREPLY[@]}'
+            ((${#COMPREPLY[@]})) &&
+                _comp_delimited , -W '"${COMPREPLY[@]}"'
             return
             ;;
         --jobs | -!(-*)j)

--- a/completions/pytest
+++ b/completions/pytest
@@ -115,7 +115,7 @@ _pytest()
             fi
         done 2>/dev/null <"$file"
         ((!${#COMPREPLY[@]})) ||
-            COMPREPLY=($(compgen -P "$file::$class::" -W '${COMPREPLY[@]}' \
+            COMPREPLY=($(compgen -P "$file::$class::" -W '"${COMPREPLY[@]}"' \
                 -- "${cur##*:?(:)}"))
         __ltrim_colon_completions "$cur"
         return
@@ -129,7 +129,7 @@ _pytest()
             fi
         done 2>/dev/null <"$file"
         ((!${#COMPREPLY[@]})) ||
-            COMPREPLY=($(compgen -P "$file::" -W '${COMPREPLY[@]}' \
+            COMPREPLY=($(compgen -P "$file::" -W '"${COMPREPLY[@]}"' \
                 -- "${cur##*.py:?(:)}"))
         __ltrim_colon_completions "$cur"
         return

--- a/completions/qemu
+++ b/completions/qemu
@@ -27,7 +27,8 @@ _qemu()
                     /usr/{local/,}share/qemu/keymaps/!(common|modifiers)
             ))
             $reset
-            COMPREPLY=($(compgen -W '${keymaps[@]##*/}' -- "$cur"))
+            ((${#keymaps[@]})) &&
+                COMPREPLY=($(compgen -W '"${keymaps[@]##*/}"}' -- "$cur"))
             return
             ;;
         -soundhw)

--- a/completions/rdesktop
+++ b/completions/rdesktop
@@ -12,7 +12,8 @@ _rdesktop()
                 command grep -E -v '(common|modifiers)'))
             COMPREPLY+=($(command ls $HOME/.rdesktop/keymaps 2>/dev/null))
             COMPREPLY+=($(command ls ./keymaps 2>/dev/null))
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
         -*a)

--- a/completions/rdesktop
+++ b/completions/rdesktop
@@ -47,7 +47,8 @@ _rdesktop()
 
     if [[ $cur == -* ]]; then
         local opts=($(_parse_help "$1"))
-        COMPREPLY=($(compgen -W '${opts[@]%:}' -- "$cur"))
+        ((${#opts[@]})) &&
+            COMPREPLY=($(compgen -W '"${opts[@]%:}"}' -- "$cur"))
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/ri
+++ b/completions/ri
@@ -15,7 +15,7 @@ _ri_get_methods()
         fi
 
         COMPREPLY+=(
-            "$(ri "${classes[@]}" 2>/dev/null | ruby -ane \
+            "$(ri ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
                 'if /^'"$regex"' methods:/.../^------------------|^$/ and \
             /^ / then print $_.split(/, |,$/).grep(/^[^\[]*$/).join("\n"); \
             end' 2>/dev/null | sort -u)")
@@ -23,7 +23,7 @@ _ri_get_methods()
         # older versions of ri didn't distinguish between class/module and
         # instance methods
         COMPREPLY+=(
-            "$(ruby -W0 $ri_path "${classes[@]}" 2>/dev/null | ruby -ane \
+            "$(ruby -W0 $ri_path ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
                 'if /^-/.../^-/ and ! /^-/ and ! /^ +(class|module): / then \
             print $_.split(/, |,$| +/).grep(/^[^\[]*$/).join("\n"); \
             end' | sort -u)")
@@ -104,7 +104,8 @@ _ri()
                 if /^ .*[A-Z]/ then print; end; end'))
     fi
 
-    COMPREPLY=($(compgen -W '${classes[@]}' -- "$cur"))
+    ((${#classes[@]})) &&
+        COMPREPLY=($(compgen -W '"${classes[@]}"' -- "$cur"))
     __ltrim_colon_completions "$cur"
 
     if [[ $cur == [A-Z]* ]]; then

--- a/completions/ri
+++ b/completions/ri
@@ -28,7 +28,8 @@ _ri_get_methods()
             print $_.split(/, |,$| +/).grep(/^[^\[]*$/).join("\n"); \
             end' | sort -u)")
     fi
-    COMPREPLY=($(compgen $prefix -W '${COMPREPLY[@]}' -- $method))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen $prefix -W '"${COMPREPLY[@]}"' -- $method))
 }
 
 # needs at least Ruby 1.8.0 in order to use -W0

--- a/completions/route
+++ b/completions/route
@@ -23,7 +23,8 @@ _route()
         $found || COMPREPLY+=("$opt")
     done
 
-    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
 } &&
     complete -F _route route
 

--- a/completions/screen
+++ b/completions/screen
@@ -4,6 +4,7 @@ _screen_sessions()
 {
     local sessions=($(command screen -ls | command sed -ne \
         's|^\t\{1,\}\([0-9]\{1,\}\.[^\t]\{1,\}\).*'"$1"'.*$|\1|p'))
+    ((${#sessions[@]} == 0)) && return
     if [[ $cur == +([0-9])?(.*) ]]; then
         # Complete sessions including pid prefixes
         COMPREPLY=($(compgen -W '${sessions[@]}' -- "$cur"))

--- a/completions/secret-tool
+++ b/completions/secret-tool
@@ -25,7 +25,8 @@ _secret_tool()
                     printf "%s\n" "$third"
                 fi
             done))
-        COMPREPLY=($(compgen -W '${modes[@]}' -- "$cur"))
+        ((${#modes[@]})) &&
+            COMPREPLY=($(compgen -W '"${modes[@]}"' -- "$cur"))
         return
     fi
 
@@ -41,7 +42,8 @@ _secret_tool()
             for word in "${words[@]:2}"; do
                 [[ $word ]] && unset -v 'opts[$word]'
             done
-            COMPREPLY=($(compgen -W '${!opts[@]}' -- "$cur"))
+            ((${#opts[@]})) &&
+                COMPREPLY=($(compgen -W '"${!opts[@]}"' -- "$cur"))
             ;;
     esac
 } &&

--- a/completions/secret-tool
+++ b/completions/secret-tool
@@ -39,7 +39,7 @@ _secret_tool()
         search)
             local -A opts=([--all]="" [--unlock]="")
             for word in "${words[@]:2}"; do
-                [[ $word ]] && unset opts["$word"]
+                [[ $word ]] && unset -v 'opts[$word]'
             done
             COMPREPLY=($(compgen -W '${!opts[@]}' -- "$cur"))
             ;;

--- a/completions/secret-tool
+++ b/completions/secret-tool
@@ -41,7 +41,7 @@ _secret_tool()
             for word in "${words[@]:2}"; do
                 [[ $word ]] && unset opts["$word"]
             done
-            COMPREPLY=($(compgen -W '${opts[@]}' -- "$cur"))
+            COMPREPLY=($(compgen -W '${!opts[@]}' -- "$cur"))
             ;;
     esac
 } &&

--- a/completions/sha256sum
+++ b/completions/sha256sum
@@ -30,7 +30,8 @@ _comp_cmd_sha256sum()
     done
 
     _filedir
-    COMPREPLY=($(compgen -X "*.$sumtype" -W '${COMPREPLY[@]}' -- "$cur"))
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=($(compgen -X "*.$sumtype" -W '"${COMPREPLY[@]}"' -- "$cur"))
 } &&
     complete -F _comp_cmd_sha256sum md5sum sha{,1,224,256,384,512}sum
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -246,7 +246,7 @@ _ssh_identityfile()
     [[ -z $cur && -d ~/.ssh ]] && cur=~/.ssh/id
     _filedir
     if ((${#COMPREPLY[@]} > 0)); then
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]}' \
+        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' \
             -X "${1:+!}*.pub" -- "$cur"))
     fi
 }

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -50,7 +50,8 @@ _ssh_keygen()
             [[ ${words[*]} != *\ -*Y\ * ]] || return
             if [[ ${words[*]} == *\ -*h\ * ]]; then
                 _known_hosts_real -- "${cur##*,}"
-                _comp_delimited , -W '${COMPREPLY[@]}'
+                ((${#COMPREPLY[@]})) &&
+                    _comp_delimited , -W '"${COMPREPLY[@]}"'
             else
                 _comp_delimited , -u
             fi

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -10,7 +10,7 @@ _ssh_keygen()
             return
             ;;
         -*b)
-            local -a sizes
+            local -a sizes=()
             case "${words[*]}" in
                 *" -t dsa"?( *))
                     sizes=(1024)
@@ -22,7 +22,8 @@ _ssh_keygen()
                     sizes=(1024 2048 3072 4096)
                     ;;
             esac
-            COMPREPLY=($(compgen -W '${sizes[@]}' -- "$cur"))
+            ((${#sizes[@]})) &&
+                COMPREPLY=($(compgen -W '"${sizes[@]}"' -- "$cur"))
             return
             ;;
         -*E)

--- a/completions/strace
+++ b/completions/strace
@@ -56,7 +56,7 @@ _strace()
                                 done 2>/dev/null <$unistd
                             fi
 
-                            COMPREPLY=($(compgen -W '${!syscalls[@]} file
+                            COMPREPLY=($(compgen -W '${syscalls[@]+"${!syscalls[@]}"} file
                                 process network signal ipc desc all none' \
                                 -- "$cur"))
                             return

--- a/completions/tree
+++ b/completions/tree
@@ -30,7 +30,10 @@ _comp_cmd_tree()
         return
     fi
 
-    if [[ ${words[*]} == *\ --fromfile\ * ]]; then
+    # Note: bash-4.2 has a bug with [[ ${arr[*]} == *text* ]], so we
+    # assign ${words[*]} in a temporary variable "line".
+    local line="${words[*]}"
+    if [[ $line == *\ --fromfile\ * ]]; then
         _filedir
     else
         _filedir -d

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -15,7 +15,8 @@ _tune2fs()
             ;;
         -*g)
             _gids
-            COMPREPLY=($(compgen -g -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -g -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
         -*M)
@@ -39,7 +40,8 @@ _tune2fs()
             ;;
         -*u)
             _uids
-            COMPREPLY=($(compgen -u -W '${COMPREPLY[@]}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -u -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
         -*U)

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -12,7 +12,7 @@ _update_rc_d()
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
 
-    services=($(printf '%s ' $sysvdir/!(README*|*.sh|$_backup_glob)))
+    services=($sysvdir/!(README*|*.sh|$_backup_glob))
     services=(${services[@]#$sysvdir/})
     options=(-f -n)
 

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -13,13 +13,13 @@ _update_rc_d()
         sysvdir=/etc/init.d
 
     services=($sysvdir/!(README*|*.sh|$_backup_glob))
-    services=(${services[@]#$sysvdir/})
+    ((${#services[@]})) && services=("${services[@]#$sysvdir/}")
     options=(-f -n)
 
     if [[ $cword -eq 1 || $prev == -* ]]; then
-        COMPREPLY=($(compgen -W '${options[@]} ${services[@]}' \
+        COMPREPLY=($(compgen -W '${options[@]} ${services[@]+"${services[@]}"}' \
             -X '$(tr " " "|" <<<${words[@]})' -- "$cur"))
-    elif [[ $prev == ?($(tr " " "|" <<<"${services[*]}")) ]]; then
+    elif ((${#services[@]})) && [[ $prev == ?($(tr " " "|" <<<"${services[*]}")) ]]; then
         COMPREPLY=($(compgen -W 'remove defaults start stop' -- "$cur"))
     elif [[ $prev == defaults && $cur == [0-9] ]]; then
         COMPREPLY=(0 1 2 3 4 5 6 7 8 9)

--- a/completions/useradd
+++ b/completions/useradd
@@ -28,7 +28,9 @@ _useradd()
             ;;
         --gid | -!(-*)g)
             _gids
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]} $(compgen -g)' -- "$cur"))
+            COMPREPLY+=($(compgen -g))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
         --groups | -!(-*)G)

--- a/completions/usermod
+++ b/completions/usermod
@@ -24,7 +24,9 @@ _usermod()
             ;;
         --gid | -!(-*)g)
             _gids
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]} $(compgen -g)' -- "$cur"))
+            COMPREPLY+=($(compgen -g))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
         --groups | -!(-*)G)

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -69,12 +69,14 @@ _vpnc()
         local IFS=$' \t\n' reset=$(shopt -p nullglob)
         shopt -s nullglob
         local -a configs=(/etc/vpnc/*.conf)
-        configs=("${configs[@]##*/}")
-        configs=("${configs[@]%.conf}")
         $reset
-        IFS=$'\n'
-        compopt -o filenames
-        COMPREPLY=($(compgen -W '${configs[@]}' -- "$cur"))
+        if ((${#configs[@]})); then
+            configs=("${configs[@]##*/}")
+            configs=("${configs[@]%.conf}")
+            IFS=$'\n'
+            compopt -o filenames
+            COMPREPLY=($(compgen -W '${configs[@]}' -- "$cur"))
+        fi
     fi
 } &&
     complete -F _vpnc vpnc

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -41,10 +41,12 @@ _xdg_mime()
                 local IFS=$' \t\n' reset=$(shopt -p nullglob)
                 shopt -s nullglob
                 local -a desktops=(/usr/share/applications/*.desktop)
-                desktops=("${desktops[@]##*/}")
                 $reset
-                IFS=$'\n'
-                COMPREPLY=($(compgen -W '${desktops[@]}' -- "$cur"))
+                if ((${#desktops[@]})); then
+                    desktops=("${desktops[@]##*/}")
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -W '"${desktops[@]}"' -- "$cur"))
+                fi
             else
                 _xdg_mime_mimetype
             fi

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -58,7 +58,8 @@ _xfreerdp()
             " <<<"$help")' -- "$cur"))
         else # old/dash syntax
             COMPREPLY=($(_parse_help - <<<"$help"))
-            COMPREPLY=($(compgen -W '${COMPREPLY[@]%:}' -- "$cur"))
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%:}"' -- "$cur"))
         fi
     else
         _filedir rdp

--- a/completions/zopflipng
+++ b/completions/zopflipng
@@ -19,7 +19,8 @@ _zopflipng()
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(_parse_help "$1" -h))
-        COMPREPLY=($(compgen -W '${COMPREPLY[@]%:}' -- "$cur"))
+        ((${#COMPREPLY[@]})) &&
+            COMPREPLY=($(compgen -W '"${COMPREPLY[@]%:}"' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/test/t/test_secret_tool.py
+++ b/test/t/test_secret_tool.py
@@ -9,4 +9,4 @@ class TestSecretTool:
 
     @pytest.mark.complete("secret-tool search ")
     def test_no_complete(self, completion):
-        assert not completion
+        assert completion == ["--all", "--unlock"]

--- a/test/t/test_secret_tool.py
+++ b/test/t/test_secret_tool.py
@@ -9,4 +9,4 @@ class TestSecretTool:
 
     @pytest.mark.complete("secret-tool search ")
     def test_no_complete(self, completion):
-        assert completion == ["--all", "--unlock"]
+        assert completion == "--all --unlock".split()


### PR DESCRIPTION
Details are described in the commit messages.

- e7b81ae3c288814861109be16096024f21dc7b9a fix(_xinetd_services,aspell,dpkg,etc.): avoid unnecessary word splitting
- 9938f7e50cc7845dc0e3d337f70be727b81fa781 fix(_ltrim_colon_completions): do compaction of sparse `COMPREPLY`
- 231a29b09cf8ac19fbd6846d441583f28c364d7d fix(secret-tool): fix empty candidates for `secret-tool search ` options
- 149a13ae118ac8afb4c7331543d995d843025c2b fix(secret-tool): protect unset opts[...] from pathname expansions
- c6574f3dbf6508ce0339028472636ded8f94488f fix(nounset): fix nounset errors of `-W '${COMPRELY[@]}'`
- b56a094ee8cb8bedd1670df41926122ec4886bf1 fix(nounset): fix nounset errors of `-W '${arr[@]}'`
- 8302aa3dc381e081162be8ea149fa17c236b1c29 fix(tree): work around bash-4.2 bug of `[[ ${arr[*]} == *text* ]]`
- 93dfc1fdf7375d965f191eb24ec38d42737b78a6 fix(man): work around the case both `manpath` and `man -w` are missing