### PR TITLE
style: prefer empty/`!` over `-n`/`-z`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -636,7 +636,7 @@ _filedir()
 
         # Try without filter if it failed to produce anything and configured to
         [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} &&
-            -n $arg && ${#toks[@]} -lt 1 ]] && {
+            $arg && ${#toks[@]} -lt 1 ]] && {
             reset=$(shopt -po noglob)
             set -o noglob
             toks+=($(compgen -f ${plusdirs+"${plusdirs[@]}"} -- $quoted))
@@ -1567,7 +1567,7 @@ _fstypes()
              $([[ -d /etc/fs ]] && command ls /etc/fs)"
     fi
 
-    [[ -n $fss ]] && COMPREPLY+=($(compgen -W "$fss" -- "$cur"))
+    [[ $fss ]] && COMPREPLY+=($(compgen -W "$fss" -- "$cur"))
 }
 
 # Get real command.
@@ -1952,7 +1952,7 @@ _known_hosts_real()
 
     # Add results of normal hostname completion, unless
     # `BASH_COMPLETION_KNOWN_HOSTS_WITH_HOSTFILE' is set to an empty value.
-    if [[ -n ${BASH_COMPLETION_KNOWN_HOSTS_WITH_HOSTFILE-${COMP_KNOWN_HOSTS_WITH_HOSTFILE-1}} ]]; then
+    if [[ ${BASH_COMPLETION_KNOWN_HOSTS_WITH_HOSTFILE-${COMP_KNOWN_HOSTS_WITH_HOSTFILE-1}} ]]; then
         COMPREPLY+=(
             $(compgen -A hostname -P "$prefix" -S "$suffix" -- "$cur"))
     fi
@@ -2136,7 +2136,7 @@ _command_offset()
                     # Note: When completion spec is removed after 124, we do
                     # not generate any completions including the default ones.
                     # This is the behavior of the original Bash progcomp.
-                    [[ -n $cspec ]] || break
+                    [[ $cspec ]] || break
 
                     continue
                 fi
@@ -2267,7 +2267,7 @@ _filedir_xspec()
     toks+=($(
         eval compgen -f -X "'!$xspec'" -- '$(quote_readline "$cur")' | {
             while read -r tmp; do
-                [[ -n $tmp ]] && printf '%s\n' $tmp
+                [[ $tmp ]] && printf '%s\n' $tmp
             done
         }
     ))
@@ -2372,7 +2372,7 @@ __load_completion()
 {
     local -a dirs=(${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions)
     local IFS=: dir cmd="${1##*/}" compfile
-    [[ -n $cmd ]] || return 1
+    [[ $cmd ]] || return 1
     for dir in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do
         dirs+=($dir/bash-completion/completions)
     done

--- a/bash_completion
+++ b/bash_completion
@@ -624,7 +624,7 @@ _filedir()
         local opts=(-f -X "$xspec")
         [[ $xspec ]] && plusdirs=(-o plusdirs)
         [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} ||
-            -z ${plusdirs-} ]] ||
+            ! ${plusdirs-} ]] ||
             opts+=("${plusdirs[@]}")
 
         reset=$(shopt -po noglob)
@@ -1993,7 +1993,7 @@ _cd()
 
     # Use standard dir completion if no CDPATH or parameter starts with /,
     # ./ or ../
