### PR TITLE
Explicitly specify `unset` types / Adjust uses of temporary global variables

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -716,13 +716,13 @@ _comp_delimited()
         existing=($cur)
         # Do not remove the last from existing if it's not followed by the
         # delimiter so we get space appended.
-        [[ ! $cur || $cur == *"$delimiter" ]] || unset "existing[${#existing[@]}-1]"
+        [[ ! $cur || $cur == *"$delimiter" ]] || unset -v "existing[${#existing[@]}-1]"
         IFS=$ifs
         if ((${#COMPREPLY[@]})); then
             for x in ${existing+"${existing[@]}"}; do
                 for i in "${!COMPREPLY[@]}"; do
                     if [[ $x == "${COMPREPLY[i]}" ]]; then
-                        unset "COMPREPLY[i]"
+                        unset -v 'COMPREPLY[i]'
                         continue 2 # assume no dupes in COMPREPLY
                     fi
                 done
@@ -765,7 +765,7 @@ _comp_variable_assignments()
             if ((${#COMPREPLY[@]})); then
                 for i in "${!COMPREPLY[@]}"; do
                     if [[ ${COMPREPLY[i]} == *.tab ]]; then
-                        unset 'COMPREPLY[i]'
+                        unset -v 'COMPREPLY[i]'
                         continue
                     elif [[ -d ${COMPREPLY[i]} ]]; then
                         COMPREPLY[i]+=/
@@ -1931,7 +1931,7 @@ _known_hosts_real()
         fi
         if [[ -v ipv4 || -v ipv6 ]]; then
             for i in "${!COMPREPLY[@]}"; do
-                [[ ${COMPREPLY[i]} ]] || unset -v "COMPREPLY[i]"
+                [[ ${COMPREPLY[i]} ]] || unset -v 'COMPREPLY[i]'
             done
         fi
     fi
@@ -2039,7 +2039,7 @@ _command_offset()
         COMP_WORDS[i]=${COMP_WORDS[i + word_offset]}
     done
     for ((i; i <= COMP_CWORD; i++)); do
-        unset 'COMP_WORDS[i]'
+        unset -v 'COMP_WORDS[i]'
     done
     ((COMP_CWORD -= word_offset))
 
@@ -2402,9 +2402,9 @@ user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
 unset user_completion
 
 unset -f have
-unset have
+unset -v have
 
 set $BASH_COMPLETION_ORIGINAL_V_VALUE
-unset BASH_COMPLETION_ORIGINAL_V_VALUE
+unset -v BASH_COMPLETION_ORIGINAL_V_VALUE
 
 # ex: filetype=sh

--- a/bash_completion
+++ b/bash_completion
@@ -1387,13 +1387,19 @@ _service()
     fi
 } &&
     complete -F _service service
-_sysvdirs
-for svcdir in "${sysvdirs[@]}"; do
-    for svc in $svcdir/!($_backup_glob); do
-        [[ -x $svc ]] && complete -F _service $svc
+
+_comp_init_set_up_service_completions()
+{
+    local sysvdirs svc svcdir
+    _sysvdirs
+    for svcdir in "${sysvdirs[@]}"; do
+        for svc in $svcdir/!($_backup_glob); do
+            [[ -x $svc ]] && complete -F _service "$svc"
+        done
     done
-done
-unset svc svcdir sysvdirs
+}
+_comp_init_set_up_service_completions
+unset -f _comp_init_set_up_service_completions
 
 # This function completes on modules
 #

--- a/bash_completion
+++ b/bash_completion
@@ -39,7 +39,7 @@ fi
 
 # Blacklisted completions, causing problems with our code.
 #
-_blacklist_glob='@(acroread.sh)'
+_comp_init_blacklist_glob='@(acroread.sh)'
 
 # Turn on extended globbing and programmable completion
 shopt -s extglob progcomp
@@ -2382,24 +2382,24 @@ _xfunc()
 }
 
 # source compat completion directory definitions
-compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
-if [[ -d $compat_dir && -r $compat_dir && -x $compat_dir ]]; then
-    for i in "$compat_dir"/*; do
-        [[ ${i##*/} != @($_backup_glob|Makefile*|$_blacklist_glob) &&
-            -f $i && -r $i ]] && . "$i"
+_comp_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
+if [[ -d $_comp_compat_dir && -r $_comp_compat_dir && -x $_comp_compat_dir ]]; then
+    for _comp_file in "$_comp_compat_dir"/*; do
+        [[ ${_comp_file##*/} != @($_backup_glob|Makefile*|$_comp_init_blacklist_glob) &&
+            -f $_comp_file && -r $_comp_file ]] && . "$_comp_file"
     done
 fi
