### PR TITLE
ci(renovate): group isort updates, mark as PEP 440 versioned

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
       "groupName": "flake8"
     },
     {
+      "matchPackagePatterns": ["(^|/)isort$"],
+      "versioning": "pep440",
+      "groupName": "isort"
+    },
+    {
       "matchPackageNames": ["perltidy/perltidy"],
       "versioning": "regex:^(?<major>\\d{8})$"
     },


### PR DESCRIPTION
Similarly as for black and flake8 already.