### PR TITLE
Properly handle environments with unset IFS

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -149,6 +149,23 @@ dequote()
     eval printf %s "$1" 2>/dev/null
 }
 
+# Unset the given variables across a scope boundary. Useful for unshadowing
+# global scoped variables. Note that simply calling unset on a local variable
+# will not unshadow the global variable. Rather, the result will be a local
+# variable in an unset state.
+# Usage: local IFS='|'; _comp_unlocal IFS
+# Param: $* Variable names to be unset
+_comp_unlocal()
+{
+    if ((BASH_VERSINFO[0] >= 5)) && shopt -q localvar_unset; then
+        shopt -u localvar_unset
+        unset -v "$@"
+        shopt -s localvar_unset
+    else
+        unset -v "$@"
+    fi
+}
+
 # Assign variable one scope above the caller
 # Usage: local "$1" && _upvar $1 "value(s)"
 # Param: $1  Variable name to assign value to
@@ -721,12 +738,12 @@ _comp_delimited()
         # glob char escaping issues to deal with. Do removals by hand instead.
         COMPREPLY=($(compgen "$@"))
         local -a existing
-        local x i ifs=$IFS IFS=$delimiter
+        local x i IFS=$delimiter
         existing=($cur)
         # Do not remove the last from existing if it's not followed by the
         # delimiter so we get space appended.
         [[ ! $cur || $cur == *"$delimiter" ]] || unset -v "existing[${#existing[@]}-1]"
