### PR TITLE
fix(ssh): don't confuse arg counting with option args

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -266,6 +266,10 @@ _ssh()
     # Keep cases sorted the same they're in ssh's usage message
     # (but do group ones with same arg completion)
     case $prev in
+        -*B)
+            _available_interfaces -a
+            return
+            ;;
         -*b)
             _ip_addresses
             return
@@ -336,7 +340,7 @@ _ssh()
     else
         local args
         # Keep glob sort in sync with cases above
-        _count_args "=" "-*[bcDeLpRWEFSIiJlmOoQw]"
+        _count_args "=" "-*[BbcDeLpRWEFSIiJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
             COMPREPLY+=($(compgen -c -- "$cur"))

--- a/completions/ssh
+++ b/completions/ssh
@@ -332,13 +332,14 @@ _ssh()
     elif [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
     else
-        _known_hosts_real ${ipvx-} -a ${configfile:+-F "$configfile"} -- "$cur"
-
         local args
         _count_args "=" "-*[bcDeLpRWEFSiIJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
             COMPREPLY+=($(compgen -c -- "$cur"))
+        else
+            _known_hosts_real ${ipvx-} -a ${configfile:+-F "$configfile"} \
+                -- "$cur"
         fi
     fi
 } &&

--- a/completions/ssh
+++ b/completions/ssh
@@ -263,6 +263,8 @@ _ssh()
 
     local ipvx
 
+    # Keep cases sorted the same they're in ssh's usage message
+    # (but do group ones with same arg completion)
     case $prev in
         -*b)
             _ip_addresses
@@ -279,12 +281,12 @@ _ssh()
             _filedir
             return
             ;;
-        -*i)
-            _ssh_identityfile
-            return
-            ;;
         -*I)
             _filedir so
+            return
+            ;;
+        -*i)
+            _ssh_identityfile
             return
             ;;
         -*J)
@@ -333,7 +335,8 @@ _ssh()
         COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
     else
         local args
-        _count_args "=" "-*[bcDeLpRWEFSiIJlmOoQw]"
+        # Keep glob sort in sync with cases above
+        _count_args "=" "-*[bcDeLpRWEFSIiJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
             COMPREPLY+=($(compgen -c -- "$cur"))

--- a/completions/ssh
+++ b/completions/ssh
@@ -335,7 +335,7 @@ _ssh()
         _known_hosts_real ${ipvx-} -a ${configfile:+-F "$configfile"} -- "$cur"
 
         local args
-        _count_args
+        _count_args "=" "-*[bcDeLpRWEFSiIJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
             COMPREPLY+=($(compgen -c -- "$cur"))

--- a/test/t/test_ssh.py
+++ b/test/t/test_ssh.py
@@ -10,8 +10,12 @@ class TestSsh:
 
     @pytest.mark.complete("ssh -F config ls", cwd="ssh")
     def test_2(self, completion):
-        """Should complete both commands and hostname."""
-        assert all(x in completion for x in "ls ls_known_host".split())
+        """
+        Should not complete commands when host is not specified.
+
+        Test sanity assumes there are commands starting with `ls`.
+        """
+        assert completion == "_known_host"
 
     @pytest.mark.complete("ssh bash", cwd="ssh")
     def test_3(self, completion):

--- a/test/t/test_ssh.py
+++ b/test/t/test_ssh.py
@@ -58,3 +58,8 @@ class TestSsh:
     def test_protocol_option_bundling(self, bash, protocol):
         completion = assert_complete(bash, "ssh -%sF ssh/" % protocol)
         assert "config" in completion
+
+    @pytest.mark.complete("ssh -F config -o ForwardX11=yes ls", cwd="ssh")
+    def test_options_with_args_and_arg_counting(self, completion):
+        """Options with arguments should not confuse arg counting."""
+        assert completion == "_known_host"


### PR DESCRIPTION
Options that take an arg must not be treated as arg the _count_args way.

Closes https://github.com/scop/bash-completion/issues/647