### PR TITLE
feat(ssh-keygen): sync -O options with openssh 8.4p1, FIDO arg fixes

### DIFF
--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -85,8 +85,8 @@ _ssh_keygen()
                         cur=${cur#*=}
                         _filedir
                         ;;
-                    application=)
-                        COMPREPLY=("ssh:")
+                    application=*([^:=]))
+                        COMPREPLY=($(compgen -W "ssh:" -- "${cur#*=}"))
                         compopt -o nospace
                         ;;
                     user=*)

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -66,11 +66,12 @@ _ssh_keygen()
                     no-x11-forwarding permit-agent-forwarding
                     permit-port-forwarding permit-pty permit-user-rc
                     permit-X11-forwarding no-touch-required source-address=
+                    verify-required
 
                     lines= start-line= checkpoint= memory= start= generator=
 
-                    application challenge= device resident user
-                    write-attestation-path
+                    application= challenge= device= no-touch-required resident
+                    user= write-attestation=
                     ' -- "$cur"))
                 [[ ${COMPREPLY-} == *[:=] ]] && compopt -o nospace
                 __ltrim_colon_completions "$cur"
@@ -80,9 +81,16 @@ _ssh_keygen()
                         compopt -o filenames
                         COMPREPLY=($(compgen -c -- "${cur#*=}"))
                         ;;
-                    checkpoint=* | challenge=*)
+                    checkpoint=* | challenge=* | write-attestation=*)
                         cur=${cur#*=}
                         _filedir
+                        ;;
+                    application=)
+                        COMPREPLY=("ssh:")
+                        compopt -o nospace
+                        ;;
+                    user=*)
+                        COMPREPLY=($(compgen -u -- "${cur#*=}"))
                         ;;
                 esac
             fi

--- a/test/t/test_ssh_keygen.py
+++ b/test/t/test_ssh_keygen.py
@@ -69,3 +69,7 @@ class TestSshKeygen:
     @pytest.mark.complete("ssh-keygen -O unknown=")
     def test_O_unknown(self, completion):
         assert not completion
+
+    @pytest.mark.complete("ssh-keygen -O application=")
+    def test_O_application(self, completion):
+        assert completion == "ssh:"

--- a/test/t/test_ssh_keygen.py
+++ b/test/t/test_ssh_keygen.py
@@ -73,3 +73,15 @@ class TestSshKeygen:
     @pytest.mark.complete("ssh-keygen -O application=")
     def test_O_application(self, completion):
         assert completion == "ssh:"
+
+    @pytest.mark.complete("ssh-keygen -O application=s")
+    def test_O_application_s(self, completion):
+        assert completion == "sh:"
+
+    @pytest.mark.complete("ssh-keygen -O application=ssh:")
+    def test_O_application_ssh_colon(self, completion):
+        assert not completion
+
+    @pytest.mark.complete("ssh-keygen -O application=nonexistent")
+    def test_O_application_nonexistent(self, completion):
+        assert not completion


### PR DESCRIPTION
The man page is missing bunch of equal signs for FIDO options that take an argument.