### PR TITLE
rsync: improve completion by using _parse_help

### DIFF
--- a/completions/rsync
+++ b/completions/rsync
@@ -37,32 +37,15 @@ _rsync()
 
     case $cur in
         -*)
-            COMPREPLY=($(compgen -W '--verbose --quiet --no-motd --checksum
-                --archive --recursive --relative --no-implied-dirs
-                --backup --backup-dir= --suffix= --update --inplace --append
-                --append-verify --dirs --old-dirs --links --copy-links
-                --copy-unsafe-links --safe-links --copy-dirlinks
-                --keep-dirlinks --hard-links --perms --executability --chmod=
-                --acls --xattrs --owner --group --devices --copy-devices
-                --specials --times --omit-dir-times --super --fake-super
-                --sparse --dry-run --whole-file --no-whole-file
-                --one-file-system --block-size= --rsh= --rsync-path=
-                --existing --ignore-existing --remove-source-files --delete
-                --delete-before --delete-during --delete-delay --delete-after
-                --delete-excluded --ignore-errors --force --max-delete=
-                --max-size= --min-size= --partial --partial-dir=
-                --delay-updates --prune-empty-dirs --numeric-ids --timeout=
-                --contimeout= --ignore-times --size-only --modify-window=
-                --temp-dir= --fuzzy --compare-dest= --copy-dest= --link-dest=
-                --compress --compress-level= --skip-compress= --cvs-exclude
-                --filter= --exclude= --exclude-from= --include= --include-from=
-                --files-from= --from0 --protect-args --address= --port=
-                --sockopts= --blocking-io --no-blocking-io --stats
-                --8-bit-output --human-readable --progress --itemize-changes
-                --out-format= --log-file= --log-file-format= --password-file=
-                --list-only --bwlimit= --write-batch= --only-write-batch=
-                --read-batch= --protocol= --iconv= --ipv4 --ipv6 --version
-                --help --daemon --config= --no-detach' -- "$cur"))
+            COMPREPLY=($(
+                # Account for the fact that older rsync versions (before cba00be6, meaning before v3.2.0)
+                # contain the following unusual line in --help:
+                # "(-h) --help                  show this help (-h is --help only if used alone)"
+                compgen -W '$(
+                "$1" --help 2>&1 | sed -e "s/^([^)]*)//" | _parse_help -)
+                --daemon --old-d{,irs}
+                --no-{blocking-io,detach,whole-file,inc-recursive,i-r}' -X '--no-OPTION' -- "$cur"
+            ))
             [[ ${COMPREPLY-} == *= ]] || compopt +o nospace
             ;;
         *:*)

--- a/test/t/test_rsync.py
+++ b/test/t/test_rsync.py
@@ -14,3 +14,7 @@ class TestRsync:
     @pytest.mark.complete("rsync --rsh=")
     def test_3(self, completion):
         assert completion == "rsh ssh".split()
+
+    @pytest.mark.complete("rsync --", require_cmd=True)
+    def test_4(self, completion):
+        assert "--help" in completion

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -318,6 +318,7 @@ rmdir
 rmmod
 rpm
 rpmbuild
+rsync
 rtcwake
 sbopkg
 screen


### PR DESCRIPTION
Hi,
I often need this option and I find the name rather long, it would be nice to have it completed.

In order to limit the size of the diff, I didn't try to optimize the layout of the options in the `COMPREPLY` variable. Let me know if that is a problem.