-    if [[ -z ${CDPATH:-} || $cur == ?(.)?(.)/* ]]; then
+    if [[ ! ${CDPATH:-} || $cur == ?(.)?(.)/* ]]; then
         _filedir -d
         return
     fi

--- a/completions/_mount
+++ b/completions/_mount
@@ -42,7 +42,7 @@ _mount()
     if [[ $cur == //* ]]; then
         host=${cur#//}
         host=${host%%/*}
-        if [[ -n $host ]]; then
+        if [[ $host ]]; then
             COMPREPLY=($(compgen -P "//$host" -W \
                 "$(smbclient -d 0 -NL $host 2>/dev/null |
                     command sed -ne '/^[[:blank:]]*Sharename/,/^$/p' |

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -236,7 +236,7 @@ _mount()
     if [[ $cur == //* ]]; then
         host=${cur#//}
         host=${host%%/*}
-        if [[ -n $host ]]; then
+        if [[ $host ]]; then
             COMPREPLY=($(compgen -P "//$host" -W \
                 "$(smbclient -d 0 -NL $host 2>/dev/null |
                     command sed -ne '/^[[:blank:]]*Sharename/,/^$/p' |

--- a/completions/abook
+++ b/completions/abook
@@ -6,7 +6,7 @@ _abook()
     _init_completion || return
 
     # abook only takes options, tabbing after command name adds a single dash
-    [[ $cword -eq 1 && -z $cur ]] &&
+    [[ $cword -eq 1 && ! $cur ]] &&
         {
             compopt -o nospace
             COMPREPLY=("-")

--- a/completions/carton
+++ b/completions/carton
@@ -39,7 +39,7 @@ _carton()
             return
             ;;
         --help | -h)
-            [[ -n $command ]] || _carton_commands "$1"
+            [[ $command ]] || _carton_commands "$1"
             return
             ;;
         --cpanfile)

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -35,7 +35,7 @@ _cppcheck()
             ;;
         --file-list)
             _filedir
-            [[ -z $cur || $cur == - ]] && COMPREPLY+=(-)
+            [[ ! $cur || $cur == - ]] && COMPREPLY+=(-)
             return
             ;;
         -I)

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -35,7 +35,7 @@ _cryptsetup()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/cvs
+++ b/completions/cvs
@@ -13,7 +13,7 @@ _cvs_entries()
 
 _cvs_modules()
 {
-    if [[ -n $prefix ]]; then
+    if [[ $prefix ]]; then
         COMPREPLY=($(command ls -d ${cvsroot}/${prefix}/!(CVSROOT)))
     else
         COMPREPLY=($(command ls -d ${cvsroot}/!(CVSROOT)))
@@ -251,7 +251,7 @@ _cvs()
                 # if $BASH_COMPLETION_CMD_CVS_REMOTE is not null, 'cvs commit'
                 # will complete on remotely checked-out files (requires
                 # passwordless access to the remote repository
-                if [[ -n ${BASH_COMPLETION_CMD_CVS_REMOTE-${COMP_CVS_REMOTE-}} ]]; then
+                if [[ ${BASH_COMPLETION_CMD_CVS_REMOTE-${COMP_CVS_REMOTE-}} ]]; then
                     # this is the least computationally intensive way found so
                     # far, but other changes (something other than
                     # changed/removed/new) may be missing

--- a/completions/cvs
+++ b/completions/cvs
@@ -152,7 +152,7 @@ _cvs()
 
             if [[ $cur != -* ]]; then
                 _cvs_entries
-                [[ -z $cur ]] && files=(!(CVS)) ||
+                [[ ! $cur ]] && files=(!(CVS)) ||
                     files=($(command ls -d ${cur}* 2>/dev/null))
                 local f
                 for i in "${!files[@]}"; do

--- a/completions/dict
+++ b/completions/dict
@@ -17,15 +17,15 @@ _dict()
         case ${words[i]} in
             --host | -!(-*)h)
                 host=${words[++i]}
-                [[ -n $host ]] && host="-h $host"
+                [[ $host ]] && host="-h $host"
                 ;;
             --port | -!(-*)p)
                 port=${words[++i]}
-                [[ -n $port ]] && port="-p $port"
+                [[ $port ]] && port="-p $port"
                 ;;
             --database | -!(-*)d)
                 db=${words[++i]}
-                [[ -n $db ]] && host="-d $db"
+                [[ $db ]] && host="-d $db"
                 ;;
         esac
     done

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -20,7 +20,7 @@ _ebtables()
             COMPREPLY=($(compgen -W 'nat filter broute' -- "$cur"))
             ;;
         -!(-*)j)
-            if [[ $table == "-t filter" || -z $table ]]; then
+            if [[ $table == "-t filter" || ! $table ]]; then
                 COMPREPLY=($(compgen -W '$targets
                 $("$1" $table -L 2>/dev/null | \
                   command sed -n -e "s/INPUT\|OUTPUT\|FORWARD//" \

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -2,7 +2,7 @@
 
 _bluetooth_addresses()
 {
-    if [[ -n ${COMP_BLUETOOTH_SCAN:-} ]]; then
+    if [[ ${COMP_BLUETOOTH_SCAN:-} ]]; then
         COMPREPLY+=($(compgen -W "$(hcitool scan |
             awk '/^\t/{print $1}')" -- "$cur"))
     fi

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -51,7 +51,7 @@ _hcitool()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         else
@@ -123,7 +123,7 @@ _sdptool()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         else
@@ -207,7 +207,7 @@ _rfcomm()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         else
@@ -247,7 +247,7 @@ _ciptool()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         else
@@ -305,7 +305,7 @@ _hciconfig()
 
     local arg
     _get_first_arg
-    if [[ -z $arg ]]; then
+    if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '--help --all' -- "$cur"))
         else

--- a/completions/info
+++ b/completions/info
@@ -48,7 +48,7 @@ _info()
     fi
 
     infopath=$infopath:
-    if [[ -n $cur ]]; then
+    if [[ $cur ]]; then
         infopath="${infopath//://$cur* }"
     else
         infopath="${infopath//:// }"

--- a/completions/iptables
+++ b/completions/iptables
@@ -19,7 +19,7 @@ _iptables()
             COMPREPLY=($(compgen -W 'nat filter mangle' -- "$cur"))
             ;;
         -j)
-            if [[ $table == "-t filter" || -z $table ]]; then
+            if [[ $table == "-t filter" || ! $table ]]; then
                 COMPREPLY=($(compgen -W 'ACCEPT DROP LOG ULOG REJECT
                 `"$1" $table -nL 2>/dev/null | command sed -ne "$chain" \
                 -e "s/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//"`' -- \

--- a/completions/java
+++ b/completions/java
@@ -24,7 +24,7 @@ _java_find_classpath()
     [[ ! -v classpath ]] && classpath=${CLASSPATH-}
 
     # default to current directory
-    [[ -z $classpath ]] && classpath=.
+    [[ ! $classpath ]] && classpath=.
 }
 
 # exact sourcepath determination

--- a/completions/make
+++ b/completions/make
@@ -73,7 +73,7 @@ _make_target_extract_script()
 EOF
 
     # don't complete with hidden targets unless we are doing a partial completion
-    if [[ -z ${prefix_pat} || ${prefix_pat} == */ ]]; then
+    if [[ ! ${prefix_pat} || ${prefix_pat} == */ ]]; then
         cat <<EOF
       /^${prefix_pat}[^a-zA-Z0-9]/d;            # convention for hidden tgt
 EOF