-        IFS=$ifs
+        _comp_unlocal IFS
         if ((${#COMPREPLY[@]})); then
             for x in ${existing+"${existing[@]}"}; do
                 for i in "${!COMPREPLY[@]}"; do
@@ -1253,14 +1270,13 @@ else
         if [[ ${1-} == -s ]]; then
             procs=($(command ps ax -o comm | command sed -e 1d))
         else
-            local line i=-1 ifs=$IFS
-            IFS=$'\n'
+            local line i=-1 IFS=$'\n'
             # Some versions of ps don't support "command", but do "comm", e.g.
             # some busybox ones. Fall back
             local -a psout=($({
                 command ps ax -o command= || command ps ax -o comm=
             } 2>/dev/null))
-            IFS=$ifs
+            _comp_unlocal IFS
             for line in "${psout[@]}"; do
                 if ((i == -1)); then
                     # First line, see if it has COMMAND column header. For
@@ -1751,7 +1767,7 @@ _included_ssh_config_files()
 # Return: Completions, starting with CWORD, are added to COMPREPLY[]
 _known_hosts_real()
 {
-    local configfile flag prefix="" ifs=$IFS
+    local configfile flag prefix=""
     local cur suffix="" aliases i host ipv4 ipv6
     local -a kh tmpkh=() khd=() config=()
 
@@ -1817,7 +1833,7 @@ _known_hosts_real()
         #          spaces in their name work (watch out for ~ expansion
         #          breakage! Alioth#311595)
         tmpkh=($(awk 'sub("^[ \t]*([Gg][Ll][Oo][Bb][Aa][Ll]|[Uu][Ss][Ee][Rr])[Kk][Nn][Oo][Ww][Nn][Hh][Oo][Ss][Tt][Ss][Ff][Ii][Ll][Ee][ \t=]+", "") { print $0 }' "${config[@]}" | sort -u))
-        IFS=$ifs
+        _comp_unlocal IFS
     fi
     if ((${#tmpkh[@]} != 0)); then
         local j
@@ -1873,7 +1889,7 @@ _known_hosts_real()
                         # Add host to candidates
                         COMPREPLY+=($host)
                     done
-                    IFS=$ifs
+                    _comp_unlocal IFS
                 done <"$i"
             done
             ((${#COMPREPLY[@]})) &&
@@ -1935,7 +1951,6 @@ _known_hosts_real()
             $(compgen -A hostname -P "$prefix" -S "$suffix" -- "$cur"))
     fi
 
-    IFS=$' \t\n'
     $reset
 
     if ((${#COMPREPLY[@]})); then
@@ -2349,12 +2364,12 @@ complete -F _minimal ''
 __load_completion()
 {
     local -a dirs=(${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions)
-    local ifs=$IFS IFS=: dir cmd="${1##*/}" compfile
+    local IFS=: dir cmd="${1##*/}" compfile
     [[ -n $cmd ]] || return 1
     for dir in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do
         dirs+=($dir/bash-completion/completions)
     done
-    IFS=$ifs
+    _comp_unlocal IFS
 
     if [[ $BASH_SOURCE == */* ]]; then
         dirs+=("${BASH_SOURCE%/*}/completions")

--- a/completions/7z
+++ b/completions/7z
@@ -49,9 +49,9 @@ _7z()
             local reset=$(shopt -po noglob)
             set -o noglob
             compopt -o filenames
-            local ifs=$IFS IFS=$'\n'
+            local IFS=$'\n'
             COMPREPLY=($(compgen -d -P${cur:0:2} -S/ -- "${cur:2}"))
-            IFS=$ifs
+            _comp_unlocal IFS
             $reset
             compopt -o nospace
             return

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -25,9 +25,9 @@ _reply_compgen_array()
     ecur=${ecur//\'/\\\'}
 
     # Actually generate completions.
-    local ifs=$IFS
-    IFS=$'\n' eval 'COMPREPLY=(`compgen -W "$wlist" -- "${ecur}"`)'
-    IFS=$ifs
+    local IFS=$'\n'
+    COMPREPLY=($(compgen -W "$wlist" -- "${ecur}"))
+    _comp_unlocal IFS
 }
 
 # Unescape strings in the linux fstab(5) format (with octal escapes).
@@ -49,24 +49,23 @@ _linux_fstab()
 
     # Read and unescape values into COMPREPLY
     local fs_spec fs_file fs_other
-    local ifs="$IFS"
     while read -r fs_spec fs_file fs_other; do
         if [[ $fs_spec == [#]* ]]; then continue; fi
         if [[ ${1-} == -L ]]; then
             local fs_label=${fs_spec/#LABEL=/}
             if [[ $fs_label != "$fs_spec" ]]; then
                 __linux_fstab_unescape fs_label
-                IFS=$'\0'
+                local IFS=$'\0'
                 COMPREPLY+=("$fs_label")
-                IFS=$ifs
+                _comp_unlocal IFS
             fi
         else
             __linux_fstab_unescape fs_spec
             __linux_fstab_unescape fs_file
-            IFS=$'\0'
+            local IFS=$'\0'
             [[ $fs_spec == */* ]] && COMPREPLY+=("$fs_spec")
             [[ $fs_file == */* ]] && COMPREPLY+=("$fs_file")
-            IFS=$ifs
+            _comp_unlocal IFS
         fi
     done
 

--- a/completions/svcadm
+++ b/completions/svcadm
@@ -44,10 +44,9 @@ _smf_complete_fmri()
             # we generate all possibles abbreviations for the FMRI
             # no need to have a generic loop as we will have a finite
             # number of components
-            local ifs="$IFS"
-            IFS="/"
+            local IFS="/"
             set -- $fmri
-            IFS=$ifs
+            _comp_unlocal IFS
             case $# in
                 1) fmri_part_list=" $1" ;;
                 2) fmri_part_list=" $2 $1/$2" ;;

--- a/test/t/unit/test_unit_unlocal.py
+++ b/test/t/unit/test_unit_unlocal.py
@@ -1,0 +1,18 @@
+import pytest
+
+from conftest import assert_bash_exec
+
+
+@pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+(VAR=|declare -f foo)")
+class TestUnlocal:
+    def test_1(self, bash):
+        cmd = (
+            "foo() { "
+            "local VAR=inner; "
+            "_comp_unlocal VAR; "
+            "echo $VAR; "
+            "}; "
+            "VAR=outer; foo; "
+        )
+        res = assert_bash_exec(bash, cmd, want_output=True).strip()
+        assert res == "outer"


### PR DESCRIPTION
From the bash man page:

    Word Splitting
    ...snip...
    The shell treats each character of IFS as a delimiter, and splits the
    results of the other expansions into words using these characters as
    field terminators.  If IFS is unset, or its value is exactly
    <space><tab><newline>, the  default, then  sequences of <space>, <tab>,
    and <newline> at the beginning and end of the results of the previous
    expansions are ignored, and any sequence of IFS characters not at the
    beginning or end serves to delimit words.  If IFS has a value other than
    the default, then sequences of the whitespace characters space, tab, and
    newline are ignored at the beginning and end of the word, as long as the
    whitespace character is in the value of IFS (an IFS whitespace
    character).  Any character  in  IFS that is not IFS whitespace, along
    with any adjacent IFS whitespace characters, delimits a field.  A
    sequence of IFS whitespace characters is also treated as a delimiter.
    If the value of IFS is null, no word splitting occurs.

Per this paragraph, IFS can have one of three states:

1. IFS is set to some value, eg $' \t\n'
2. IFS is unset, in which case it behaves like $' \t\n'
3. IFS is null, in this case no splitting occurs.

Prior to this commit, the current state of `IFS` was stored into a local
variable `ifs`. Later, IFS is restored by setting `IFS=$ifs`. If the
user starts with either a set `IFS` or a null `IFS`, then this behavior
is correct. If the user starts with an unset `IFS`, then `IFS=$ifs`
results in a NULL `IFS`, which is not the original state. Most of the
time a null `IFS` is not desired, and indeed it breaks some things
inside bash-completions. eg

```
unset IFS
local ifs=$IFS IFS=$' \t\n'
restore=$(shopt -po noglob)
IFS=$ifs
$restore
```

Above the line `IFS=$ifs` puts us in a NULL `IFS` state, which is not
where we started. The line `$restore` fails with a confusing error
message `-bash: set -o noglob: command not found`.

In addition, this pattern does not make good use of bash shadowing
rules. When a `local IFS` shadows the global `IFS`, all that is needed
to restore the global IFS is to unset the local one.

With this commit, all instances of `local ifs=$IFS` have been removed.