### PR TITLE
test(ubuntu14): switch Python to Pyston 2.3.1

### DIFF
--- a/test/docker/ubuntu14/Dockerfile
+++ b/test/docker/ubuntu14/Dockerfile
@@ -9,12 +9,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         make \
         software-properties-common \
         xvfb \
-    && apt-add-repository -y ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get -y --no-install-recommends install \
-        python3.6 \
-    && python3.6 -c "import urllib.request; urllib.request.urlretrieve('https://bootstrap.pypa.io/get-pip.py', '/tmp/get-pip.py')" \
-    && python3.6 /tmp/get-pip.py --prefix /usr/local
+    && python3.4 -c "import urllib.request; urllib.request.urlretrieve('https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable_v2.tar.gz', '/tmp/pyston.tar.gz')" \
+    && tar xCf /usr/local /tmp/pyston.tar.gz --strip-components=1
 
 ADD test-cmd-list.txt \
     requirements.txt \
@@ -22,7 +18,7 @@ ADD test-cmd-list.txt \
     /tmp/
 
 RUN set -x \
-    && python3.6 -m pip install --prefix /usr/local -Ir /tmp/requirements.txt
+    && pyston3 -m pip install -Ir /tmp/requirements.txt
 
 RUN /tmp/install-packages.sh </tmp/test-cmd-list.txt \
     && rm -r /tmp/* /root/.cache/pip /var/lib/apt/lists/*


### PR DESCRIPTION
deadsnakes packages for Ubuntu 14.04 and 16.04 no longer exist, switch to portable Pyston 2.3.1. Go with Pyston instead of PyPy for (hopefully) better compatibility with CPython.

- https://github.com/deadsnakes/issues/issues/195
- https://github.com/scop/bash-completion/runs/4995567978?check_suite_focus=true#step:4:548

The primary reasons Ubuntu 14 is still kept around in the test matrix are that it's our only bash 4.3 environment at the moment, and it's nice to be able to test against various older versions of tools -- the coverage with e.g. CentOS 7 isn't as big.