### PR TITLE
chore(renovate): allow 20 concurrent PR's

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "config:base",
+    ":prConcurrentLimit20",
     ":preserveSemverRanges"
   ],
   "ignorePresets": [


### PR DESCRIPTION
The config:base preset sets it to 10. That's a tad low when one
intentionally keeps bumps open (to reduce churn), for example until
they break something or a release is imminent.