### PR TITLE
doc(styleguide): fix asciidoc format

### DIFF
--- a/doc/styleguide.txt
+++ b/doc/styleguide.txt
@@ -61,22 +61,22 @@ need that kind of processing (e.g. file and command names). The
 _filedir and _filedir_xspec helpers do this automatically whenever
 they return some completions.
 
-&#91;[ ${COMPREPLY-} == *= ]] && compopt -o nospace
-------------------------------------------------
+`[[ ${COMPREPLY-} == *= ]] && compopt -o nospace`
+-------------------------------------------------
 
 The above is functionally a shorthand for:
-----
-if [[ ${#COMPREPLY[@]} -eq 1 && ${COMPREPLY[0]} == *= ]]; then
-    compopt -o nospace
-fi
-----
+
+    if [[ ${#COMPREPLY[@]} -eq 1 && ${COMPREPLY[0]} == *= ]]; then
+        compopt -o nospace
+    fi
+
 It is used to ensure that long options' name won't get a space
 appended after the equal sign.  Calling compopt -o nospace makes sense
 in case completion actually occurs: when only one completion is
 available in COMPREPLY.
 
-$split && return
-----------------
+`$split && return`
+------------------
 
 Should be used in completions using the -s flag of _init_completion,
 or other similar cases where _split_longopt has been invoked, after


### PR DESCRIPTION
I have noticed that `doc/*.txt` are actually AsciiDoc, and some of the formatting in the HTML file `doc/html~/main.html` generated by `./makeHtml.sh` is broken. This PR fixes the formatting.