### PR TITLE
feat(_comp_expand_glob): Add a utility to safely perform pathname expansions (Fix #705)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1148,15 +1148,20 @@ _mac_addresses()
 #
 _configured_interfaces()
 {
+    local -a files
     if [[ -f /etc/debian_version ]]; then
         # Debian system
+        _comp_expand_glob files '/etc/network/interfaces /etc/network/interfaces.d/*'
+        ((${#files[@]})) || return 0
         COMPREPLY=($(compgen -W "$(command sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p' \
-            /etc/network/interfaces /etc/network/interfaces.d/* 2>/dev/null)" \
+            "${files[@]}" 2>/dev/null)" \
             -- "$cur"))
     elif [[ -f /etc/SuSE-release ]]; then
         # SuSE system
+        _comp_expand_glob files '/etc/sysconfig/network/ifcfg-*'
+        ((${#files[@]})) || return 0
         COMPREPLY=($(compgen -W "$(printf '%s\n' \
-            /etc/sysconfig/network/ifcfg-* |
+            "${files[@]}" |
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
     elif [[ -f /etc/pld-release ]]; then
         # PLD Linux
@@ -1165,8 +1170,10 @@ _configured_interfaces()
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
     else
         # Assume Red Hat
+        _comp_expand_glob files '/etc/sysconfig/network-scripts/ifcfg-*'
+        ((${#files[@]})) || return 0
         COMPREPLY=($(compgen -W "$(printf '%s\n' \
-            /etc/sysconfig/network-scripts/ifcfg-* |
+            "${files[@]}" |
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
     fi
 }
@@ -1422,12 +1429,12 @@ _xinetd_services()
 {
     local xinetddir=${_comp__test_xinetd_dir:-/etc/xinetd.d}
     if [[ -d $xinetddir ]]; then
-        local IFS=$' \t\n' reset=$(shopt -p nullglob)
-        shopt -s nullglob
-        local -a svcs=($xinetddir/!($_comp_backup_glob))
-        $reset
-        ((!${#svcs[@]})) ||
+        local -a svcs
+        _comp_expand_glob svcs '$xinetddir/!($_comp_backup_glob)'
+        if ((${#svcs[@]})); then
+            local IFS=$'\n'
             COMPREPLY+=($(compgen -W '"${svcs[@]#$xinetddir/}"' -- "${cur-}"))
+        fi
     fi
 }
 
@@ -1438,12 +1445,9 @@ _services()
     local sysvdirs
     _sysvdirs
 
-    local IFS=$' \t\n' reset=$(shopt -p nullglob)
-    shopt -s nullglob
-    COMPREPLY=(
-        $(printf '%s\n' ${sysvdirs[0]}/!($_comp_backup_glob|functions|README)))
-    $reset
+    _comp_expand_glob COMPREPLY '${sysvdirs[0]}/!($_comp_backup_glob|functions|README)'
 
+    local IFS=$'\n'
     COMPREPLY+=($({
         systemctl list-units --full --all ||
             systemctl list-unit-files
@@ -1474,7 +1478,7 @@ _service()
         _services
         [[ -e /etc/mandrake-release ]] && _xinetd_services
     else
-        local sysvdirs
+        local IFS=$'\n' sysvdirs
         _sysvdirs
         COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
@@ -1726,7 +1730,9 @@ _terms()
         {
             toe -a || toe
         } | awk '{ print $1 }'
-        find /{etc,lib,usr/lib,usr/share}/terminfo/? -type f -maxdepth 1 |
+        _comp_expand_glob dirs '/{etc,lib,usr/lib,usr/share}/terminfo/?'
+        ((${#dirs[@]})) &&
+            find "${dirs[@]}" -type f -maxdepth 1 |
             awk -F/ '{ print $NF }'
     } 2>/dev/null)" -- "$cur"))
 }

--- a/bash_completion
+++ b/bash_completion
@@ -1786,7 +1786,7 @@ _included_ssh_config_files()
 {
     (($# < 1)) &&
         echo "bash_completion: $FUNCNAME: missing mandatory argument CONFIG" >&2
-    local configfile i f
+    local configfile i files f
     configfile=$1
 
     local IFS=$' \t\n' reset=$(shopt -po noglob)
@@ -1809,15 +1809,16 @@ _included_ssh_config_files()
         fi
         __expand_tilde_by_ref i
         # In case the expanded variable contains multiple paths
-        set +o noglob
-        for f in $i; do
-            if [[ -r $f ]]; then
-                config+=("$f")
-                # The Included file is processed to look for Included files in itself
-                _included_ssh_config_files $f
-            fi
-        done
-        $reset
+        _comp_expand_glob files '$i'
+        if ((${#files[@]})); then
+            for f in "${files[@]}"; do
+                if [[ -r $f ]]; then
+                    config+=("$f")
+                    # The Included file is processed to look for Included files in itself
+                    _included_ssh_config_files $f
+                fi
+            done
+        fi
     done
 } # _included_ssh_config_files()
 

--- a/bash_completion
+++ b/bash_completion
@@ -260,6 +260,55 @@ _upvars()
     done
 }
 
+# Get the list of filenames that match with the specified glob pattern.
+# This function does the globbing in a controlled environment, avoiding
+# interference from user's shell options/settings or environment variables.
+# @param $1 array_name  Array name
+#   The array name should not start with the double underscores "__".  The
+#   array name should not be "GLOBIGNORE".
+# @param $2 pattern     Pattern string to be evaluated.
+#   This pattern string will be evaluated using "eval", so brace expansions,
+#   parameter expansions, command substitutions, and other expansions will be
+#   processed.  The user-provided strings should not be directly specified to
+#   this argument.
+_comp_expand_glob()
+{
+    if (($# != 2)); then
+        printf 'bash-completion: %s: unexpected number of arguments\n' "$FUNCNAME" >&2
+        printf 'usage: %s ARRAY_NAME PATTERN\n' "$FUNCNAME" >&2
+        return 2
+    elif [[ $1 == @(GLOBIGNORE|__*|*[^_a-zA-Z0-9]*|[0-9]*|'') ]]; then
+        printf 'bash-completion: %s: invalid array name "%s"\n' "$FUNCNAME" "$1" >&2
+        return 2
+    fi
+
+    # Save and adjust the settings.
+    local __original_opts=$SHELLOPTS:$BASHOPTS
+    set +o noglob
+    shopt -s nullglob
+    shopt -u failglob dotglob
+
+    # Also the user's GLOBIGNORE may affect the result of pathname expansions.
+    local GLOBIGNORE=
+
+    eval -- "$1=()" # a fallback in case that the next line fails.
+    eval -- "$1=($2)"
+
+    # Restore the settings.  Note: Changing GLOBIGNORE affects the state of
+    # "shopt -q dotglob", so we need to explicitly restore the original state
+    # of "shopt -q dotglob".
+    _comp_unlocal GLOBIGNORE
+    if [[ :$__original_opts: == *:dotglob:* ]]; then
+        shopt -s dotglob
+    else
+        shopt -u dotglob
+    fi
+    [[ :$__original_opts: == *:nullglob:* ]] || shopt -u nullglob
+    [[ :$__original_opts: == *:failglob:* ]] && shopt -s failglob
+    [[ :$__original_opts: == *:noglob:* ]] && set -o noglob
+    return 0
+}
+
 # Reassemble command line words, excluding specified characters from the
 # list of word completion separators (COMP_WORDBREAKS).
 # @param $1 chars  Characters out of $COMP_WORDBREAKS which should

--- a/completions/_rtcwake
+++ b/completions/_rtcwake
@@ -17,7 +17,7 @@ _rtcwake()
             return
             ;;
         --device | -d)
-            COMPREPLY=($(command ls -d /dev/rtc?* 2>/dev/null))
+            _comp_expand_glob COMPREPLY '/dev/rtc?*'
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]#/dev/}"' -- "$cur"))
             return

--- a/completions/_yum
+++ b/completions/_yum
@@ -30,7 +30,10 @@ _yum_repolist()
 
 _yum_plugins()
 {
-    command ls /usr/lib/yum-plugins/*.py{,c,o} 2>/dev/null |
+    local -a files
+    _comp_expand_glob files '/usr/lib/yum-plugins/*.py{,c,o}'
+    ((${#files[@]})) &&
+        printf '%s\n' "${files[@]}" |
         command sed -ne 's|.*/\([^./]*\)\.py[co]\{0,1\}$|\1|p' | sort -u
 }
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -133,7 +133,7 @@ _dpkg_reconfigure()
 
     case $prev in
         --frontend | -!(-*)f)
-            opt=(/usr/share/perl5/Debconf/FrontEnd/*)
+            _comp_expand_glob opt '/usr/share/perl5/Debconf/FrontEnd/*'
             if ((${#opt[@]})); then
                 opt=(${opt[@]##*/})
                 opt=(${opt[@]%.pm})

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -354,7 +354,7 @@ _hciattach()
         _count_args
         case $args in
             1)
-                COMPREPLY=(/dev/tty*)
+                _comp_expand_glob COMPREPLY '/dev/tty*'
                 ((${#COMPREPLY[@]})) &&
                     COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"
                         "${COMPREPLY[@]#/dev/}"' -- "$cur"))

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -10,15 +10,12 @@ _hunspell()
             return
             ;;
         -d)
-            local IFS=$' \t\n' reset=$(shopt -p nullglob)
-            shopt -s nullglob
-            local -a dicts=(/usr/share/hunspell/*.dic
-                /usr/local/share/hunspell/*.dic)
-            $reset
+            local -a dicts
+            _comp_expand_glob dicts '/usr/share/hunspell/*.dic /usr/local/share/hunspell/*.dic'
             if ((${#dicts[@]})); then
                 dicts=("${dicts[@]##*/}")
                 dicts=("${dicts[@]%.dic}")
-                IFS=$'\n'
+                local IFS=$'\n'
                 COMPREPLY=($(compgen -W '${dicts[@]}' -- "$cur"))
             fi
             return

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -19,11 +19,7 @@ _ipmitool()
             local -a files
             _comp_expand_glob files '/dev/ipmi* /dev/ipmi/* /dev/ipmidev/*'
             ((${#files[@]})) &&
-                COMPREPLY=($(compgen -W "$(
-                    printf '%s\n' "${files[@]}" |
-                        command sed -ne 's/^[^0-9]*\([0-9]\{1,\}\)/\1/p'
-                )" \
-                    -- "$cur"))
+                COMPREPLY=($(compgen -W '"${files[@]##*([^0-9])}"' -X '![0-9]*' -- "$cur"))
             return
             ;;
         -*I)

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -16,11 +16,14 @@ _ipmitool()
             return
             ;;
         -*d)
-            COMPREPLY=($(compgen -W "$(
-                command ls -d /dev/ipmi* /dev/ipmi/* /dev/ipmidev/* \
-                    2>/dev/null | command sed -ne 's/^[^0-9]*\([0-9]\{1,\}\)/\1/p'
-            )" \
-                -- "$cur"))
+            local -a files
+            _comp_expand_glob files '/dev/ipmi* /dev/ipmi/* /dev/ipmidev/*'
+            ((${#files[@]})) &&
+                COMPREPLY=($(compgen -W "$(
+                    printf '%s\n' "${files[@]}" |
+                        command sed -ne 's/^[^0-9]*\([0-9]\{1,\}\)/\1/p'
+                )" \
+                    -- "$cur"))
             return
             ;;
         -*I)

--- a/completions/lintian
+++ b/completions/lintian
@@ -2,14 +2,16 @@
 
 _lintian_tags()
 {
-    local match search tags
+    local match search tags check_files
+    _comp_expand_glob check_files '/usr/share/lintian/checks/*.desc'
+    ((${#check_files[@]})) || return 0
 
-    tags=$(awk '/^Tag/ { print $2 }' /usr/share/lintian/checks/*.desc)
+    tags=$(awk '/^Tag/ { print $2 }' "${check_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }
         for item in $search; do
             match=$(command grep -nE "^Tag: $item$" \
-                /usr/share/lintian/checks/*.desc | cut -d: -f1)
+                "${check_files[@]}" | cut -d: -f1)
             tags=$(command sed -e "s/\<$item\>//g" <<<$tags)
         done
         COMPREPLY+=($(compgen -W "$tags"))
@@ -22,15 +24,17 @@ _lintian_tags()
 
 _lintian_checks()
 {
-    local match search todisable checks
+    local match search todisable checks check_files
+    _comp_expand_glob check_files '/usr/share/lintian/checks/*.desc'
+    ((${#check_files[@]})) || return 0
 
     checks=$(awk '/^(Check-Script|Abbrev)/ { print $2 }' \
-        /usr/share/lintian/checks/*.desc)
+        "${check_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }
         for item in $search; do
             match=$(command grep -nE "^(Check-Script|Abbrev): $item$" \
-                /usr/share/lintian/checks/*.desc | cut -d: -f1)
+                "${check_files[@]}" | cut -d: -f1)
             todisable=$(awk '/^(Check-Script|Abbrev)/ { print $2 }' $match)
             for name in $todisable; do
                 checks=$(command sed -e "s/\<$name\>//g" <<<$checks)
@@ -46,15 +50,17 @@ _lintian_checks()
 
 _lintian_infos()
 {
-    local match search infos
+    local match search infos collection_files
+    _comp_expand_glob collection_files '/usr/share/lintian/collection/*.desc'
+    ((${#collection_files[@]})) || return 0
 
     infos=$(awk '/^Collector/ { print $2 }' \
-        /usr/share/lintian/collection/*.desc)
+        "${collection_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }
         for item in $search; do
             match=$(command grep -nE "^Collector: $item$" \
-                /usr/share/lintian/collection/*.desc | cut -d: -f1)
+                "${collection_files[@]}" | cut -d: -f1)
             infos=$(command sed -e "s/\<$item\>//g" <<<$infos)
         done
         COMPREPLY+=($(compgen -W "$infos"))

--- a/completions/minicom
+++ b/completions/minicom
@@ -15,7 +15,7 @@ _minicom()
             return
             ;;
         --ptty | -!(-*)p)
-            COMPREPLY=(/dev/tty*)
+            _comp_expand_glob COMPREPLY '/dev/tty*'
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}}' \
                     -- "$cur"))
@@ -31,10 +31,10 @@ _minicom()
         return
     fi
 
-    COMPREPLY=(
-        $(printf '%s\n' /etc/minirc.* /etc/minicom/minirc.* ~/.minirc.* |
-            command sed -e '/\*$/d' -e 's/^.*minirc\.//' |
-            command grep "^${cur}"))
+    local -a files
+    _comp_expand_glob files '/etc/minirc.* /etc/minicom/minirc.* ~/.minirc.*'
+    ((${#files[@]})) &&
+        COMPREPLY=($(compgen -W '"${files[@]##*minirc.}"' -- "$cur"))
 } &&
     complete -F _minicom -o default minicom
 

--- a/completions/mysql
+++ b/completions/mysql
@@ -3,12 +3,12 @@
 _comp_xfunc_mysql_character_sets()
 {
     local -a charsets
-    _comp_expand_glob charsets '/usr/share/m{ariadb,ysql}/charsets/*.xml'
+    _comp_expand_glob charsets '/usr/share/m{ariadb,ysql}/charsets/!(Index).xml'
     charsets+=(utf8)
     charsets=("${charsets[@]##*/}")
-    charsets=("${charsets[@]%%?(Index).xml}")
+    charsets=("${charsets[@]%.xml}")
     local IFS=$'\n'
-    COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
+    COMPREPLY+=($(compgen -W '${charsets[@]}' -X '' -- "$cur"))
 }
 
 _comp_deprecate_func _mysql_character_sets _comp_xfunc_mysql_character_sets

--- a/completions/mysql
+++ b/completions/mysql
@@ -4,12 +4,11 @@ _comp_xfunc_mysql_character_sets()
 {
     local -a charsets
     _comp_expand_glob charsets '/usr/share/m{ariadb,ysql}/charsets/*.xml'
-    if ((${#charsets[@]})); then
-        charsets=("${charsets[@]##*/}")
-        charsets=("${charsets[@]%%?(Index).xml}" utf8)
-        local IFS=$'\n'
-        COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
-    fi
+    charsets+=(utf8)
+    charsets=("${charsets[@]##*/}")
+    charsets=("${charsets[@]%%?(Index).xml}")
+    local IFS=$'\n'
+    COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
 }
 
 _comp_deprecate_func _mysql_character_sets _comp_xfunc_mysql_character_sets

--- a/completions/mysql
+++ b/completions/mysql
@@ -2,13 +2,12 @@
 
 _comp_xfunc_mysql_character_sets()
 {
-    local IFS=$' \t\n' reset=$(shopt -p failglob)
-    shopt -u failglob
-    local -a charsets=(/usr/share/m{ariadb,ysql}/charsets/*.xml)
-    $reset
+    local -a charsets
+    _comp_expand_glob charsets '/usr/share/m{ariadb,ysql}/charsets/*.xml'
     if ((${#charsets[@]})); then
         charsets=("${charsets[@]##*/}")
-        charsets=("${charsets[@]%%?(Index|\*).xml}" utf8)
+        charsets=("${charsets[@]%%?(Index).xml}" utf8)
+        local IFS=$'\n'
         COMPREPLY+=($(compgen -W '${charsets[@]}' -- "$cur"))
     fi
 }

--- a/completions/ps
+++ b/completions/ps
@@ -39,10 +39,7 @@ _comp_cmd_ps()
             return
             ;;
         ?(-)t | [^-]*t | --tty)
-            COMPREPLY=($(
-                shopt -s nullglob
-                printf '%s\n' /dev/tty*
-            ))
+            _comp_expand_glob COMPREPLY '/dev/tty*'
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"' \
                     -- "$cur"))

--- a/completions/qemu
+++ b/completions/qemu
@@ -20,13 +20,8 @@ _qemu()
             return
             ;;
         -k)
-            local IFS=$' \t\n' reset=$(shopt -p nullglob)
-            shopt -s nullglob
-            local -a keymaps=($(
-                printf "%s\n" \
-                    /usr/{local/,}share/qemu/keymaps/!(common|modifiers)
-            ))
-            $reset
+            local -a keymaps
+            _comp_expand_glob keymaps '/usr/{local/,}share/qemu/keymaps/!(common|modifiers)'
             ((${#keymaps[@]})) &&
                 COMPREPLY=($(compgen -W '"${keymaps[@]##*/}"}' -- "$cur"))
             return

--- a/completions/screen
+++ b/completions/screen
@@ -28,12 +28,9 @@ _screen_sessions()
 
         if ((cword == 1)); then
             if [[ $cur == /dev* ]]; then
-                COMPREPLY=($(compgen -W "$(
-                    shopt -s nullglob
-                    printf '%s\n' \
-                        /dev/serial/*/* /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
-                )" \
-                    -- "$cur"))
+                _comp_expand_glob COMPREPLY '/dev/serial/*/* /dev/ttyUSB* /dev/ttyACM*'
+                ((${#COMPREPLY[@]})) &&
+                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
                 return
             fi
             if [[ $cur == //* ]]; then

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -31,12 +31,14 @@ _valgrind()
         --tool)
             # Tools seem to be named e.g. like memcheck-amd64-linux from which
             # we want to grab memcheck.
-            COMPREPLY=($(compgen -W '$(
-                for f in /usr{,/local}/lib{,64,exec}{/*-linux-gnu,}/valgrind/*
-                do
-                    [[ $f != *.so && -x $f && $f =~ ^.*/(.*)-[^-]+-[^-]+ ]] &&
-                        printf "%s\n" "${BASH_REMATCH[1]}"
-                done)' -- "$cur"))
+            local -a files
+            _comp_expand_glob files '/usr{,/local}/lib{,64,exec}{/*-linux-gnu,}/valgrind/*'
+            ((${#files[@]})) &&
+                COMPREPLY=($(compgen -W '$(
+                    for f in "${files[@]}"; do
+                        [[ $f != *.so && -x $f && $f =~ ^.*/(.*)-[^-]+-[^-]+ ]] &&
+                            printf "%s\n" "${BASH_REMATCH[1]}"
+                    done)' -- "$cur"))
             return
             ;;
         --sim-hints)

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -66,14 +66,12 @@ _vpnc()
         _filedir conf
     else
         # config name, /etc/vpnc/<name>.conf
-        local IFS=$' \t\n' reset=$(shopt -p nullglob)
-        shopt -s nullglob
-        local -a configs=(/etc/vpnc/*.conf)
-        $reset
+        local -a configs
+        _comp_expand_glob configs '/etc/vpnc/*.conf'
         if ((${#configs[@]})); then
             configs=("${configs[@]##*/}")
             configs=("${configs[@]%.conf}")
-            IFS=$'\n'
+            local IFS=$'\n'
             compopt -o filenames
             COMPREPLY=($(compgen -W '${configs[@]}' -- "$cur"))
         fi

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -38,13 +38,11 @@ _xdg_mime()
             ;;
         default)
             if ((args == 2)); then
-                local IFS=$' \t\n' reset=$(shopt -p nullglob)
-                shopt -s nullglob
-                local -a desktops=(/usr/share/applications/*.desktop)
-                $reset
+                local -a desktops
+                _comp_expand_glob desktops '/usr/share/applications/*.desktop'
                 if ((${#desktops[@]})); then
                     desktops=("${desktops[@]##*/}")
-                    IFS=$'\n'
+                    local IFS=$'\n'
                     COMPREPLY=($(compgen -W '"${desktops[@]}"' -- "$cur"))
                 fi
             else

--- a/test/t/unit/test_unit_expand_glob.py
+++ b/test/t/unit/test_unit_expand_glob.py
@@ -1,0 +1,106 @@
+import pytest
+
+from conftest import assert_bash_exec, bash_env_saved
+
+
+@pytest.mark.bashcomp(
+    cmd=None,
+    cwd="_filedir",
+    ignore_env=r"^\+(my_array=|declare -f dump_array$)",
+)
+class TestExpandGlob:
+    def test_match_all(self, bash):
+        assert_bash_exec(
+            bash,
+            "dump_array() { ((${#my_array[@]})) && printf '<%s>' \"${my_array[@]}\"; echo; }",
+        )
+        output = assert_bash_exec(
+            bash,
+            "LC_ALL= LC_COLLATE=C _comp_expand_glob my_array '*';dump_array",
+            want_output=True,
+        )
+        assert output.strip() == "<a b><a$b><a&b><a'b><ab><aé><brackets><ext>"
+
+    def test_match_pattern(self, bash):
+        output = assert_bash_exec(
+            bash,
+            "LC_ALL= LC_COLLATE=C _comp_expand_glob my_array 'a*';dump_array",
+            want_output=True,
+        )
+        assert output.strip() == "<a b><a$b><a&b><a'b><ab><aé>"
+
+    def test_match_unmatched(self, bash):
+        output = assert_bash_exec(
+            bash,
+            "_comp_expand_glob my_array 'unmatched-*';dump_array",
+            want_output=True,
+        )
+        assert output.strip() == ""
+
+    def test_match_multiple_words(self, bash):
+        output = assert_bash_exec(
+            bash,
+            "_comp_expand_glob my_array 'b* e*';dump_array",
+            want_output=True,
+        )
+        assert output.strip() == "<brackets><ext>"
+
+    def test_match_brace_expansion(self, bash):
+        output = assert_bash_exec(
+            bash,
+            "_comp_expand_glob my_array 'brac{ket,unmatched}*';dump_array",
+            want_output=True,
+        )
+        assert output.strip() == "<brackets>"
+
+    def test_protect_from_noglob(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.set("noglob", True)
+            output = assert_bash_exec(
+                bash,
+                "LC_ALL= LC_COLLATE=C _comp_expand_glob my_array 'a*';dump_array",
+                want_output=True,
+            )
+            assert output.strip() == "<a b><a$b><a&b><a'b><ab><aé>"
+
+    def test_protect_from_failglob(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("failglob", True)
+            output = assert_bash_exec(
+                bash,
+                "_comp_expand_glob my_array 'unmatched-*';dump_array",
+                want_output=True,
+            )
+            assert output.strip() == ""
+
+    def test_protect_from_nullglob(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("nullglob", False)
+            output = assert_bash_exec(
+                bash,
+                "_comp_expand_glob my_array 'unmatched-*';dump_array",
+                want_output=True,
+            )
+            assert output.strip() == ""
+
+    def test_protect_from_dotglob(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("dotglob", True)
+            output = assert_bash_exec(
+                bash,
+                "_comp_expand_glob my_array 'ext/foo/*';dump_array",
+                want_output=True,
+            )
+            assert output.strip() == ""
+
+    def test_protect_from_GLOBIGNORE(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            # Note: dotglob is changed by GLOBIGNORE
+            bash_env.save_shopt("dotglob")
+            bash_env.write_variable("GLOBIGNORE", "*")
+            output = assert_bash_exec(
+                bash,
+                "LC_ALL= LC_COLLATE=C _comp_expand_glob my_array 'a*';dump_array",
+                want_output=True,
+            )
+            assert output.strip() == "<a b><a$b><a&b><a'b><ab><aé>"


### PR DESCRIPTION
Fixes #705 and similar problems

## Description

Pathname expansions are used in many places in the codebase, but it seems only a small part of these pathname expansions considers the setting of `nullglob`, and only `mysql` considers the setting of `failglob`. All the pathname expansions except for that in `mysql` can possibly fail due to `failglob`. Actually, there are even other settings that we need to care about for the pathname expansions, such as `nounset`, `dotglob`, `GLOBIGNORE`, and `nocaseglob`.

We don't want to always write codes to check all these settings in-place, so I suggest introducing a shell function `_comp_expand_glob` to perform the pathname expansions.

## Commits

This PR contains several changes.

- ecc384df This is an extension to `conftest.py (bash_env_saved)` that allows an arbitrary change to the variables and settings within the `bash_env` context. This is used in [a test of `_comp_expand_glob`](https://github.com/scop/bash-completion/commit/fae52a81dd996bb601dec5bf2842ebcb34913846#diff-7b154d46af2d8ced2f735ba1a2ee1bf1b133a0e5fd7ee5c953056f4bec44f5e0R99).
- f0a4028d This is also an extension to `conftest.py (bash_env_saved)` that allows saving/restoring the settings of `set -o NAME` and checking the unintended changes to them (just like the existing ones for `shopt` and variables). This is also used in [a test of `_comp_expand_glob`](https://github.com/scop/bash-completion/commit/fae52a81dd996bb601dec5bf2842ebcb34913846#diff-7b154d46af2d8ced2f735ba1a2ee1bf1b133a0e5fd7ee5c953056f4bec44f5e0R58).
- 59ec4602 This is the function to perform the pathname expansions. (This function is actually a simplified version of my functions [`ble/util/eval-pathname-expansion`](https://github.com/akinomyoga/ble.sh/blob/b9fdaabd4c551177ea0857ac1c258832889ad447/src/util.sh#L3597-L3642) and [`ble/complete/util/eval-pathname-expansion`](https://github.com/akinomyoga/ble.sh/blob/master/lib/core-complete.sh#L2429-L2509)).
- 36a540f5 Fixes #705.
- 89dc92ea This fixes the other pathname expansions that I could find (I guess there are still other places that use the pathname expansions).
- 3b858481 This is a fix of a problem of `mysql` completion uncovered by the new `_comp_expand_glob`, which has originally happened with `shopt -s nullglob`.
- 5d9d3547 This is another fix to `mysql` for a problem that has existed for a long time.

## Discussion

There are several things that I want to discuss for the detailed design.

### 1. `dotglob`

While performing the pathname expansions, should we turn `dotglob` on or turn it off? Currently, It's turned off as that is the default of Bash. But maybe it is better to be turned on in some cases.

### 2. `nocaseglob`

Currently, `_comp_expand_glob` doesn't change the settings for `nocaseglob` for its internal expansions, but maybe we should also normalize the behavior of the case matching regardless of the current user settings of `nocaseglob`.

### 3. Naming of `_comp_expand_glob`

Other possibilities include
- `_comp{,_util}_{,_}expand_{pathname{,s},glob}`

### 4. `extglob`

I think we are requiring that `extglob` is turned on, but maybe we can explicitly adjust `extglob` as well as the other options.
