### PR TITLE
fix(_parse_help): protect custom help options from pathname expansions

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -926,9 +926,10 @@ __parse_options()
 _parse_help()
 {
     local IFS=$' \t\n'
-    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe)
+    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe) reset_noglob=$(shopt -po noglob)
     set +o monitor
     shopt -s lastpipe
+    set -o noglob
 
     eval local cmd="$(quote "$1")"
     local line rc=1
@@ -951,6 +952,7 @@ _parse_help()
 
     $reset_monitor
     $reset_lastpipe
+    $reset_noglob
     return $rc
 }
 
@@ -961,9 +963,10 @@ _parse_help()
 _parse_usage()
 {
     local IFS=$' \t\n'
-    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe)
+    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe) reset_noglob=$(shopt -po noglob)
     set +o monitor
     shopt -s lastpipe
+    set -o noglob
 
     eval local cmd="$(quote "$1")"
     local line match option i char rc=1
@@ -997,6 +1000,7 @@ _parse_usage()
 
     $reset_monitor
     $reset_lastpipe
+    $reset_noglob
     return $rc
 }
 

--- a/test/t/test_ssh_add.py
+++ b/test/t/test_ssh_add.py
@@ -15,3 +15,23 @@ class TestSshAdd:
     )
     def test_2(self, completion):
         assert completion
+
+    @pytest.mark.complete(
+        "ssh-add -",
+        require_cmd=True,
+        xfail="ssh-add --help 2>&1 | "
+        "command grep -qiF 'Could not open a connection'",
+        shopt=dict(failglob=True),
+    )
+    def test_2_failglob(self, completion):
+        assert completion
+
+    @pytest.mark.complete(
+        "ssh-add -",
+        require_cmd=True,
+        xfail="ssh-add --help 2>&1 | "
+        "command grep -qiF 'Could not open a connection'",
+        shopt=dict(nullglob=True),
+    )
+    def test_2_nullglob(self, completion):
+        assert completion

--- a/test/t/test_ssh_keygen.py
+++ b/test/t/test_ssh_keygen.py
@@ -7,6 +7,18 @@ class TestSshKeygen:
     def test_1(self, completion):
         assert completion
 
+    @pytest.mark.complete(
+        "ssh-keygen -", require_cmd=True, shopt=dict(failglob=True)
+    )
+    def test_1_failglob(self, completion):
+        assert completion
+
+    @pytest.mark.complete(
+        "ssh-keygen -", require_cmd=True, shopt=dict(nullglob=True)
+    )
+    def test_1_nullglob(self, completion):
+        assert completion
+
     @pytest.mark.complete("ssh-keygen -s foo_key ssh-copy-id/.ssh/")
     def test_filedir_pub_at_end_of_s(self, completion):
         assert completion


### PR DESCRIPTION
This is another fix of `_parse_help` and `_parse_usage` caused with `shopt -s failglob` or `shopt -s nullglob`.

```bash
$ shopt -s failglob
$ ssh-keygen -[TAB]bash: no match: -?
bash: no match: -?
```

With `nullglob`, it hangs:

```bash
$ shopt -s failglob
$ ssh-keygen -[TAB] # --> no response to subsequent user inputs until the user presses [C-c]
```