### PR TITLE
feat: implement `BASH_COMPLETION_FINALIZE_HOOKS`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1590,16 +1590,16 @@ _comp_finalize()
     while ((${#FUNCNAME[@]} <= ${_comp_finalize__depth[-1]})); do
         if [[ ${#FUNCNAME[@]} -eq ${_comp_finalize__depth[-1]} && ${FUNCNAME[1]-} == "${_comp_finalize__target[-1]}" ]]; then
             # Call finalizer for each command
-            local cmd=${words[0]-} _comp_local_hook
+            local cmd=${words[0]-} _hook
             if [[ $cmd ]]; then
-                _comp_local_hook=${BASH_COMPLETION_FINALIZE_CMD_HOOKS[$cmd]-}
-                eval -- "$_comp_local_hook"
+                _hook=${BASH_COMPLETION_FINALIZE_CMD_HOOKS[$cmd]-}
+                eval -- "$_hook"
             fi
 
             # Call general finalizers
             if [[ ${BASH_COMPLETION_FINALIZE_HOOKS[*]+set} ]]; then
-                for _comp_local_hook in "${BASH_COMPLETION_FINALIZE_HOOKS[@]}"; do
-                    eval -- "$_comp_local_hook"
+                for _hook in "${BASH_COMPLETION_FINALIZE_HOOKS[@]}"; do
+                    eval -- "$_hook"
                 done
             fi
         fi

--- a/bash_completion
+++ b/bash_completion
@@ -1572,6 +1572,14 @@ _comp_variable_assignments()
     return 0
 }
 
+_comp_return_hook()
+{
+    ((${#FUNCNAME[*]} != 2)) && return  # this _will_ need some refinement and thought
+    echo "Hello from return hook for ${FUNCNAME[1]}"
+    echo "words: ${words[@]}"
+    echo "COMPREPLY: ${COMPREPLY[@]}"
+}
+
 # Initialize completion and deal with various general things: do file
 # and variable completion where appropriate, and adjust prev, words,
 # and cword as if no redirections exist so that completions do not
@@ -1608,6 +1616,8 @@ _comp_variable_assignments()
 _comp_initialize()
 {
     local exclude="" opt_split="" outx="" errx="" inx=""
+
+    trap _comp_return_hook RETURN
 
     local flag OPTIND=1 OPTARG="" OPTERR=0
     while getopts "n:e:o:i:s" flag "$@"; do

--- a/bash_completion
+++ b/bash_completion
@@ -1572,13 +1572,51 @@ _comp_variable_assignments()
     return 0
 }
 
-_comp_return_hook()
+_comp_finalize__depth=()
+_comp_finalize__target=()
+_comp_finalize__original_return_trap=
+
+# This associative array contains the finalizer commands with the key
+# being the name of the completed command.
+declare -gA BASH_COMPLETION_FINALIZE_CMD_HOOKS
+
+# This array contains the general finalizer commands that will be
+# executed for all the commands.
+declare -ga BASH_COMPLETION_FINALIZE_HOOKS
+
+_comp_finalize()
 {
-    ((${#FUNCNAME[*]} != 2)) && return  # this _will_ need some refinement and thought
-    echo "Hello from return hook for ${FUNCNAME[1]}"
-    echo "words: ${words[@]}"
-    echo "COMPREPLY: ${COMPREPLY[@]}"
+    ((${#_comp_finalize__depth[@]})) || return 0
+    while ((${#FUNCNAME[@]} <= ${_comp_finalize__depth[-1]})); do
+        if [[ ${#FUNCNAME[@]} -eq ${_comp_finalize__depth[-1]} && ${FUNCNAME[1]-} == "${_comp_finalize__target[-1]}" ]]; then
+            # Call finalizer for each command
+            local cmd=${words[0]-} _comp_local_hook
+            if [[ $cmd ]]; then
+                _comp_local_hook=${BASH_COMPLETION_FINALIZE_CMD_HOOKS[$cmd]-}
+                eval -- "$_comp_local_hook"
+            fi
+
+            # Call general finalizers
+            if [[ ${BASH_COMPLETION_FINALIZE_HOOKS[*]+set} ]]; then
+                for _comp_local_hook in "${BASH_COMPLETION_FINALIZE_HOOKS[@]}"; do
+                    eval -- "$_comp_local_hook"
+                done
+            fi
+        fi
+
+        unset -v '_comp_finalize__depth[-1]'
+        unset -v '_comp_finalize__target[-1]'
+        if ((${#_comp_finalize__depth[@]} == 0)); then
+            eval -- "${_comp_finalize__original_return_trap:-trap - RETURN}"
+            _comp_finalize__original_return_trap=
+            break
+        fi
+    done
 }
+# Note: We need to set "trace" function attribute of _comp_finalize to
+# make the trap restoration by "trap - RETURN" take effect in the
+# upper level.
+declare -ft _comp_finalize
 
 # Initialize completion and deal with various general things: do file
 # and variable completion where appropriate, and adjust prev, words,
@@ -1617,7 +1655,28 @@ _comp_initialize()
 {
     local exclude="" opt_split="" outx="" errx="" inx=""
 
-    trap _comp_return_hook RETURN
+    if ((${#FUNCNAME[@]} >= 2)); then
+        # Install "_comp_finalize" to the RETURN trap when "_init_completion" is
+        # called for the top-level completion. [ Note: the completion function may
+        # be called recursively using "_command_offset", etc. ]
+        if ((${#_comp_finalize__depth[@]} == 0)); then
+            if shopt -q extdebug || shopt -qo functrace; then
+                # If extdebug / functrace is set, we need to explicitly save and
+                # restore the original trap handler because the outer trap handlers
+                # will be affected by "trap - RETURN" inside functions with these
+                # settings.
+                _comp_finalize__original_return_trap=$(trap -p RETURN)
+            else
+                # Otherwise, the outer RETURN trap will be restored when the RETURN
+                # trap is removed inside the functions using "trap - RETURN".  So, we
+                # do not need to explicitly save the outer trap handler.
+                _comp_finalize__original_return_trap=
+            fi
+            trap _comp_finalize RETURN
+        fi
+        _comp_finalize__depth+=("${#FUNCNAME[@]}")
+        _comp_finalize__target+=("${FUNCNAME[1]-}")
+    fi
 
     local flag OPTIND=1 OPTARG="" OPTERR=0
     while getopts "n:e:o:i:s" flag "$@"; do

--- a/bash_completion
+++ b/bash_completion
@@ -1575,6 +1575,7 @@ _comp_variable_assignments()
 _comp_finalize__depth=()
 _comp_finalize__target=()
 _comp_finalize__original_return_trap=
+_comp_finalize__original_int_trap=
 
 # This associative array contains the finalizer commands with the key
 # being the name of the completed command.
@@ -1584,6 +1585,28 @@ declare -gA BASH_COMPLETION_FINALIZE_CMD_HOOKS
 # executed for all the commands.
 declare -ga BASH_COMPLETION_FINALIZE_HOOKS
 
+# This array contains the finalizer commands that will be executed for the
+# top-level bash-completion functions. Unlike BASH_COMPLETION_FINALIZE_HOOKS,
+# these hooks are only called at the end of the top-level bash-completion.
+# These hooks are ensured to be called even when the completion is canceled by
+# SIGINT.
+declare -ga BASH_COMPLETION_FINALIZE_TOPLEVEL_HOOKS
+
+_comp_finalize__clear()
+{
+    local _hook
+    if [[ ${BASH_COMPLETION_FINALIZE_TOPLEVEL_HOOKS[*]+set} ]]; then
+        for _hook in "${BASH_COMPLETION_FINALIZE_TOPLEVEL_HOOKS[@]}"; do
+            eval -- "$_hook"
+        done
+    fi
+    _comp_finalize__depth=()
+    _comp_finalize__target=()
+    eval -- "${_comp_finalize__original_int_trap:-trap - INT}"
+    eval -- "${_comp_finalize__original_return_trap:-trap - RETURN}"
+    _comp_finalize__original_int_trap=
+    _comp_finalize__original_return_trap=
+}
 _comp_finalize()
 {
     ((${#_comp_finalize__depth[@]})) || return 0
@@ -1610,16 +1633,15 @@ _comp_finalize()
         unset -v '_comp_finalize__depth[${#_comp_finalize__depth[@]}-1]'
         unset -v '_comp_finalize__target[${#_comp_finalize__target[@]}-1]'
         if ((${#_comp_finalize__depth[@]} == 0)); then
-            eval -- "${_comp_finalize__original_return_trap:-trap - RETURN}"
-            _comp_finalize__original_return_trap=
+            _comp_finalize__clear
             break
         fi
     done
 }
-# Note: We need to set "trace" function attribute of _comp_finalize to
-# make the trap restoration by "trap - RETURN" take effect in the
-# upper level.
-declare -ft _comp_finalize
+# Note: We need to set "trace" function attribute of _comp_finalize{,__clear}
+# to make the trap restoration by "trap - RETURN" take effect in the upper
+# level.
+declare -ft _comp_finalize__clear _comp_finalize
 
 # Initialize completion and deal with various general things: do file
 # and variable completion where appropriate, and adjust prev, words,
@@ -1663,6 +1685,7 @@ _comp_initialize()
         # called for the top-level completion. [ Note: the completion function may
         # be called recursively using "_command_offset", etc. ]
         if ((${#_comp_finalize__depth[@]} == 0)); then
+            _comp_finalize__original_int_trap=$(trap -p INT)
             if shopt -q extdebug || shopt -qo functrace; then
                 # If extdebug / functrace is set, we need to explicitly save and
                 # restore the original trap handler because the outer trap handlers
@@ -1675,7 +1698,15 @@ _comp_initialize()
                 # do not need to explicitly save the outer trap handler.
                 _comp_finalize__original_return_trap=
             fi
+
+            # Note: Ignore the traps previously set by us to avoid infinite
+            # loop in case that the previously set traps remain by some
+            # accidents.
+            _comp_finalize__original_return_trap=${_comp_finalize__original_return_trap##"trap -- '_comp_finalize"*}
+            _comp_finalize__original_int_trap=${_comp_finalize__original_int_trap##"trap -- '_comp_finalize"*}
+
             trap _comp_finalize RETURN
+            trap '_comp_finalize__clear; kill -INT "$BASHPID"' INT
         fi
         _comp_finalize__depth+=("${#FUNCNAME[@]}")
         _comp_finalize__target+=("${FUNCNAME[1]-}")

--- a/bash_completion
+++ b/bash_completion
@@ -1681,21 +1681,22 @@ _comp_initialize()
     local exclude="" opt_split="" outx="" errx="" inx=""
 
     if ((${#FUNCNAME[@]} >= 2)); then
-        # Install "_comp_finalize" to the RETURN trap when "_init_completion" is
-        # called for the top-level completion. [ Note: the completion function may
-        # be called recursively using "_command_offset", etc. ]
+        # Install "_comp_finalize" to the RETURN trap when "_init_completion"
+        # is called for the top-level completion. [ Note: the completion
+        # function may be called recursively using "_command_offset", etc. ]
         if ((${#_comp_finalize__depth[@]} == 0)); then
             _comp_finalize__original_int_trap=$(trap -p INT)
             if shopt -q extdebug || shopt -qo functrace; then
-                # If extdebug / functrace is set, we need to explicitly save and
-                # restore the original trap handler because the outer trap handlers
-                # will be affected by "trap - RETURN" inside functions with these
-                # settings.
+                # If extdebug / functrace is set, we need to explicitly save
+                # and restore the original trap handler because the outer trap
+                # handlers will be affected by "trap - RETURN" inside functions
+                # with these settings.
                 _comp_finalize__original_return_trap=$(trap -p RETURN)
             else
-                # Otherwise, the outer RETURN trap will be restored when the RETURN
-                # trap is removed inside the functions using "trap - RETURN".  So, we
-                # do not need to explicitly save the outer trap handler.
+                # Otherwise, the outer RETURN trap will be restored when the
+                # RETURN trap is removed inside the functions using "trap -
+                # RETURN".  So, we do not need to explicitly save the outer
+                # trap handler.
                 _comp_finalize__original_return_trap=
             fi
 

--- a/bash_completion
+++ b/bash_completion
@@ -1604,8 +1604,11 @@ _comp_finalize()
             fi
         fi
 
-        unset -v '_comp_finalize__depth[-1]'
-        unset -v '_comp_finalize__target[-1]'
+        # Note: bash 4.2 does not support negative array indices with `unset`
+        # like `unset -v 'arr[-1]'` even when the array has at least one
+        # element.  It is supported in bash 4.3.
+        unset -v '_comp_finalize__depth[${#_comp_finalize__depth[@]}-1]'
+        unset -v '_comp_finalize__target[${#_comp_finalize__target[@]}-1]'
         if ((${#_comp_finalize__depth[@]} == 0)); then
             eval -- "${_comp_finalize__original_return_trap:-trap - RETURN}"
             _comp_finalize__original_return_trap=


### PR DESCRIPTION
This is an experimental implementation of hooks mentioned in https://github.com/scop/bash-completion/issues/720#issuecomment-1093764792.

This is still a stub; the design should be considered well, tests and documentation need to be added, etc. Nevertheless, I'd like to hear your thoughts in the current status.

- 05b4159470648f98cd777a6e0f0ed195e84ac754 This commit cares everything related to `RETURN` handling that I now recognize. I initially thought the proper handling might be more complicated, but it finally ended with this form.
- bc6f87d7 This implements a function `_comp_array_filter`. I'm not sure whether Ville would finally find it reasonable to include the function in bash-completion, but I tried to make the interface minimal (one function `_comp_array_filter`) yet make the function versatile as @calestyo would be likely to request. In any way, this function can be used for the array manipulations of general cases.
