### PR TITLE
Disable `/etc/bash_completion.d/redefine_filedir`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -37,10 +37,6 @@ else
     set +v
 fi
 
-# Blacklisted completions, causing problems with our code.
-#
-_comp__init_blacklist_glob='@(acroread.sh)'
-
 # Turn on extended globbing and programmable completion
 shopt -s extglob progcomp
 
@@ -2463,11 +2459,11 @@ _comp_deprecate_func _xfunc _comp_xfunc
 _comp__init_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
 if [[ -d $_comp__init_compat_dir && -r $_comp__init_compat_dir && -x $_comp__init_compat_dir ]]; then
     for _comp__init_file in "$_comp__init_compat_dir"/*; do
-        [[ ${_comp__init_file##*/} != @($_comp_backup_glob|Makefile*|$_comp__init_blacklist_glob) &&
+        [[ ${_comp__init_file##*/} != @($_comp_backup_glob|Makefile*|${BASH_COMPLETION_COMPAT_IGNORE-}) &&
             -f $_comp__init_file && -r $_comp__init_file ]] && . "$_comp__init_file"
     done
 fi
-unset -v _comp__init_compat_dir _comp__init_file _comp__init_blacklist_glob
+unset -v _comp__init_compat_dir _comp__init_file
 
 # source user completion file
 #

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -46,6 +46,32 @@ known hosts completion will omit hostnames from `HOSTFILE`. Omitting
 hostnames from `HOSTFILE` is useful if `HOSTFILE` contains many entries for
 local web development or ad-blocking.
 
+### `BASH_COMPLETION_COMPAT_IGNORE`
+
+Files in `BASH_COMPLETION_COMPAT_DIR` (the compat dir) to ignore, specified by
+a glob pattern.  The completion files in the compat dir whose basename matches
+with this pattern will not be sourced by `bash_completion` at its load time.
+This variable can be used to suppress the problematic completions.  Note that
+backup files and Makefiles in the compat dir are by default ignored regardless
+of this setting.
+
+One example is `acroread.sh` which is installed by some versions of Adobe
+Reader, overrides `_filedir` with an incompatible version, and causes
+various problems.  To recover this `_filedir`, another completion file
+`redefine_filedir` had been placed in the compat dir, which could also
+cause another incompatibility when the user uses their own version of
+bash-completion instead of the systemwide version.  To suppress these files
+one can set the following value:
+
+```bash
+export BASH_COMPLETION_COMPAT_IGNORE='@(acroread.sh|redefine_filedir)'
+```
+
+- <https://bugzilla.redhat.com/677446>
+- <http://forums.adobe.com/thread/745833>
+- <https://bugzilla.redhat.com/show_bug.cgi?id=1171396#c27>
+- <https://github.com/scop/bash-completion/pull/667>
+
 ### `BASH_COMPLETION_CMD_CONFIGURE_HINTS`
 
 If set and not null, `configure` completion will return the entire option

--- a/test/config/bashrc
+++ b/test/config/bashrc
@@ -41,6 +41,7 @@ export BASH_COMPLETION_USER_DIR=$(
 )
 # /var/empty isn't necessarily actually always empty :P
 export BASH_COMPLETION_COMPAT_DIR=/var/empty/bash_completion.d
+export BASH_COMPLETION_COMPAT_IGNORE='*'
 export XDG_DATA_DIRS=/var/empty
 
 # Make sure default settings are in effect


### PR DESCRIPTION
I'm not sure what is the most appropriate way to solve the issue, but let me explain the issue here.

Fedora (and probably its downstream RHEL and CentOS) has `/etc/bash_completion.d/redefine_filedir` which tries to overwrite the shell function `_filedir` with the version defined in `/usr/share/bash-completion/bash_completion`. This doesn't cause the problem as far as the user uses the distribution version of `bash-completion` in `/usr/share`. However, if one downloads and uses the latest version of `bash-completion`, this introduces the inconsistency because `_filedir` in `redefine_filedir` is not necessarily the same as the downloaded version.

The reason why Fedora tries to overwrite `_filedir` is explained in `/etc/bash_completion.d/redefine_filedir`:

```
# This is a copy of the _filedir function in bash_completion, included
# and (re)defined separately here because some versions of Adobe
# Reader, if installed, are known to override this function with an
# incompatible version, causing various problems.
#
# https://bugzilla.redhat.com/677446
# http://forums.adobe.com/thread/745833
```

Actually, its  workaround is already implemented in bash-completion itself in commit 2a05603ecd4af35d88b1f91c963d1ee7aaf1749e, so there is no need to source `redefine_filedir` in the latest version of `bash-completion`. So I'd propose adding `redefine_filedir` along with `acroread.sh` in the blacklist.

- [When we want to use `acroread.sh`] By the way, the blacklist is somehow made empty in the distributed version of bash-completion in Fedora. Maybe it is because they still want to allow `acroread.sh`. But, even when we intendedly source `acroread.sh`, I'm not sure if `acroread.sh` still has the problem after ten years.
- [Background of PR] Actually, I haven't faced with an explicit inconsistency by the older version of `_filedir`, but the older version of `_filedir` caused the performance issue. Currently the result of `compgen` is processed by `IFS=$'\n'; COMPREPLY=($(compgen ...))`, but an older version of `_filedir` had used `while read -r line: do ... done <<< $(compgen ...)` which is very slow in the directory with thousands of files. This was discussed in
  - https://github.com/banoris/dotfiles/issues/11#issuecomment-997354377 (the second item)
  
  I tried to replace `_filedir` with the latest implementation, but the problem is that **there is no way to disable `redefine_filedir` forcing an old `_filedir`** (other than disabling entire `/etc/bash_completion.d` by setting `BASH_COMPLETION_COMPAT_DIR`) even though I am using the latest version of `bash-completion`.

As @scop has mentioned in https://bugzilla.redhat.com/677446, maybe we can think about *namespacing* bash-completion functions (cf #537) for this. Nevertheless I tend to think we can include `redefine_filedir` in the blacklist as far as we have `acroread.sh` there. Maybe there is another approach. What do you think?




