### PR TITLE
feat(feh): complete on WebP images

### DIFF
--- a/completions/feh
+++ b/completions/feh
@@ -113,7 +113,7 @@ _feh()
 
     # FIXME: It is hard to determine correct supported extensions.
     # feh can handle any format that imagemagick can plus some others
-    _filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)'
+    _filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp'
 } &&
     complete -F _feh feh
 


### PR DESCRIPTION
(trivial change)

`feh` (as well as ImageMagick) has been supporting WebP for a while now. WebP has already gained much traction as a successor to PNG and JPEG, so it’s important than completion lets us open them. :-)