--- a/completions/man
+++ b/completions/man
@@ -58,7 +58,7 @@ _man()
     fi
 
     local manpath=$(manpath 2>/dev/null || command man -w 2>/dev/null)
-    if [[ -z $manpath ]]; then
+    if [[ ! $manpath ]]; then
         # Note: Both "manpath" and "man -w" may be unavailable, in
         # which case we determine the man paths based on the
         # environment variable MANPATH.

--- a/completions/man
+++ b/completions/man
@@ -76,7 +76,7 @@ _man()
     [[ $prev == $mansect ]] && sect=$prev || sect='*'
 
     manpath=$manpath:
-    if [[ -n $cur ]]; then
+    if [[ $cur ]]; then
         manpath="${manpath//://*man$sect/$cur* } ${manpath//://*cat$sect/$cur* }"
     else
         manpath="${manpath//://*man$sect/ } ${manpath//://*cat$sect/ }"

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -81,7 +81,7 @@ _modprobe()
             # do filename completion if we're giving a path to a module
             if [[ $cur == @(*/|[.~])* ]]; then
                 _filedir '@(?(k)o?(.[gx]z|.zst))'
-            elif [[ -n $module ]]; then
+            elif [[ $module ]]; then
                 # do module parameter completion
                 if [[ $cur == *=* ]]; then
                     prev=${cur%%=*}

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -62,7 +62,7 @@ _modprobe()
                 # skip all other options
                 ;;
             *)
