### PR TITLE
chore(pre-commit): make use of `default_stages` in commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_stages: [commit]
+
 repos:
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
@@ -18,7 +20,6 @@ repos:
         types: [text]
         files: ^(bash_completion|completions/.+|test/(config/bashrc|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
-        stages: [commit]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.7.2.1
@@ -29,7 +30,6 @@ repos:
         files: ^(bash_completion|completions/.+|test/(config/bashrc|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
         require_serial: false  # We disable SC1090 anyway, so parallel is ok
-        stages: [commit]
 
   - repo: local
     hooks:
@@ -39,7 +39,6 @@ repos:
         entry: test/update-test-cmd-list
         files: ^test/t/.+\.py$
         pass_filenames: false
-        stages: [commit]
 
   - repo: https://github.com/psf/black
     rev: 21.7b0
@@ -48,7 +47,6 @@ repos:
         types: [text]
         files: ^(helpers/python|.+\.py)$
         exclude: ^completions/
-        stages: [commit]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
@@ -67,14 +65,12 @@ repos:
         types: [text]
         files: ^(helpers/python|.+\.py)$
         exclude: ^completions/
-        stages: [commit]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3
     hooks:
       - id: isort
         args: [--filter-files, --settings-path=test/setup.cfg]
-        stages: [commit]
 
   - repo: local
     hooks:
@@ -89,7 +85,6 @@ repos:
         types: [python]
         # Intentionally not run on helpers/python (we support very old versions)
         exclude: ^completions/|^test/fixtures/pytest/
-        stages: [commit]
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.24.0
@@ -97,7 +92,6 @@ repos:
       - id: pyupgrade
         args: [--py36-plus, --keep-percent-format]
         exclude: ^completions/
-        stages: [commit]
 
   - repo: https://github.com/perltidy/perltidy
     rev: "20210717"
@@ -105,7 +99,6 @@ repos:
       - id: perltidy
         types: [text]
         files: ^(helpers/perl|.+\.p[ml])$
-        stages: [commit]
 
   - repo: local
     hooks:
@@ -117,24 +110,20 @@ repos:
         args: [--quiet, --verbose, "5"]
         types: [text]
         files: ^(helpers/perl|.+\.p[ml])$
-        stages: [commit]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.28.1
     hooks:
       - id: markdownlint
         exclude: ^CHANGELOG\.md$
-        stages: [commit]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-case-conflict
-        stages: [commit]
 
   - repo: https://github.com/crate-ci/typos
     rev: v1.0.11
     hooks:
       - id: typos
         exclude: ^(CHANGELOG\.md|test/(test-cmd-list\.txt|fixtures/.+))$
-        stages: [commit]


### PR DESCRIPTION
So we don't have to repeat `stages: [commit]` for almost all checks.