### PR TITLE
refactor(bash_completion): rename internal/initialization variables

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2454,10 +2454,10 @@ unset -v _comp_compat_dir _comp_file _comp__init_blacklist_glob
 # Remark: We explicitly check that $user_completion is not '/dev/null' since
 #   /dev/null may be a regular file in broken systems and can contain arbitrary
 #   garbages of suppressed command outputs.
-_comp_user_completion=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
-[[ $_comp_user_completion != "${BASH_SOURCE[0]}" && $_comp_user_completion != /dev/null && -r $_comp_user_completion && -f $_comp_user_completion ]] &&
-    . $_comp_user_completion
-unset -v _comp_user_completion
+_comp__init_user_file=${BASH_COMPLETION_USER_FILE:-~/.bash_completion}
+[[ $_comp__init_user_file != "${BASH_SOURCE[0]}" && $_comp__init_user_file != /dev/null && -r $_comp__init_user_file && -f $_comp__init_user_file ]] &&
+    . $_comp__init_user_file
+unset -v _comp__init_user_file
 
 unset -f have
 unset -v have

--- a/bash_completion
+++ b/bash_completion
@@ -2440,14 +2440,14 @@ _xfunc()
 }
 
 # source compat completion directory definitions
-_comp_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
-if [[ -d $_comp_compat_dir && -r $_comp_compat_dir && -x $_comp_compat_dir ]]; then
-    for _comp_file in "$_comp_compat_dir"/*; do
-        [[ ${_comp_file##*/} != @($_comp_backup_glob|Makefile*|$_comp__init_blacklist_glob) &&
-            -f $_comp_file && -r $_comp_file ]] && . "$_comp_file"
+_comp__init_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
+if [[ -d $_comp__init_compat_dir && -r $_comp__init_compat_dir && -x $_comp__init_compat_dir ]]; then
+    for _comp__init_file in "$_comp__init_compat_dir"/*; do
+        [[ ${_comp__init_file##*/} != @($_comp_backup_glob|Makefile*|$_comp__init_blacklist_glob) &&
+            -f $_comp__init_file && -r $_comp__init_file ]] && . "$_comp__init_file"
     done
 fi
-unset -v _comp_compat_dir _comp_file _comp__init_blacklist_glob
+unset -v _comp__init_compat_dir _comp__init_file _comp__init_blacklist_glob
 
 # source user completion file
 #

--- a/bash_completion
+++ b/bash_completion
@@ -1346,7 +1346,11 @@ _gids()
 
 # Glob for matching various backup files.
 #
-_backup_glob='@(#*#|*@(~|.@(bak|orig|rej|swp|dpkg*|rpm@(orig|new|save))))'
+_comp_backup_glob='@(#*#|*@(~|.@(bak|orig|rej|swp|dpkg*|rpm@(orig|new|save))))'
+
+# @deprecated Use the variable `_comp_backup_glob` instead.  This is the
+# backward-compatibility name.
+_backup_glob=$_comp_backup_glob
 
 # Complete on xinetd services
 #
@@ -1356,7 +1360,7 @@ _xinetd_services()
     if [[ -d $xinetddir ]]; then
         local IFS=$' \t\n' reset=$(shopt -p nullglob)
         shopt -s nullglob