-unset compat_dir i _blacklist_glob
+unset -v _comp_compat_dir _comp_file _comp_init_blacklist_glob
 
 # source user completion file
 #
 # Remark: We explicitly check that $user_completion is not '/dev/null' since
 #   /dev/null may be a regular file in broken systems and can contain arbitrary
 #   garbages of suppressed command outputs.
-user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
-[[ $user_completion != "${BASH_SOURCE[0]}" && $user_completion != /dev/null && -r $user_completion && -f $user_completion ]] &&
-    . $user_completion
-unset user_completion
+_comp_user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
+[[ $_comp_user_completion != "${BASH_SOURCE[0]}" && $_comp_user_completion != /dev/null && -r $_comp_user_completion && -f $_comp_user_completion ]] &&
+    . $_comp_user_completion
+unset -v _comp_user_completion
 
 unset -f have
 unset -v have

--- a/completions/_op
+++ b/completions/_op
@@ -14,7 +14,7 @@ _op_command_options()
     case $cur in
         -*)
             for i in "${!words[@]}"; do
-                [[ ${words[i]} == -* || $i -eq 0 ]] && unset "words[i]"
+                [[ ${words[i]} == -* || $i -eq 0 ]] && unset -v 'words[i]'
             done
             COMPREPLY=($(compgen -W \
                 '$(_parse_usage "$1" "${words[*]} --help") --help' -- "$cur"))

--- a/completions/crontab
+++ b/completions/crontab
@@ -18,19 +18,19 @@ _crontab()
 
     local i
     for i in "${!words[@]}"; do
-        [[ ${words[i]} && $i -ne $cword ]] && unset "opts[${words[i]}]"
+        [[ ${words[i]} && $i -ne $cword ]] && unset -v "opts[${words[i]}]"
         case "${words[i]}" in
             -l)
-                unset 'opts[-r]' 'opts[-e]' 'opts[-i]' 'opts[-s]'
+                unset -v 'opts[-r]' 'opts[-e]' 'opts[-i]' 'opts[-s]'
                 ;;
             -e)
-                unset 'opts[-l]' 'opts[-r]' 'opts[-i]'
+                unset -v 'opts[-l]' 'opts[-r]' 'opts[-i]'
                 ;;
             -r)
-                unset 'opts[-l]' 'opts[-e]'
+                unset -v 'opts[-l]' 'opts[-e]'
                 ;;
             -u)
-                unset 'opts[-i]'
+                unset -v 'opts[-i]'
                 ;;
         esac
     done

--- a/completions/cvs
+++ b/completions/cvs
@@ -157,11 +157,11 @@ _cvs()
                 local f
                 for i in "${!files[@]}"; do
                     if [[ ${files[i]} == ?(*/)CVS ]]; then