-                [[ -z $module ]] && module=${words[i]}
+                [[ ! $module ]] && module=${words[i]}
                 ;;
         esac
     done

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -79,7 +79,7 @@ _mplayer()
             # if you don't have installed mplayer in /usr you
             # may want to set the MPLAYER_SKINS_DIR global variable
             local -a dirs
-            if [[ -n $MPLAYER_SKINS_DIR ]]; then
+            if [[ $MPLAYER_SKINS_DIR ]]; then
                 dirs=($MPLAYER_SKINS_DIR)
             else
                 dirs=(/usr/share/mplayer/skins /usr/local/share/mplayer/skins)

--- a/completions/mr
+++ b/completions/mr
@@ -35,7 +35,7 @@ _mr()
             bootstrap)
                 _filedir
                 # Also complete stdin (-) as a potential bootstrap source.
-                if [[ -z ${cur} || $cur == - ]] && [[ $prev != - ]]; then
+                if [[ ! ${cur} || $cur == - ]] && [[ $prev != - ]]; then
                     COMPREPLY+=(-)
                 fi
                 return

--- a/completions/mutt
+++ b/completions/mutt
@@ -118,7 +118,7 @@ _muttfiledir()
     elif [[ $cur == !* ]]; then
         spoolfile="$($muttcmd -F "$muttrc" -Q spoolfile 2>/dev/null |
             command sed -e 's|^spoolfile=\"\(.*\)\"$|\1|')"
-        [[ -n $spoolfile ]] && eval cur="${cur/^!/$spoolfile}"
+        [[ $spoolfile ]] && eval cur="${cur/^!/$spoolfile}"
     fi
     _filedir
 }

--- a/completions/mutt
+++ b/completions/mutt
@@ -72,7 +72,7 @@ _muttaliases()
     local -a conffiles aliases
 
     muttrc=$(_muttrc)
-    [[ -z $muttrc ]] && return
+    [[ ! $muttrc ]] && return
 
     conffiles=($(eval _muttconffiles $muttrc $muttrc))
     # shellcheck disable=SC2046
@@ -88,7 +88,7 @@ _muttquery()
     local -a queryresults
 
     querycmd="$($muttcmd -Q query_command 2>/dev/null | command sed -e 's|^query_command=\"\(.*\)\"$|\1|' -e 's|%s|'$cur'|')"
-    if [[ -z $cur || -z $querycmd ]]; then
+    if [[ ! $cur || ! $querycmd ]]; then
         queryresults=()
     else
         __expand_tilde_by_ref querycmd

--- a/completions/openssl
+++ b/completions/openssl
@@ -13,7 +13,7 @@ _openssl_sections()
     done
 
     # if no config given, check some usual default locations
-    if [[ -z $config ]]; then
+    if [[ ! $config ]]; then
         for f in /etc/ssl/openssl.cnf /etc/pki/tls/openssl.cnf \
             /usr/share/ssl/openssl.cnf; do
             [[ -f $f ]] && config=$f && break

--- a/completions/pkg-get
+++ b/completions/pkg-get
@@ -15,7 +15,7 @@ _pkg_get_get_catalog_file()
     done
     conffile="${conffile:-/opt/csw/etc/pkg-get.conf}"
 
-    if [[ -z $url ]]; then
+    if [[ ! $url ]]; then
         url=$(awk -F= ' $1=="url" { print $2 }' $conffile)
     fi
 