-        local -a svcs=($xinetddir/!($_backup_glob))
+        local -a svcs=($xinetddir/!($_comp_backup_glob))
         $reset
         ((!${#svcs[@]})) ||
             COMPREPLY+=($(compgen -W '"${svcs[@]#$xinetddir/}"' -- "${cur-}"))
@@ -1373,7 +1377,7 @@ _services()
     local IFS=$' \t\n' reset=$(shopt -p nullglob)
     shopt -s nullglob
     COMPREPLY=(
-        $(printf '%s\n' ${sysvdirs[0]}/!($_backup_glob|functions|README)))
+        $(printf '%s\n' ${sysvdirs[0]}/!($_comp_backup_glob|functions|README)))
     $reset
 
     COMPREPLY+=($({
@@ -1420,7 +1424,7 @@ _comp_init_set_up_service_completions()
     local sysvdirs svc svcdir
     _sysvdirs
     for svcdir in "${sysvdirs[@]}"; do
-        for svc in "$svcdir"/!($_backup_glob); do
+        for svc in "$svcdir"/!($_comp_backup_glob); do
             [[ -x $svc ]] && complete -F _service "$svc"
         done
     done
@@ -2439,7 +2443,7 @@ _xfunc()
 _comp_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
 if [[ -d $_comp_compat_dir && -r $_comp_compat_dir && -x $_comp_compat_dir ]]; then
     for _comp_file in "$_comp_compat_dir"/*; do
-        [[ ${_comp_file##*/} != @($_backup_glob|Makefile*|$_comp_init_blacklist_glob) &&
+        [[ ${_comp_file##*/} != @($_comp_backup_glob|Makefile*|$_comp_init_blacklist_glob) &&
             -f $_comp_file && -r $_comp_file ]] && . "$_comp_file"
     done
 fi

--- a/bash_completion
+++ b/bash_completion
@@ -39,7 +39,7 @@ fi
 
 # Blacklisted completions, causing problems with our code.
 #
-_comp_init_blacklist_glob='@(acroread.sh)'
+_comp__init_blacklist_glob='@(acroread.sh)'
 
 # Turn on extended globbing and programmable completion
 shopt -s extglob progcomp
@@ -2443,11 +2443,11 @@ _xfunc()
 _comp_compat_dir=${BASH_COMPLETION_COMPAT_DIR:-/etc/bash_completion.d}
 if [[ -d $_comp_compat_dir && -r $_comp_compat_dir && -x $_comp_compat_dir ]]; then
     for _comp_file in "$_comp_compat_dir"/*; do
-        [[ ${_comp_file##*/} != @($_comp_backup_glob|Makefile*|$_comp_init_blacklist_glob) &&
+        [[ ${_comp_file##*/} != @($_comp_backup_glob|Makefile*|$_comp__init_blacklist_glob) &&
             -f $_comp_file && -r $_comp_file ]] && . "$_comp_file"
     done
 fi
-unset -v _comp_compat_dir _comp_file _comp_init_blacklist_glob
+unset -v _comp_compat_dir _comp_file _comp__init_blacklist_glob
 
 # source user completion file
 #

--- a/bash_completion
+++ b/bash_completion
@@ -1419,7 +1419,7 @@ _service()
 } &&
     complete -F _service service
 
-_comp_init_set_up_service_completions()
+_comp__init_set_up_service_completions()
 {
     local sysvdirs svc svcdir
     _sysvdirs
@@ -1428,9 +1428,9 @@ _comp_init_set_up_service_completions()
             [[ -x $svc ]] && complete -F _service "$svc"
         done
     done
+    unset -f "$FUNCNAME"
 }
-_comp_init_set_up_service_completions
-unset -f _comp_init_set_up_service_completions
+_comp__init_set_up_service_completions
 
 # This function completes on modules
 #

--- a/bash_completion
+++ b/bash_completion
@@ -26,9 +26,9 @@
 BASH_COMPLETION_VERSINFO=(2 11 0)
 
 if [[ $- == *v* ]]; then
-    BASH_COMPLETION_ORIGINAL_V_VALUE="-v"
+    _comp__init_original_set_v="-v"
 else
-    BASH_COMPLETION_ORIGINAL_V_VALUE="+v"
+    _comp__init_original_set_v="+v"
 fi
 
 if [[ ${BASH_COMPLETION_DEBUG-} ]]; then
@@ -2462,7 +2462,7 @@ unset -v _comp__init_user_file
 unset -f have
 unset -v have
 
-set $BASH_COMPLETION_ORIGINAL_V_VALUE
-unset -v BASH_COMPLETION_ORIGINAL_V_VALUE
+set $_comp__init_original_set_v
+unset -v _comp__init_original_set_v
 
 # ex: filetype=sh

--- a/completions/cvs
+++ b/completions/cvs
@@ -168,7 +168,7 @@ _cvs()
                     fi
                 done
                 ((${#files[@]})) &&
-                    COMPREPLY=($(compgen -X "$_backup_glob" -W '"${files[@]}"' \
+                    COMPREPLY=($(compgen -X "$_comp_backup_glob" -W '"${files[@]}"' \
                         -- "$cur"))
             else
                 _cvs_command_options "$1" $mode

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -12,7 +12,7 @@ _invoke_rc_d()
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
 
-    services=($sysvdir/!(README*|*.sh|$_backup_glob))
+    services=($sysvdir/!(README*|*.sh|$_comp_backup_glob))
     services=(${services[@]#$sysvdir/})
     options=(--help --quiet --force --try-anyway --disclose-deny --query
         --no-fallback)

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -12,7 +12,7 @@ _update_rc_d()
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
 
-    services=($sysvdir/!(README*|*.sh|$_backup_glob))
+    services=($sysvdir/!(README*|*.sh|$_comp_backup_glob))
     ((${#services[@]})) && services=("${services[@]#$sysvdir/}")
     options=(-f -n)
 


### PR DESCRIPTION
Ref. https://github.com/scop/bash-completion/pull/729#issuecomment-1097211746

Also includes the change of an initialization-function name.