### PR TITLE
fix(_parse_help): protect word splitting from pathname expansions

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -888,7 +888,10 @@ __parse_options()
 
     # Take first found long option, or first one (short) if not found.
     option=
+    local reset=$(shopt -po noglob)
+    set -o noglob
     local -a array=($1)
+    $reset
     for i in "${array[@]}"; do
         case "$i" in
             ---*) break ;;

--- a/test/t/unit/test_unit_parse_help.py
+++ b/test/t/unit/test_unit_parse_help.py
@@ -94,6 +94,20 @@ class TestUnitParseHelp:
         output = assert_bash_exec(bash, "_parse_help fn", want_output=True)
         assert output.split() == "--foo".split()
 
+    def test_17_failglob(self, bash):
+        assert_bash_exec(bash, "fn() { echo '--foo[=bar]'; }")
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("failglob", True)
+            output = assert_bash_exec(bash, "_parse_help fn", want_output=True)
+        assert output.split() == "--foo".split()
+
+    def test_17_nullglob(self, bash):
+        assert_bash_exec(bash, "fn() { echo '--foo[=bar]'; }")
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("nullglob", True)
+            output = assert_bash_exec(bash, "_parse_help fn", want_output=True)
+        assert output.split() == "--foo".split()
+
     def test_18(self, bash):
         assert_bash_exec(bash, "fn() { echo '--foo=<bar>'; }")
         output = assert_bash_exec(bash, "_parse_help fn", want_output=True)


### PR DESCRIPTION
This solves error messages on the standard option completions under `shopt -s failglob`. For example, with `shopt -s failglob`, we see the following error message:

```bash
$ shopt -failglob 
$ tar -[TAB]bash: no match: --occurrence[=NUMBER]
```

