### PR TITLE
chore(pre-commit): upgrade shfmt to 3.4.0, use scop/pre-commit-shfmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,10 @@ repos:
       - id: gitlint
         stages: [commit-msg]
 
-  - repo: local
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.4.0-1
     hooks:
-      - id: shfmt
-        name: shfmt
-        language: golang
-        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.3.1]
-        entry: shfmt
-        args: [-w, -s]
+      - id: shfmt-docker
         types: [text]
         files: ^(bash_completion|completions/.+|test/(config/bashrc|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$


### PR DESCRIPTION
Use the docker variant; I believe it's more likely contributors have docker rather than go installed.