### PR TITLE
fix(_umount.linux): remove unnecessary IFS setups

### DIFF
--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -55,17 +55,13 @@ _linux_fstab()
             local fs_label=${fs_spec/#LABEL=/}
             if [[ $fs_label != "$fs_spec" ]]; then
                 __linux_fstab_unescape fs_label
-                local IFS=$'\0'
                 COMPREPLY+=("$fs_label")
-                _comp_unlocal IFS
             fi
         else
             __linux_fstab_unescape fs_spec
             __linux_fstab_unescape fs_file
-            local IFS=$'\0'
             [[ $fs_spec == */* ]] && COMPREPLY+=("$fs_spec")
             [[ $fs_file == */* ]] && COMPREPLY+=("$fs_file")
-            _comp_unlocal IFS
         fi
     done
 


### PR DESCRIPTION
This removes some ineffective `IFS` settings found in #687 like the following:

```bash
                local IFS=$'\0'
                COMPREPLY+=("$fs_label")
                _comp_unlocal IFS
```

First of all, the value `"$fs_label"` is quoted so that the word splitting is disabled. So the behavior doesn't change by changing `IFS`. Next, Bash doesn't allow storing NUL in the variable, so `IFS=$'\0'` actually results in an empty value `IFS=''`.

I'm not sure what has been the original intent of setting NUL to `IFS`. I have checked the change history. This `IFS` setting was originally introduced in commit [`99b2894`](https://github.com/scop/bash-completion/commit/99b289474ead02cc8c629ceec1192ce9f0b4f84e#diff-a33e10856930590d5777b4de609f66b088b7477e930a200bb2439e83724ef328L51-R87). At that time, the code looked like

```bash
IFS=$'\0' eval "COMPRELPY+=( $'$fs_spec' )"
```

where `fs_spec` may contain some octal escape sequences of the form `\040`. Here `eval` is used to resolve the octal escape sequences. At this point, `IFS=$'\0'` already doesn't have any effects because `$'...'` is anyway a quoted string and thus not subject to the word splitting. I've also checked the changes in the history until the current version ([`1c4b461`](https://github.com/scop/bash-completion/commit/1c4b461882c94febb39a550e0fe3065208139757#diff-a33e10856930590d5777b4de609f66b088b7477e930a200bb2439e83724ef328R55-R60), [`2f61acd`](https://github.com/scop/bash-completion/commit/2f61acd068a67e630dd28ce04157908398dd8798#diff-a33e10856930590d5777b4de609f66b088b7477e930a200bb2439e83724ef328R50-R53), [`4375c4b`](https://github.com/scop/bash-completion/commit/4375c4b94ea7bdd370cd771aeb3483f36a42bd9f#diff-a33e10856930590d5777b4de609f66b088b7477e930a200bb2439e83724ef328L50-L53)), but the setting of `IFS` did not seem to take effect at any point, So, actually the setting `IFS=$'\0'` can be safely dropped without any regression.

----

Even though the code has never worked expectedly, we might guess what has been the original intent of `IFS=$'\0'`. The original code is introduced to properly process the escape sequences used in `/etc/fstab` such as `\040` for a space.

- One possibility is that `\000` or a NUL character can be used to separate multiple filesystems in a single line of `/etc/fstab`. If this is the case, we can handle NUL-separated data using `read -d ''`. I have searched for whether there are any descriptions on NUL in `/etc/fstab` but could not find any mentions of the special meaning of NUL in `/etc/fstab`. I can find some explanations on the escape sequences in [`man fstab`](https://linux.die.net/man/5/fstab) and other Q&A sites ([1](https://stackoverflow.com/questions/15316017/how-do-i-specify-a-label-path-with-spaces-in-etc-fstab), [2](https://lists.ubuntu.com/archives/ubuntu-users/2011-February/240440.html), [3](https://www.linuxquestions.org/questions/linux-newbie-8/escaping-space-in-etc-fstab-with-%5C-is-not-recognized-4175661169/)). but none seem to mention NUL.
- Another possibility is that just the original author wanted to make sure that the word splitting will not happen. However, that was actually not needed because the word splitting doesn't happen for quoted strings.

Maybe the original author @cdleonard remembers something at that time.