### PR TITLE
Handle compspec changes during meta-command completion.

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2096,6 +2096,10 @@ _command_offset()
 
                 # restart completion (once) if function exited with 124
                 if (($? == 124 && retry_count++ == 0)); then
+                    # Note: When the completion function returns 124, the state
+                    # of COMPREPLY is discarded.
+                    COMPREPLY=()
+
                     cspec=$(complete -p "$compcmd" 2>/dev/null)
 
                     # Note: When completion spec is removed after 124, we do

--- a/bash_completion
+++ b/bash_completion
@@ -2073,48 +2073,55 @@ _command_offset()
             cspec=$(complete -p "$compcmd" 2>/dev/null)
         fi
 
-        if [[ -n $cspec ]]; then
-            for ((i = 0; i <= 1; i++)); do
-                if [[ ${cspec#* -F } != "$cspec" ]]; then
-                    # complete -F <function>
-
-                    # get function name
-                    local func=${cspec#*-F }
-                    func=${func%% *}
-
-                    if ((${#COMP_WORDS[@]} >= 2)); then
-                        $func "$cmd" "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
-                    else
-                        $func "$cmd" "${COMP_WORDS[-1]}"
-                    fi
-
-                    # restart completion (once) if function exited with 124
-                    if (($? == 124 && i == 0)); then
-                        cspec=$(complete -p "$compcmd" 2>/dev/null)
-                        [[ -n $cspec ]] && continue
-                    fi
-
-                    # restore initial compopts
-                    local opt
-                    while [[ $cspec == *" -o "* ]]; do
-                        # FIXME: should we take "+o opt" into account?
-                        cspec=${cspec#*-o }
-                        opt=${cspec%% *}
-                        compopt -o $opt
-                        cspec=${cspec#"$opt"}
-                    done
-                else
-                    cspec=${cspec#complete}
-                    cspec=${cspec%%"$compcmd"}
-                    COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
+        local retry_count=0
+        while true; do # loop for the retry request by status 124
+            if [[ ! $cspec ]]; then
+                if ((${#COMPREPLY[@]} == 0)); then
+                    # XXX will probably never happen as long as completion loader loads
+                    #     *something* for every command thrown at it ($cspec != empty)
+                    _minimal
                 fi
-                break
-            done
-        elif ((${#COMPREPLY[@]} == 0)); then
-            # XXX will probably never happen as long as completion loader loads
-            #     *something* for every command thrown at it ($cspec != empty)
-            _minimal
-        fi
+            elif [[ $cspec == *' -F '* ]]; then
+                # complete -F <function>
+
+                # get function name
+                local func=${cspec#* -F }
+                func=${func%% *}
+
+                if ((${#COMP_WORDS[@]} >= 2)); then
+                    $func "$cmd" "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
+                else
+                    $func "$cmd" "${COMP_WORDS[-1]}"
+                fi
+
+                # restart completion (once) if function exited with 124
+                if (($? == 124 && retry_count++ == 0)); then
+                    cspec=$(complete -p "$compcmd" 2>/dev/null)
+
+                    # Note: When completion spec is removed after 124, we do
+                    # not generate any completions including the default ones.
+                    # This is the behavior of the original Bash progcomp.
+                    [[ -n $cspec ]] || break
+
+                    continue
+                fi
+
+                # restore initial compopts
+                local opt
+                while [[ $cspec == *" -o "* ]]; do
+                    # FIXME: should we take "+o opt" into account?
+                    cspec=${cspec#*-o }
+                    opt=${cspec%% *}
+                    compopt -o $opt
+                    cspec=${cspec#"$opt"}
+                done
+            else
+                cspec=${cspec#complete}
+                cspec=${cspec%%"$compcmd"}
+                COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
+            fi
+            break
+        done
     fi
 }
 complete -F _command aoss command "do" else eval exec ltrace nice nohup padsp \

--- a/bash_completion
+++ b/bash_completion
@@ -2074,33 +2074,42 @@ _command_offset()
         fi
 
         if [[ -n $cspec ]]; then
-            if [[ ${cspec#* -F } != "$cspec" ]]; then
-                # complete -F <function>
+            for ((i = 0; i <= 1; i++)); do
+                if [[ ${cspec#* -F } != "$cspec" ]]; then
+                    # complete -F <function>
 
-                # get function name
-                local func=${cspec#*-F }
-                func=${func%% *}
+                    # get function name
+                    local func=${cspec#*-F }
+                    func=${func%% *}
 
-                if ((${#COMP_WORDS[@]} >= 2)); then
-                    $func "$cmd" "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
+                    if ((${#COMP_WORDS[@]} >= 2)); then
+                        $func "$cmd" "${COMP_WORDS[-1]}" "${COMP_WORDS[-2]}"
+                    else
+                        $func "$cmd" "${COMP_WORDS[-1]}"
+                    fi
+
+                    # restart completion (once) if function exited with 124
+                    if (($? == 124 && i == 0)); then
+                        cspec=$(complete -p "$compcmd" 2>/dev/null)
+                        [[ -n $cspec ]] && continue
+                    fi
+
+                    # restore initial compopts
+                    local opt
+                    while [[ $cspec == *" -o "* ]]; do
+                        # FIXME: should we take "+o opt" into account?
+                        cspec=${cspec#*-o }
+                        opt=${cspec%% *}
+                        compopt -o $opt
+                        cspec=${cspec#"$opt"}
+                    done
                 else
-                    $func "$cmd" "${COMP_WORDS[-1]}"
+                    cspec=${cspec#complete}
+                    cspec=${cspec%%"$compcmd"}
+                    COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
                 fi
-
-                # restore initial compopts
-                local opt
-                while [[ $cspec == *" -o "* ]]; do
-                    # FIXME: should we take "+o opt" into account?
-                    cspec=${cspec#*-o }
-                    opt=${cspec%% *}
-                    compopt -o $opt
-                    cspec=${cspec#"$opt"}
-                done
-            else
-                cspec=${cspec#complete}
-                cspec=${cspec%%"$compcmd"}
-                COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
-            fi
+                break
+            done
         elif ((${#COMPREPLY[@]} == 0)); then
             # XXX will probably never happen as long as completion loader loads
             #     *something* for every command thrown at it ($cspec != empty)

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -1,6 +1,13 @@
+from shlex import quote
+
 import pytest
 
 from conftest import assert_bash_exec, assert_complete
+
+
+def join(words):
+    """Return a shell-escaped string from *words*."""
+    return " ".join(quote(word) for word in words)
 
 
 @pytest.mark.bashcomp(
@@ -8,13 +15,41 @@ from conftest import assert_bash_exec, assert_complete
     ignore_env=r"^[+-](COMP(_(WORDS|CWORD|LINE|POINT)|REPLY)|cur|cword|words)=",
 )
 class TestUnitCommandOffset:
+    wordlist = sorted(["foo", "bar"])
+
     @pytest.fixture(scope="class")
     def functions(self, bash):
         assert_bash_exec(
             bash,
-            "_co1() { _command_offset 1; }; complete -F _co1 co1",
+            "_cmd1() { _command_offset 1; }; complete -F _cmd1 cmd1; "
+            "complete -F _command meta; "
+            "_compfunc() { COMPREPLY=(%s); }" % join(self.wordlist),
         )
+        completions = [
+            'complete -F _compfunc "${COMP_WORDS[0]}"',
+            'complete -W %s "${COMP_WORDS[0]}"' % quote(join(self.wordlist)),
+            'complete -r "${COMP_WORDS[0]}"',
+        ]
+
+        for idx, comp in enumerate(completions, 2):
+            assert_bash_exec(
+                bash,
+                "_cmd%(idx)s() { %(comp)s && return 124; }; "
+                "complete -F _cmd%(idx)s cmd%(idx)s"
+                % {"idx": idx, "comp": comp},
+            )
 
     def test_1(self, bash, functions):
-        assert_complete(bash, 'co1 "/tmp/aaa bbb" ')
+        assert_complete(bash, 'cmd1 "/tmp/aaa bbb" ')
         assert_bash_exec(bash, "! complete -p aaa", want_output=None)
+
+    @pytest.mark.parametrize(
+        "cmd,expected_completion",
+        [("cmd2", wordlist), ("cmd3", wordlist), ("cmd4", [])],
+    )
+    def test_2(self, bash, functions, cmd, expected_completion):
+        """
+        Test meta-completion for completion functions that signal that
+        completion should be retried (i.e. change compspec and return 124).
+        """
+        assert assert_complete(bash, "meta %s " % cmd) == expected_completion


### PR DESCRIPTION
This pull request addresses a problem that occurs when `_command_offset` is being executed (e.g. when using sudo), and a completion function exists already. When this function signals that completion should be retried (changes compspec and exits with status 124), completion is not attempted again.