### PR TITLE
ci: cache non-pre-commit venv PyPI downloads

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ">=1.15"  # for shfmt
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{hashFiles('test/requirements*.txt')}}
       - run: |
           python3 -m venv venv  # for venv-run
           source venv/bin/activate


### PR DESCRIPTION
For some reason these are not picked up by the pre-commit action cache
which seems somewhat magical: it does not specify to cache pip (but just
the pre-commit cache), but CI logs show "cached" wheels etc being
installed anyway.

Do it explicitly ourselves instead.