### PR TITLE
feat: Per-user opt-out when installed system-wide

### DIFF
--- a/bash_completion.sh.in
+++ b/bash_completion.sh.in
@@ -7,7 +7,8 @@ if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BASH_COMPLETION_VERSINFO
         [ "${BASH_VERSINFO[0]}" -eq 4 -a "${BASH_VERSINFO[1]}" -ge 2 ]; then
         [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion" ] &&
             . "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion"
-        if shopt -q progcomp && [ -r @datadir@/@PACKAGE@/bash_completion ]; then
+        if shopt -q progcomp && [ -r @datadir@/@PACKAGE@/bash_completion -a \
+            "x${BASH_COMPLETION_DISABLE_SYSTEMWIDE_AUTOLOAD-}" = x ]; then
             # Source completion code.
             . @datadir@/@PACKAGE@/bash_completion
         fi

--- a/doc/bash_completion.txt
+++ b/doc/bash_completion.txt
@@ -25,6 +25,10 @@ Environment variables
     loaded. If unset or null, the default compatibility directory to use is
     `/etc/bash_completion.d`.
 
+*BASH_COMPLETION_DISABLE_SYSTEMWIDE_AUTOLOAD*::
+    If set and not null, the bash_completion.sh profile.d script will not
+    source the bash_completion script.
+
 *COMP_CONFIGURE_HINTS*::
     If set and not null, `configure` completion will return the entire option
     string (e.g.  `--this-option=DESCRIPTION`) so one can see what kind of data


### PR DESCRIPTION
If the `BASH_COMPLETION_DISABLE_SYSTEMWIDE_AUTOLOAD` env var is defined
and not null (eg. inside the `~/.config/bash_completion` config file),
then `/etc/profile.d/bash_completion.sh` will not source
`bash_completion`.

Fixes #627.