--- a/completions/puppet
+++ b/completions/puppet
@@ -2,7 +2,7 @@
 
 _puppet_logdest()
 {
-    if [[ -z $cur ]]; then
+    if [[ ! $cur ]]; then
         COMPREPLY=($(compgen -W 'syslog console /' -- "$cur"))
     else
         COMPREPLY=($(compgen -W 'syslog console' -- "$cur"))
@@ -55,7 +55,7 @@ _puppet_references()
 _puppet_subcmd_opts()
 {
     # puppet cmd help is somewhat slow, avoid if possible
-    [[ -z $cur || $cur == -* ]] &&
+    [[ ! $cur || $cur == -* ]] &&
         COMPREPLY+=($(compgen -W \
             '$(_parse_usage "$1" "help $2")' -- "$cur"))
 }

--- a/completions/qdbus
+++ b/completions/qdbus
@@ -5,7 +5,7 @@ _qdbus()
     local cur prev words cword
     _init_completion || return
 
-    [[ -n $cur ]] && unset -v "words[$((${#words[@]} - 1))]"
+    [[ $cur ]] && unset -v "words[$((${#words[@]} - 1))]"
     COMPREPLY=($(compgen -W '$(command ${words[@]} 2>/dev/null | \
         command sed "s/(.*)//")' -- "$cur"))
 } &&

--- a/completions/ri
+++ b/completions/ri
@@ -6,7 +6,7 @@ _ri_get_methods()
     local regex
 
     if [[ $ri_version == integrated ]]; then
-        if [[ -z $separator ]]; then
+        if [[ ! $separator ]]; then
             regex="(Instance|Class)"
         elif [[ $separator == "#" ]]; then
             regex=Instance

--- a/completions/rpcdebug
+++ b/completions/rpcdebug
@@ -11,7 +11,7 @@ _rpcdebug_flags()
         fi
     done
 
-    if [[ -n $module ]]; then
+    if [[ $module ]]; then
         COMPREPLY=($(compgen -W "$(rpcdebug -vh 2>&1 |
             command sed -ne 's/^'$module'[[:space:]]\{1,\}//p')" -- "$cur"))
     fi

--- a/completions/rpm
+++ b/completions/rpm
@@ -298,7 +298,7 @@ _rpmbuild()
                 ;;
         esac
     done
-    [[ -n $ext ]] && _filedir $ext
+    [[ $ext ]] && _filedir $ext
 } &&
     complete -F _rpmbuild rpmbuild rpmbuild-md5
 

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -88,7 +88,7 @@ _smartctl_drivedb()
         cur="${cur#+}"
     fi
     _filedir h
