### PR TITLE
curl: fix option listing in newer versions

### DIFF
--- a/completions/curl
+++ b/completions/curl
@@ -159,7 +159,7 @@ _comp_cmd_curl()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help all)' -- "$cur"))
+        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help all")' -- "$cur"))
         [[ ${COMPREPLY-} ]] ||
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     fi

--- a/test/t/test_curl.py
+++ b/test/t/test_curl.py
@@ -31,3 +31,15 @@ class TestCurl:
     def test_unknown_option(self, completion):
         # Just see that it does not error out
         pass
+
+    @pytest.mark.complete("curl --data-bina", require_cmd=True)
+    def test_help_all_option(self, completion):
+        """
+        The option used as a canary here is one that should be available
+        in all curl versions. It should be only listed in `--help all` output
+        for curl versions that have their help output split to multiple
+        categories (i.e. ones that support `--help all` to get the complete
+        list), as well as the basic `--help` output for earlier versions that
+        do not have that.
+        """
+        assert completion


### PR DESCRIPTION
`_parse_help` only takes a single parameter (which is then splits) for the options that it invokes the tool with, so `curl` was being invoked with just `--help`, not with `--help all`.