### PR TITLE
style(test): remove redundant require_cmd with require_longopt

### DIFF
--- a/test/t/test_2to3.py
+++ b/test/t/test_2to3.py
@@ -6,6 +6,6 @@ class Test2to3:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("2to3 -", require_cmd=True, require_longopt=True)
+    @pytest.mark.complete("2to3 -", require_longopt=True)
     def test_2(self, completion):
         assert completion

--- a/test/t/test_cpan2dist.py
+++ b/test/t/test_cpan2dist.py
@@ -2,8 +2,6 @@ import pytest
 
 
 class TestCpan2dist:
-    @pytest.mark.complete(
-        "cpan2dist -", require_cmd=True, require_longopt=True
-    )
+    @pytest.mark.complete("cpan2dist -", require_longopt=True)
     def test_1(self, completion):
         assert completion

--- a/test/t/test_dmypy.py
+++ b/test/t/test_dmypy.py
@@ -9,6 +9,6 @@ class TestDmypy:
         assert "help" in completion
         assert not any("," in x for x in completion)
 
-    @pytest.mark.complete("dmypy -", require_cmd=True, require_longopt=True)
+    @pytest.mark.complete("dmypy -", require_longopt=True)
     def test_options(self, completion):
         assert "--help" in completion

--- a/test/t/test_isort.py
+++ b/test/t/test_isort.py
@@ -6,6 +6,6 @@ class TestIsort:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("isort -", require_cmd=True, require_longopt=True)
+    @pytest.mark.complete("isort -", require_longopt=True)
     def test_2(self, completion):
         assert completion

--- a/test/t/test_jsonschema.py
+++ b/test/t/test_jsonschema.py
@@ -6,8 +6,6 @@ class TestJsonschema:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete(
-        "jsonschema -", require_cmd=True, require_longopt=True
-    )
+    @pytest.mark.complete("jsonschema -", require_longopt=True)
     def test_2(self, completion):
         assert completion

--- a/test/t/test_mypy.py
+++ b/test/t/test_mypy.py
@@ -6,7 +6,7 @@ class TestMypy:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("mypy --", require_cmd=True, require_longopt=True)
+    @pytest.mark.complete("mypy --", require_longopt=True)
     def test_2(self, completion):
         assert completion
 

--- a/test/t/test_pydocstyle.py
+++ b/test/t/test_pydocstyle.py
@@ -6,8 +6,6 @@ class TestPydocstyle:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete(
-        "pydocstyle -", require_cmd=True, require_longopt=True
-    )
+    @pytest.mark.complete("pydocstyle -", require_longopt=True)
     def test_2(self, completion):
         assert completion

--- a/test/t/test_pylint.py
+++ b/test/t/test_pylint.py
@@ -2,7 +2,7 @@ import pytest
 
 
 class TestPylint:
-    @pytest.mark.complete("pylint --v", require_cmd=True, require_longopt=True)
+    @pytest.mark.complete("pylint --v", require_longopt=True)
     def test_1(self, completion):
         assert completion
 


### PR DESCRIPTION
`require_longopt=True` implies `require_cmd=True` by default.