### PR TITLE
Supports JEP 330 in 'java' autocompletion

### DIFF
--- a/completions/java
+++ b/completions/java
@@ -230,6 +230,8 @@ _java()
         else
             # classes completion
             _java_classes
+            # single-file source execution support (JEP 330)
+            _filedir 'java'
         fi
     fi
 


### PR DESCRIPTION
JEP 330 allows execution of single-file source code with "java" command as follows:

$ java HelloWorld.java

This commit updates the bash autocompletion to suggest *.java files in addition to precompiled classes.