-    [[ -n $prefix ]] && COMPREPLY=("${COMPREPLY[@]/#/$prefix}")
+    [[ $prefix ]] && COMPREPLY=("${COMPREPLY[@]/#/$prefix}")
 }
 
 _smartctl()

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -7,14 +7,14 @@ _samba_resolve_order()
 
 _samba_domains()
 {
-    if [[ -n ${COMP_SAMBA_SCAN:-} ]]; then
+    if [[ ${COMP_SAMBA_SCAN:-} ]]; then
         COMPREPLY=($(compgen -W '$(smbtree -N -D)' -- "$cur"))
     fi
 }
 
 _samba_hosts()
 {
-    if [[ -n ${COMP_SAMBA_SCAN:-} ]]; then
+    if [[ ${COMP_SAMBA_SCAN:-} ]]; then
         COMPREPLY=($(compgen -W "$(
             smbtree -N -S |
                 command sed -ne 's/^[[:space:]]*\\\\*\([^[:space:]]*\).*/\1/p'

--- a/completions/ssh
+++ b/completions/ssh
@@ -66,7 +66,7 @@ _ssh_options()
         GSSAPITrustDns SmartcardDevice UsePrivilegedPort
     )
     local protocols=$(_ssh_query "${1:-ssh}" protocol-version)
-    if [[ -z $protocols || $protocols == *1* ]]; then
+    if [[ ! $protocols || $protocols == *1* ]]; then
         opts+=(Cipher CompressionLevel Protocol RhostsRSAAuthentication
             RSAAuthentication)
     fi
@@ -243,7 +243,7 @@ _ssh_configfile()
 # shellcheck disable=SC2120
 _ssh_identityfile()
 {
-    [[ -z $cur && -d ~/.ssh ]] && cur=~/.ssh/id
+    [[ ! $cur && -d ~/.ssh ]] && cur=~/.ssh/id
     _filedir
     if ((${#COMPREPLY[@]} > 0)); then
         COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' \
@@ -439,7 +439,7 @@ _scp_remote_files()
     path=$(command sed -e 's/\\\\\\\('"$_comp_cmd_scp__path_esc"'\)/\\\1/g' <<<"$path")
 
     # default to home dir of specified user on remote host
-    if [[ -z $path ]]; then
+    if [[ ! $path ]]; then
         path=$(ssh -o 'Batchmode yes' "$userhost" pwd 2>/dev/null)
     fi
 

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -118,7 +118,7 @@ _ssh_keygen()
 
     if [[ $cur == -* ]]; then
         local opts=$(_parse_usage "$1" "-?")
-        [[ -z $opts ]] && opts=$(_parse_help "$1" "-?") # OpenSSH < 7
+        [[ ! $opts ]] && opts=$(_parse_help "$1" "-?") # OpenSSH < 7
         COMPREPLY=($(compgen -W "$opts" -- "$cur"))
     fi
 

--- a/completions/svcadm
+++ b/completions/svcadm
@@ -38,7 +38,7 @@ _smf_complete_fmri()
 
     for fmri in $(svcs -H -o FMRI "$pattern" 2>/dev/null); do
         local fmri_part_list fmri_part
-        if [[ -z $exact_mode ]]; then
+        if [[ ! $exact_mode ]]; then
             fmri=${fmri#"$prefix/"}
 
             # we generate all possibles abbreviations for the FMRI

--- a/completions/tar
+++ b/completions/tar
@@ -289,14 +289,14 @@ __tar_complete_mode()
 
         # when user passed something like 'tar cf' do not put the '-' before
         filler=
-        if [[ -z $cur && ! -v basic_tar ]]; then
+        if [[ ! $cur && ! -v basic_tar ]]; then
             filler=-
         fi
 
         generated=""
         for ((i = 0; 1; i++)); do
             local c="${short_modes:i:1}"
-            [[ -z $c ]] && break
+            [[ ! $c ]] && break
             generated+=" $filler$cur$c"
         done
 
@@ -319,7 +319,7 @@ __tar_complete_mode()
     generated=
     for ((i = 0; 1; i++)); do
         local c="${allshort_raw_unused:i:1}"
-        [[ -z $c ]] && break
+        [[ ! $c ]] && break
         generated+=" $cur$c"
     done
 
@@ -345,7 +345,7 @@ __gtar_complete_sopts()
 
     for ((i = 0; 1; i++)); do
         c="${allshort_raw_unused:i:1}"
-        [[ -z $c ]] && break
+        [[ ! $c ]] && break
         generated+=" $cur$c"
     done
 

--- a/completions/tar
+++ b/completions/tar
@@ -135,7 +135,7 @@ __gnu_tar_parse_help()
             # variable may contain e.g. '-X, --XXX[=NAME], -XXX2[=NAME]'.
             arg=none
             if [[ $line =~ --[A-Za-z0-9-]+(\[?)= ]]; then
-                [[ -n ${BASH_REMATCH[1]} ]] && arg=opt || arg=req
+                [[ ${BASH_REMATCH[1]} ]] && arg=opt || arg=req
             fi
 
             __gtar_parse_help_line "$str" "$arg"
@@ -170,19 +170,19 @@ __tar_parse_old_opt()
     local first_word char
 
     # current word is the first word
-    [[ $cword -eq 1 && -n $cur && ${cur:0:1} != '-' ]] &&
+    [[ $cword -eq 1 && $cur && ${cur:0:1} != '-' ]] &&
         old_opt_progress=1
 
     # check that first argument does not begin with "-"
     first_word=${words[1]}
-    [[ -n $first_word && ${first_word:0:1} != "-" ]] &&
+    [[ $first_word && ${first_word:0:1} != "-" ]] &&
         old_opt_used=1
 
     # parse the old option (if present) contents to allow later code expect
     # corresponding arguments
     if ((old_opt_used == 1)); then
         char=${first_word:0:1}
-        while [[ -n $char ]]; do
+        while [[ $char ]]; do
             if __tar_is_argreq "$char"; then
                 old_opt_parsed+=("$char")
             fi

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -25,10 +25,10 @@ _update_rc_d()
         COMPREPLY=(0 1 2 3 4 5 6 7 8 9)
     elif [[ $prev == defaults && $cur == [sk]?([0-9]) ]]; then
         COMPREPLY=(0 1 2 3 4 5 6 7 8 9)
-    elif [[ $prev == defaults && -z $cur ]]; then
+    elif [[ $prev == defaults && ! $cur ]]; then
         COMPREPLY=(0 1 2 3 4 5 6 7 8 9 s k)
     elif [[ $prev == ?(start|stop) ]]; then
-        if [[ $cur == [0-9] || -z $cur ]]; then
+        if [[ $cur == [0-9] || ! $cur ]]; then
             COMPREPLY=(0 1 2 3 4 5 6 7 8 9)
         elif [[ $cur == [0-9][0-9] ]]; then
             COMPREPLY=($cur)
@@ -36,7 +36,7 @@ _update_rc_d()
             COMPREPLY=()
         fi
     elif [[ $prev == ?([0-9][0-9]|[0-6S]) ]]; then
-        if [[ -z $cur ]]; then
+        if [[ ! $cur ]]; then
             if [[ $prev == [0-9][0-9] ]]; then
                 COMPREPLY=(0 1 2 3 4 5 6 S)
             else

--- a/completions/wget
+++ b/completions/wget
@@ -72,7 +72,7 @@ _wget()
             return
             ;;
         --output-document | --input-file | -!(-*)[Oi])
-            _filedir && [[ $cur == - || -z $cur ]] && COMPREPLY+=(-)
+            _filedir && [[ $cur == - || ! $cur ]] && COMPREPLY+=(-)
             return
             ;;
         --secure-protocol)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PROG_SED
 AC_ARG_WITH([pytest],[  --with-pytest=executable],[PYTEST="$withval"])
-if test -z "$PYTEST"; then
+if test ! "$PYTEST"; then
     AC_CHECK_PROGS([PYTEST],[pytest pytest-3],[pytest])
 fi
 AC_CONFIG_FILES([

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PROG_LN_S
 AC_PROG_MKDIR_P
 AC_PROG_SED
 AC_ARG_WITH([pytest],[  --with-pytest=executable],[PYTEST="$withval"])
-if test ! "$PYTEST"; then
+if test "x$PYTEST" = x; then
     AC_CHECK_PROGS([PYTEST],[pytest pytest-3],[pytest])
 fi
 AC_CONFIG_FILES([

--- a/doc/styleguide.md
+++ b/doc/styleguide.md
@@ -31,7 +31,8 @@ prone, more featureful, and slightly faster.
 
 ## `$x` and `! $x` vs `-n $x` and `-z $x`
 
-Use `[[ $x ]]` and `[[ ! $x ]]` instead of `[[ -n $x ]]` and `[[ -z $x ]]`.
+Use `[[ $x ]]` and `[[ ! $x ]]` instead of `[[ -n $x ]]` and `[[ -z $x ]]`,
+and similarly with the `test` builtin.
 Rationale: no strong technical reasons to prefer either style, but the former
 is subjectively slightly more readable and it was traditionally more common in
 the codebase before this style item was standardized.

--- a/doc/styleguide.md
+++ b/doc/styleguide.md
@@ -29,6 +29,13 @@ doesn't confuse editors as bad as the latter, and is concise enough.
 Always use `[[ ]]` instead of `[ ]`. Rationale: the former is less error
 prone, more featureful, and slightly faster.
 
+## `$x` and `! $x` vs `-n $x` and `-z $x`
+
+Use `[[ $x ]]` and `[[ ! $x ]]` instead of `[[ -n $x ]]` and `[[ -z $x ]]`.
+Rationale: no strong technical reasons to prefer either style, but the former
+is subjectively slightly more readable and it was traditionally more common in
+the codebase before this style item was standardized.
+
 ## Line wrapping
 
 Try to wrap lines at 79 characters. Never go past this limit, unless

--- a/test/runLint
+++ b/test/runLint
@@ -5,7 +5,7 @@ gitgrep()
     local out=$(git grep -I -P -n "$1" |
         grep -E '^(bash_completion|completions/|test/)' |
         grep -Ev "^test/runLint\>${filter_out:+|$filter_out}")
-    if [ -n "$out" ]; then
+    if [ "$out" ]; then
         printf '***** %s\n' "$2"
         printf '%s\n\n' "$out"
     fi

--- a/test/t/test_arp.py
+++ b/test/t/test_arp.py
@@ -3,7 +3,7 @@ import pytest
 
 class TestArp:
     @pytest.mark.complete(
-        "arp ", require_cmd=True, skipif='test -z "$(arp 2>/dev/null)"'
+        "arp ", require_cmd=True, skipif='test ! "$(arp 2>/dev/null)"'
     )
     def test_1(self, completion):
         assert completion

--- a/test/t/test_avahi_browse.py
+++ b/test/t/test_avahi_browse.py
@@ -12,7 +12,7 @@ class TestAvahiBrowse:
     @pytest.mark.complete(
         "avahi-browse _",
         require_cmd=True,
-        xfail='test -z "$(avahi-browse --dump-db 2>/dev/null)"',
+        xfail='test ! "$(avahi-browse --dump-db 2>/dev/null)"',
     )
     def test_service_types(self, completion):
         assert completion

--- a/test/t/test_dpkg.py
+++ b/test/t/test_dpkg.py
@@ -6,7 +6,7 @@ class TestDpkg:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("dpkg -L ", xfail='test -z "$(dpkg -l 2>/dev/null)"')
+    @pytest.mark.complete("dpkg -L ", xfail='test ! "$(dpkg -l 2>/dev/null)"')
     def test_2(self, completion):
         assert completion
 

--- a/test/t/test_rpm.py
+++ b/test/t/test_rpm.py
@@ -6,7 +6,7 @@ class TestRpm:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("rpm -q ", skipif='test -z "$(rpm -qa 2>/dev/null)"')
+    @pytest.mark.complete("rpm -q ", skipif='test ! "$(rpm -qa 2>/dev/null)"')
     def test_2(self, completion):
         assert completion
 

--- a/test/t/test_xfreerdp.py
+++ b/test/t/test_xfreerdp.py
@@ -42,7 +42,7 @@ class TestXfreerdp:
     @pytest.mark.complete(
         "xfreerdp /kbd:",
         require_cmd=True,
-        skipif='test -z "$(xfreerdp /kbd-list 2>/dev/null)"',
+        skipif='test ! "$(xfreerdp /kbd-list 2>/dev/null)"',
     )
     def test_4(self, bash, completion, help_success, slash_syntax):
         assert completion


### PR DESCRIPTION
Originally from comments in https://github.com/scop/bash-completion/pull/678.

Docs only for now; we should implement the actual change in this PR too.