### PR TITLE
refactor(bash_completion): rename functions `_userland`, `_sysdirs`, `_have`, and `_rl_enabled`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2073,8 +2073,9 @@ _cd()
         return
     fi
 
-    local -r mark_dirs=$(_comp_readline_variable_on mark-directories && echo y)
-    local -r mark_symdirs=$(_comp_readline_variable_on mark-symlinked-directories && echo y)
+    local mark_dirs='' mark_symdirs=''
+    _comp_readline_variable_on mark-directories && mark_dirs=y
+    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=y
 
     # we have a CDPATH, so loop on its contents
     for i in ${CDPATH//:/$'\n'}; do

--- a/bash_completion
+++ b/bash_completion
@@ -94,12 +94,14 @@ complete -b builtin
 
 # Check if we're running on the given userland
 # @param $1 userland to check for
-_userland()
+_comp_userland()
 {
     local userland=$(uname -s)
     [[ $userland == @(Linux|GNU/*) ]] && userland=GNU
     [[ $userland == "$1" ]]
 }
+
+_comp_deprecate_func _userland _comp_userland
 
 # This function sets correct SysV init directories
 #

--- a/bash_completion
+++ b/bash_completion
@@ -119,20 +119,22 @@ _comp_deprecate_func _sysvdirs _comp_sysvdirs
 
 # This function checks whether we have a given program on the system.
 #
-_have()
+_comp_have_command()
 {
     # Completions for system administrator commands are installed as well in
     # case completion is attempted via `sudo command ...'.
     PATH=$PATH:/usr/sbin:/sbin:/usr/local/sbin type $1 &>/dev/null
 }
 
+_comp_deprecate_func _have _comp_have_command
+
 # Backwards compatibility for compat completions that use have().
 # @deprecated should no longer be used; generally not needed with dynamically
-#             loaded completions, and _have is suitable for runtime use.
+#             loaded completions, and _comp_have_command is suitable for runtime use.
 have()
 {
     unset -v have
-    _have $1 && have=yes
+    _comp_have_command $1 && have=yes
 }
 
 # This function checks whether a given readline variable

--- a/bash_completion
+++ b/bash_completion
@@ -140,10 +140,12 @@ have()
 # This function checks whether a given readline variable
 # is `on'.
 #
-_rl_enabled()
+_comp_readline_variable_on()
 {
     [[ $(bind -v) == *$1+([[:space:]])on* ]]
 }
+
+_comp_deprecate_func _rl_enabled _comp_readline_variable_on
 
 # This function shell-quotes the argument
 quote()
@@ -2071,8 +2073,8 @@ _cd()
         return
     fi
 
-    local -r mark_dirs=$(_rl_enabled mark-directories && echo y)
-    local -r mark_symdirs=$(_rl_enabled mark-symlinked-directories && echo y)
+    local -r mark_dirs=$(_comp_readline_variable_on mark-directories && echo y)
+    local -r mark_symdirs=$(_comp_readline_variable_on mark-symlinked-directories && echo y)
 
     # we have a CDPATH, so loop on its contents
     for i in ${CDPATH//:/$'\n'}; do

--- a/bash_completion
+++ b/bash_completion
@@ -105,7 +105,7 @@ _comp_deprecate_func _userland _comp_userland
 
 # This function sets correct SysV init directories
 #
-_sysvdirs()
+_comp_sysvdirs()
 {
     sysvdirs=()
     [[ -d /etc/rc.d/init.d ]] && sysvdirs+=(/etc/rc.d/init.d)
@@ -114,6 +114,8 @@ _sysvdirs()
     [[ -f /etc/slackware-version ]] && sysvdirs=(/etc/rc.d)
     return 0
 }
+
+_comp_deprecate_func _sysvdirs _comp_sysvdirs
 
 # This function checks whether we have a given program on the system.
 #
@@ -1441,7 +1443,7 @@ _xinetd_services()
 _services()
 {
     local sysvdirs
-    _sysvdirs
+    _comp_sysvdirs
 
     _comp_expand_glob COMPREPLY '${sysvdirs[0]}/!($_comp_backup_glob|functions|README)'
 
@@ -1477,7 +1479,7 @@ _service()
         [[ -e /etc/mandrake-release ]] && _xinetd_services
     else
         local IFS=$'\n' sysvdirs
-        _sysvdirs
+        _comp_sysvdirs
         COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
             ${sysvdirs[0]}/${prev##*/} 2>/dev/null` start stop' -- "$cur"))
@@ -1488,7 +1490,7 @@ _service()
 _comp__init_set_up_service_completions()
 {
     local sysvdirs svc svcdir
-    _sysvdirs
+    _comp_sysvdirs
     for svcdir in "${sysvdirs[@]}"; do
         for svc in "$svcdir"/!($_comp_backup_glob); do
             [[ -x $svc ]] && complete -F _service "$svc"

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -1,6 +1,6 @@
 # Debian aptitude(1) completion                            -*- shell-script -*-
 
-if _have grep-status; then
+if _comp_have_command grep-status; then
     _comp_dpkg_hold_packages()
     {
         grep-status -P -e "^$1" -a -FStatus 'hold' -n -s Package

--- a/completions/arch
+++ b/completions/arch
@@ -2,7 +2,7 @@
 
 # Try to detect whether this is the mailman "arch" to avoid installing
 # it for the coreutils/util-linux-ng one.
-_have mailmanctl &&
+_comp_have_command mailmanctl &&
     _arch()
     {
         local cur prev words cword split

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -1,6 +1,6 @@
 # This function is required by _dpkg and _dpkg-reconfigure -*- shell-script -*-
 
-if _have grep-status; then
+if _comp_have_command grep-status; then
     _comp_xfunc_dpkg_installed_packages()
     {
         grep-status -P -e "^${1-}" -a -FStatus 'ok installed' -n -s Package

--- a/completions/ifup
+++ b/completions/ifup
@@ -1,6 +1,6 @@
 # Red Hat & Debian GNU/Linux if{up,down} completion        -*- shell-script -*-
 
-_userland GNU || return 1
+_comp_userland GNU || return 1
 
 _ifupdown()
 {


### PR DESCRIPTION
- This is still a draft; only a small part of the functions are processed.
- This is based on #734 (`_comp_xfunc`)
- I open this PR to reference the related PRs because some of my existing branches already contain some part of refactoring names and behaviors, so I'd like to process them at the same time.