-                        unset 'files[i]'
+                        unset -v 'files[i]'
                     elif ((${#entries[@]})); then
                         for f in "${entries[@]}"; do
                             if [[ ${files[i]} == "$f" && ! -d $f ]]; then
-                                unset 'files[i]'
+                                unset -v 'files[i]'
                                 break
                             fi
                         done
@@ -355,7 +355,7 @@ _cvs()
                 if [[ $prev != -f ]]; then
                     # find out what files are missing
                     for i in "${!entries[@]}"; do
-                        [[ -r ${entries[i]} ]] && unset 'entries[i]'
+                        [[ -r ${entries[i]} ]] && unset -v 'entries[i]'
                     done
                 fi
                 ((${#entries[@]})) &&

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -115,7 +115,7 @@ _dpkg()
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     for i in ${!COMPREPLY[*]}; do
         # remove ones ending with a dash (known parse issue, hard to fix)
-        [[ ${COMPREPLY[i]} != *- ]] || unset 'COMPREPLY[i]'
+        [[ ${COMPREPLY[i]} != *- ]] || unset -v 'COMPREPLY[i]'
     done
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&

--- a/completions/find
+++ b/completions/find
@@ -101,7 +101,7 @@ _find()
         for i in "${words[@]}"; do
             [[ $i && -v onlyonce["$i"] ]] || continue
             for j in "${!COMPREPLY[@]}"; do
-                [[ ${COMPREPLY[j]} == "$i" ]] && unset 'COMPREPLY[j]'
+                [[ ${COMPREPLY[j]} == "$i" ]] && unset -v 'COMPREPLY[j]'
             done
         done
     fi

--- a/completions/info
+++ b/completions/info
@@ -62,7 +62,7 @@ _info()
     COMPREPLY=(${COMPREPLY[@]##*/?(:)})
     # weed out info dir file
     for i in ${!COMPREPLY[*]}; do
-        [[ ${COMPREPLY[i]} == dir ]] && unset "COMPREPLY[i]"
+        [[ ${COMPREPLY[i]} == dir ]] && unset -v 'COMPREPLY[i]'
     done
     # strip suffix from info pages
     COMPREPLY=(${COMPREPLY[@]%.@(gz|bz2|xz|lzma)})

--- a/completions/lvm
+++ b/completions/lvm
@@ -32,7 +32,7 @@ _lvm_logicalvolumes()
         _filedir
         local i
         for i in "${!COMPREPLY[@]}"; do
-            [[ ${COMPREPLY[i]} == */control ]] && unset 'COMPREPLY[i]'
+            [[ ${COMPREPLY[i]} == */control ]] && unset -v 'COMPREPLY[i]'
         done
     fi
 }

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -107,7 +107,7 @@ _modprobe()
                     for i in "${!mods[@]}"; do
                         for module in "${COMPREPLY[@]}"; do
                             if [[ ${mods[i]} == "$module" ]]; then
-                                unset 'mods[i]'
+                                unset -v 'mods[i]'
                                 break
                             fi
                         done

--- a/completions/protoc
+++ b/completions/protoc
@@ -49,7 +49,7 @@ _protoc()
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
             local i
             for i in "${!COMPREPLY[@]}"; do
-                [[ ${COMPREPLY[i]} == -oFILE ]] && unset 'COMPREPLY[i]'
+                [[ ${COMPREPLY[i]} == -oFILE ]] && unset -v 'COMPREPLY[i]'
             done
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return

--- a/completions/qdbus
+++ b/completions/qdbus
@@ -5,7 +5,7 @@ _qdbus()
     local cur prev words cword
     _init_completion || return
 
-    [[ -n $cur ]] && unset "words[$((${#words[@]} - 1))]"
+    [[ -n $cur ]] && unset -v "words[$((${#words[@]} - 1))]"
     COMPREPLY=($(compgen -W '$(command ${words[@]} 2>/dev/null | \
         command sed "s/(.*)//")' -- "$cur"))
 } &&

--- a/completions/tar
+++ b/completions/tar
@@ -483,7 +483,7 @@ _gtar()
 
     if [[ -v BASHCOMP_TAR_OPT_DEBUG ]]; then
         set -x
-        PS4='$BASH_SOURCE:$LINENO: '
+        local PS4='$BASH_SOURCE:$LINENO: '
     fi
 
     local cur prev words cword split
@@ -636,7 +636,6 @@ _gtar()
 
     if [[ -v BASHCOMP_TAR_OPT_DEBUG ]]; then
         set +x
-        unset PS4
     fi
 }
 

--- a/test/runLint
+++ b/test/runLint
@@ -11,10 +11,10 @@ gitgrep()
     fi
 }
 
-unset CDPATH
+unset -v CDPATH
 cd $(dirname "$0")/..
 
-cmdstart='(^|[[:space:]]|\()'
+cmdstart='(^|[[:space:];&|]|\()'
 filter_out=
 
 gitgrep $cmdstart"awk\b.*-F([[:space:]]|[[:space:]]*[\"'][^\"']{2,})" \
@@ -49,3 +49,5 @@ gitgrep '<<<' 'herestrings use temp files, use some other way'
 
 filter_out='^(test/|bash_completion\.sh)' gitgrep ' \[ ' \
     'use [[ ]] instead of [ ]'
+
+gitgrep $cmdstart'unset [^-]' 'Explicitly specify "unset -v/-f"'

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -131,7 +131,7 @@ def known_hosts(bash: pexpect.spawn) -> List[str]:
     output = assert_bash_exec(
         bash,
         '_known_hosts_real ""; '
-        r'printf "%s\n" "${COMPREPLY[@]}"; unset COMPREPLY',
+        r'printf "%s\n" "${COMPREPLY[@]}"; unset -v COMPREPLY',
         want_output=True,
     )
     return sorted(set(output.split()))

--- a/test/t/test_ls.py
+++ b/test/t/test_ls.py
@@ -24,7 +24,7 @@ class TestLs:
             assert_bash_exec(
                 bash,
                 "for u in $(compgen -u); do "
-                "eval test -d ~$u || echo $u; unset u; done",
+                "eval test -d ~$u || echo $u; unset -v u; done",
                 want_output=True,
             )
             .strip()

--- a/test/t/unit/test_unit_expand.py
+++ b/test/t/unit/test_unit_expand.py
@@ -10,7 +10,7 @@ class TestUnitExpand:
 
     def test_2(self, bash):
         """Test environment non-pollution, detected at teardown."""
-        assert_bash_exec(bash, "foo() { _expand; }; foo; unset foo")
+        assert_bash_exec(bash, "foo() { _expand; }; foo; unset -f foo")
 
     def test_user_home_compreply(self, bash, user_home):
         user, home = user_home

--- a/test/t/unit/test_unit_expand_tilde_by_ref.py
+++ b/test/t/unit/test_unit_expand_tilde_by_ref.py
@@ -12,7 +12,7 @@ class TestUnitExpandTildeByRef:
         """Test environment non-pollution, detected at teardown."""
         assert_bash_exec(
             bash,
-            '_x() { local aa="~"; __expand_tilde_by_ref aa; }; _x; unset _x',
+            '_x() { local aa="~"; __expand_tilde_by_ref aa; }; _x; unset -f _x',
         )
 
     @pytest.mark.parametrize("plain_tilde", (True, False))

--- a/test/t/unit/test_unit_filedir.py
+++ b/test/t/unit/test_unit_filedir.py
@@ -15,18 +15,18 @@ class TestUnitFiledir:
     def functions(self, request, bash):
         assert_bash_exec(
             bash,
-            "_f() { local cur=$(_get_cword); unset COMPREPLY; _filedir; }; "
+            "_f() { local cur=$(_get_cword); unset -v COMPREPLY; _filedir; }; "
             "complete -F _f f; "
             "complete -F _f -o filenames f2",
         )
         assert_bash_exec(
             bash,
-            "_g() { local cur=$(_get_cword); unset COMPREPLY; _filedir e1; }; "
+            "_g() { local cur=$(_get_cword); unset -v COMPREPLY; _filedir e1; }; "
             "complete -F _g g",
         )
         assert_bash_exec(
             bash,
-            "_fd() { local cur=$(_get_cword); unset COMPREPLY; _filedir -d; };"
+            "_fd() { local cur=$(_get_cword); unset -v COMPREPLY; _filedir -d; };"
             "complete -F _fd fd",
         )
 

--- a/test/t/unit/test_unit_init_completion.py
+++ b/test/t/unit/test_unit_init_completion.py
@@ -17,7 +17,7 @@ class TestUnitInitCompletion(TestUnitBase):
             "local cur prev words cword "
             "COMP_WORDS=() COMP_CWORD=0 COMP_LINE= COMP_POINT=0; "
             "_init_completion; }; "
-            "foo; unset foo",
+            "foo; unset -f foo",
         )
 
     def test_2(self, bash):

--- a/test/t/unit/test_unit_ip_addresses.py
+++ b/test/t/unit/test_unit_ip_addresses.py
@@ -9,19 +9,19 @@ class TestUnitIpAddresses:
     def functions(self, request, bash):
         assert_bash_exec(
             bash,
-            "_ia() { local cur=$(_get_cword);unset COMPREPLY;"
+            "_ia() { local cur=$(_get_cword);unset -v COMPREPLY;"
             "_ip_addresses; }",
         )
         assert_bash_exec(bash, "complete -F _ia ia")
         assert_bash_exec(
             bash,
-            "_iaa() { local cur=$(_get_cword);unset COMPREPLY;"
+            "_iaa() { local cur=$(_get_cword);unset -v COMPREPLY;"
             "_ip_addresses -a; }",
         )
         assert_bash_exec(bash, "complete -F _iaa iaa")
         assert_bash_exec(
             bash,
-            " _ia6() { local cur=$(_get_cword);unset COMPREPLY;"
+            " _ia6() { local cur=$(_get_cword);unset -v COMPREPLY;"
             "_ip_addresses -6; }",
         )
         assert_bash_exec(bash, "complete -F _ia6 ia6")

--- a/test/t/unit/test_unit_known_hosts_real.py
+++ b/test/t/unit/test_unit_known_hosts_real.py
@@ -50,7 +50,7 @@ class TestUnitKnownHostsReal:
         output = assert_bash_exec(
             bash,
             "_known_hosts_real -a%sF _known_hosts_real/config '%s'; "
-            r'printf "%%s\n" "${COMPREPLY[@]}"; unset COMPREPLY'
+            r'printf "%%s\n" "${COMPREPLY[@]}"; unset -v COMPREPLY'
             % (colon_flag, prefix),
             want_output=True,
         )

--- a/test/t/unit/test_unit_pgids.py
+++ b/test/t/unit/test_unit_pgids.py
@@ -12,7 +12,9 @@ class TestUnitPgids:
 
     def test_non_pollution(self, bash):
         """Test environment non-pollution, detected at teardown."""
-        assert_bash_exec(bash, "foo() { local cur=; _pgids; }; foo; unset foo")
+        assert_bash_exec(
+            bash, "foo() { local cur=; _pgids; }; foo; unset -f foo"
+        )
 
     def test_ints(self, bash):
         """Test that we get something, and only ints."""

--- a/test/t/unit/test_unit_pids.py
+++ b/test/t/unit/test_unit_pids.py
@@ -12,7 +12,9 @@ class TestUnitPids:
 
     def test_non_pollution(self, bash):
         """Test environment non-pollution, detected at teardown."""
-        assert_bash_exec(bash, "foo() { local cur=; _pids; }; foo; unset foo")
+        assert_bash_exec(
+            bash, "foo() { local cur=; _pids; }; foo; unset -f foo"
+        )
 
     def test_ints(self, bash):
         """Test that we get something, and only ints."""

--- a/test/t/unit/test_unit_pnames.py
+++ b/test/t/unit/test_unit_pnames.py
@@ -13,7 +13,7 @@ class TestUnitPnames:
     def test_non_pollution(self, bash):
         """Test environment non-pollution, detected at teardown."""
         assert_bash_exec(
-            bash, "foo() { local cur=; _pnames; }; foo; unset foo"
+            bash, "foo() { local cur=; _pnames; }; foo; unset -f foo"
         )
 
     def test_something(self, bash):

--- a/test/t/unit/test_unit_quote_readline.py
+++ b/test/t/unit/test_unit_quote_readline.py
@@ -13,7 +13,7 @@ class TestUnitQuoteReadline:
     def test_env_non_pollution(self, bash):
         """Test environment non-pollution, detected at teardown."""
         assert_bash_exec(
-            bash, "foo() { quote_readline meh >/dev/null; }; foo; unset foo"
+            bash, "foo() { quote_readline meh >/dev/null; }; foo; unset -f foo"
         )
 
     def test_github_issue_189_1(self, bash):

--- a/test/t/unit/test_unit_tilde.py
+++ b/test/t/unit/test_unit_tilde.py
@@ -11,7 +11,7 @@ class TestUnitTilde:
     def test_2(self, bash):
         """Test environment non-pollution, detected at teardown."""
         assert_bash_exec(
-            bash, 'foo() { local aa="~"; _tilde "$aa"; }; foo; unset foo'
+            bash, 'foo() { local aa="~"; _tilde "$aa"; }; foo; unset -f foo'
         )
 
     def test_3(self, bash):

--- a/test/t/unit/test_unit_xinetd_services.py
+++ b/test/t/unit/test_unit_xinetd_services.py
@@ -10,13 +10,15 @@ class TestUnitXinetdServices:
 
     def test_env_non_pollution(self, bash):
         """Test environment non-pollution, detected at teardown."""
-        assert_bash_exec(bash, "foo() { _xinetd_services; }; foo; unset foo")
+        assert_bash_exec(
+            bash, "foo() { _xinetd_services; }; foo; unset -f foo"
+        )
 
     def test_basic(self, bash):
         output = assert_bash_exec(
             bash,
-            "foo() { local BASHCOMP_XINETDDIR=$PWD/shared/bin;unset COMPREPLY; "
-            '_xinetd_services; printf "%s\\n" "${COMPREPLY[@]}"; }; foo; unset foo',
+            "foo() { local BASHCOMP_XINETDDIR=$PWD/shared/bin;unset -v COMPREPLY; "
+            '_xinetd_services; printf "%s\\n" "${COMPREPLY[@]}"; }; foo; unset -f foo',
             want_output=True,
         )
         assert sorted(output.split()) == ["arp", "ifconfig"]


### PR DESCRIPTION
I describe the detail in the commit message of each commit.