### PR TITLE
feat(pylint): message ids completion

### DIFF
--- a/completions/pylint
+++ b/completions/pylint
@@ -1,5 +1,17 @@
 # pylint(1) completion                                     -*- shell-script -*-
 
+_comp_cmd_pylint_message_ids()
+{
+    local filter=p
+    [[ ${2-} ]] && filter="/^$2 messages/,/^$/p"
+    # 6: arbitrary, assumed no ids shorter than that
+    _comp_delimited , -W "$(
+        ${1:-pylint} --list-msgs-enabled 2>/dev/null |
+            command sed -ne "$filter" |
+            command sed -ne 's/^[[:space:]]\{1,\}\([a-z-]\{6,\}\).*/\1/p'
+    )"
+}
+
 _pylint()
 {
     local cur prev words cword split
@@ -9,8 +21,8 @@ _pylint()
     [[ ${1##*/} == *3* ]] && python=python3
 
     case $prev in
-        --version | --help | --long-help | --help-msg | --init-hook | \
-            --ignore | --enable | --evaluation | --max-line-length | \
+        --version | --help | --long-help | --init-hook | \
+            --ignore | --evaluation | --max-line-length | \
             --max-module-lines | --indent-string | --min-similarity-lines | \
             --max-args | --ignored-argument-names | --max-locals | \
             --max-returns | --max-branchs | --max-statements | --max-parents | \
@@ -23,11 +35,20 @@ _pylint()
             --ignored-classes | --generated-members | \
             --overgeneral-exceptions | --ignore-iface-methods | \
             --defining-attr-methods | --valid-classmethod-first-arg | \
-            --valid-metaclass-classmethod-first-arg | -!(-*)[he])
+            --valid-metaclass-classmethod-first-arg | -!(-*)[h])
+            return
+            ;;
+        --fail-on | --help-msg)
+            _comp_cmd_pylint_message_ids "$1"
+            return
+            ;;
+        --enable | -!(-*)e)
+            _comp_cmd_pylint_message_ids "$1" Disabled
             return
             ;;
         --disable | -!(-*)d)
-            COMPREPLY=($(compgen -W 'all' -- "$cur"))
+            _comp_cmd_pylint_message_ids "$1" Enabled
+            COMPREPLY+=($(compgen -W 'all' -- "$cur"))
             return
             ;;
         --rcfile)

--- a/test/t/test_pylint.py
+++ b/test/t/test_pylint.py
@@ -9,3 +9,15 @@ class TestPylint:
     @pytest.mark.complete("pylint --confidence=HIGH,")
     def test_2(self, completion):
         assert completion
+
+    @pytest.mark.complete("pylint --help-msg=", require_longopt=True)
+    def test_all_message_ids(self, completion):
+        assert any("-" in x for x in completion)
+
+    @pytest.mark.complete("pylint --disable=", require_longopt=True)
+    def test_enabled_message_ids(self, completion):
+        assert any("-" in x for x in completion)
+
+    @pytest.mark.complete("pylint --enable=foo,", require_longopt=True)
+    def test_disabled_message_ids(self, completion):
+        assert any("-" in x for x in completion)


### PR DESCRIPTION
Complete message ids for `--fail-on`, `--help-msg`, `--enable`, and
`--disable`. We scrape the output of `--list-msgs-enabled` instead of
`--list-msgs`, because it outputs both enabled and disable message ids
and thus allows for one implementation for all cases, even though the
output is somewhat less parseable than that of the latter.

Curiously, `--list-msgs-enabled` also outputs some message ids that
`--list-msgs` does not.