### PR TITLE
ci(github): run pushes only on master

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,6 +3,8 @@ name: checks
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Avoids running twice for pull requests whose source branch is in this
repo.