### PR TITLE
scp remote file completion extended with port parsing

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -429,7 +429,7 @@ _scp_remote_files()
     local IFS=$'\n'
 	
     # Parse port number from whole command
-    __sshport=`echo ${COMP_WORDS[@]} | sed -n 's/.*-*P\([ 0-9]*\)[ ].*/\1/p' `
+    __sshport=`echo ${COMP_WORDS[@]} | sed -n 's/^.*\( -\w*P\)\([ 0-9]*\)[ ].*/\2/p' `
     [[ -n $"{__sshport// }" ]] && __sshoption="-p $__sshport" || __sshoption=""
 
     # remove backslash escape from the first colon

--- a/completions/ssh
+++ b/completions/ssh
@@ -427,6 +427,10 @@ _scp_path_esc='[][(){}<>"'"'"',:;^&!$=?`\\|[:space:]]'
 _scp_remote_files()
 {
     local IFS=$'\n'
+	
+    # Parse port number from whole command
+    __sshport=`echo ${COMP_WORDS[@]} | sed -n 's/.*-*P\([ 0-9]*\)[ ].*/\1/p' `
+    [[ -n $"{__sshport// }" ]] && __sshoption="-p $__sshport" || __sshoption=""
 
     # remove backslash escape from the first colon
     cur=${cur/\\:/:}
@@ -440,21 +444,21 @@ _scp_remote_files()
 
     # default to home dir of specified user on remote host
     if [[ -z $path ]]; then
-        path=$(ssh -o 'Batchmode yes' "$userhost" pwd 2>/dev/null)
+        path=$(ssh $__sshoption -o 'Batchmode yes' "$userhost" pwd 2>/dev/null)
     fi
 
     local files
     if [[ ${1-} == -d ]]; then
         # escape problematic characters; remove non-dirs
         # shellcheck disable=SC2090
-        files=$(ssh -o 'Batchmode yes' "$userhost" \
+        files=$(ssh $__sshoption -o 'Batchmode yes' "$userhost" \
             command ls -aF1dL "$path*" 2>/dev/null |
             command sed -e 's/'"$_scp_path_esc"'/\\\\\\&/g' -e '/[^\/]$/d')
     else
         # escape problematic characters; remove executables, aliases, pipes
         # and sockets; add space at end of file names
         # shellcheck disable=SC2090
-        files=$(ssh -o 'Batchmode yes' "$userhost" \
+        files=$(ssh $__sshoption -o 'Batchmode yes' "$userhost" \
             command ls -aF1dL "$path*" 2>/dev/null |
             command sed -e 's/'"$_scp_path_esc"'/\\\\\\&/g' -e 's/[*@|=]$//g' \
                 -e 's/[^\/]$/& /g')


### PR DESCRIPTION
Hi there, 

There was a issue with the remote file path completion with scp command. 
If remote server uses non-default or not configured port number, remote file completion does not work at all because of it does not know which port to use for connection. (actually it tries out default port for connection and it fails eventually). 

What I did to fix this issue is: parse `-P portnumber` part from the scp command and pass the `portnumber` as argument to ssh command for successful connection.

I have checked these different command variations and all of them is working as intended. 

> scp -P 1234 server.com:/Users/admin
scp -P1234 server.com:/Users/admin/
scp -rP1234 server.com:/Users/admin/
scp -rP1234 server.com:/Users/admin/
scp -rP 1234 server.com:/Users/admin/
scp -rxxxP 1234 server.com:/Users/admin/
scp -r -P 1234 server.com:/Users/admin/
scp -P 1234 -r server.com:/Users/admin/
scp -P1234 -r server.com:/Users/admin/
scp -r -P1234 server.com:/Users/admin/
scp -r -P1234 server-Px999:/Users/admin/
scp -r -P1234 server-Px999:/Users/admin/
scp -r -P1234 server-P999.com:/Users/admin/
scp -P 1234 serverP9999.com:/Users/admin/
scp -rxXXP 1234 server.com:/Users/admin/
scp -P1234 server.com:/Users/Ps9999/
scp -r -P1234 server.com:/Users/adminP999/
scp -r -P1234 server.com:/Users/adminP999/
scp -r -P1234 server.com:/Users/adminP999 
scp -r -P1234 server.com:/Users/admin-P999 
scp -P1234 carbon-1P9999:/Users/admin/
scp -P1234 carbonP9999:/Users/admin/
scp carbon-P9999:/Users/admin/
scp carbonP9999:/Users/admin/
scp -r carbonP9999:/Users/admin/

