### PR TITLE
Add missing double quotes for command variables.

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2069,7 +2069,7 @@ _command_offset()
                 done
             else
                 cspec=${cspec#complete}
-                cspec=${cspec%%$compcmd}
+                cspec=${cspec%%"$compcmd"}
                 COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
             fi
         elif ((${#COMPREPLY[@]} == 0)); then

--- a/bash_completion
+++ b/bash_completion
@@ -2030,18 +2030,18 @@ _command_offset()
         COMPREPLY=($(compgen -d -c -- "$cur"))
     else
         local cmd=${COMP_WORDS[0]} compcmd=${COMP_WORDS[0]}
-        local cspec=$(complete -p $cmd 2>/dev/null)
+        local cspec=$(complete -p "$cmd" 2>/dev/null)
 
         # If we have no completion for $cmd yet, see if we have for basename
         if [[ ! $cspec && $cmd == */* ]]; then
-            cspec=$(complete -p ${cmd##*/} 2>/dev/null)
+            cspec=$(complete -p "${cmd##*/}" 2>/dev/null)
             [[ $cspec ]] && compcmd=${cmd##*/}
         fi
         # If still nothing, just load it for the basename
         if [[ ! $cspec ]]; then
             compcmd=${cmd##*/}
-            _completion_loader $compcmd
-            cspec=$(complete -p $compcmd 2>/dev/null)
+            _completion_loader "$compcmd"
+            cspec=$(complete -p "$compcmd" 2>/dev/null)
         fi
 
         if [[ -n $cspec ]]; then
@@ -2053,9 +2053,9 @@ _command_offset()
                 func=${func%% *}
 
                 if ((${#COMP_WORDS[@]} >= 2)); then
-                    $func $cmd "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
+                    $func "$cmd" "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
                 else
-                    $func $cmd "${COMP_WORDS[-1]}"
+                    $func "$cmd" "${COMP_WORDS[-1]}"
                 fi
 
                 # restore initial compopts

--- a/test/t/test_sudo.py
+++ b/test/t/test_sudo.py
@@ -1,5 +1,6 @@
 import pytest
 
+from conftest import assert_bash_exec
 from conftest import assert_complete
 
 
@@ -81,3 +82,13 @@ class TestSudo:
         part, _ = part_full_group
         completion = assert_complete(bash, "sudo chown foo:bar:%s" % part)
         assert not completion
+
+    def test_12(self, bash):
+        completion = assert_complete(bash, 'sudo "/tmp/aaa bbb" ')
+        output = assert_bash_exec(
+            bash, "complete -p aaa || true", want_output=True
+        )
+        assert output.endswith(
+            "bash: complete: aaa: no completion specification"
+        )
+

--- a/test/t/test_sudo.py
+++ b/test/t/test_sudo.py
@@ -1,7 +1,6 @@
 import pytest
 
-from conftest import assert_bash_exec
-from conftest import assert_complete
+from conftest import assert_complete, assert_bash_exec
 
 
 class TestSudo:
@@ -84,11 +83,6 @@ class TestSudo:
         assert not completion
 
     def test_12(self, bash):
-        completion = assert_complete(bash, 'sudo "/tmp/aaa bbb" ')
-        output = assert_bash_exec(
-            bash, "complete -p aaa || true", want_output=True
-        )
-        assert output.endswith(
-            "bash: complete: aaa: no completion specification"
-        )
+        assert_complete(bash, 'sudo "/tmp/aaa bbb" ')
+        assert_bash_exec(bash, "! complete -p aaa", want_output=None)
 

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -1,0 +1,22 @@
+import pytest
+
+from conftest import TestUnitBase, assert_bash_exec, assert_complete
+
+
+@pytest.mark.bashcomp(
+    cmd=None,
+    ignore_env=r"^[+-](COMP(_(WORDS|CWORD|LINE|POINT)|REPLY)|cur|cword|words)=",
+)
+class TestUnitCommandOffset:
+    @pytest.fixture(scope="class")
+    def functions(self, bash):
+        assert_bash_exec(
+            bash,
+            "_co1() { _command_offset 1; }; "
+            "complete -F _co1 co1",
+        )
+
+    def test_1(self, bash, functions):
+        assert_complete(bash, 'co1 "/tmp/aaa bbb" ')
+        assert_bash_exec(bash, "! complete -p aaa", want_output=None)
+


### PR DESCRIPTION
Some command variables may contain spaces but were used without double
quotes. This commit fixes this error by double quoting these variables.

Issue https://github.com/scop/bash-completion/issues/569.