### PR TITLE
test(pre-commit): use separate isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,16 @@ repos:
         args: [--config=test/setup.cfg]
         additional_dependencies:
           - flake8-bugbear==21.4.3
-          - flake8-isort==4.0.0
-          - isort==5.9.1
         types: [text]
         files: ^(helpers/python|.+\.py)$
         exclude: ^completions/
+        stages: [commit]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.1
+    hooks:
+      - id: isort
+        args: [--filter-files, --settings-path=test/setup.cfg]
         stages: [commit]
 
   - repo: local


### PR DESCRIPTION
Running from flake8 only checks for modifications, while the standalone
one takes care of writing its changes too, avoiding one human step in
the process.