### PR TITLE
fix ip netns list parsing

### DIFF
--- a/completions/ip
+++ b/completions/ip
@@ -360,7 +360,9 @@ _ip()
                 delete | exec | pids | set)
                     [[ $prev == "$subcmd" ]] &&
                         COMPREPLY=($(compgen -W "$(
-                            $1 -c=never netns list 2>/dev/null || $1 netns list
+                            {
+                                $1 -c=never netns list 2>/dev/null || $1 netns list
+                            } | awk '{print $1}'
                         )" -- "$cur"))
                     ;;
                 *)


### PR DESCRIPTION
…t/commit/?id=f19966efeedf5292f003aaccecc3ac3a8a069b28

    ip netns list output has change, it's now look like this
    ip netns list
    netns12 (id: 1)
    netns45 (id: 0)