### PR TITLE
Add more module dirs to kldload

### DIFF
--- a/completions/kldload
+++ b/completions/kldload
@@ -7,12 +7,16 @@ _kldload()
     local cur prev words cword
     _init_completion || return
 
-    local moddir=/modules/
-    [[ -d $moddir ]] || moddir=/boot/kernel/
+    local moddirs modules i
+    IFS=';' read -ra moddirs <<< "$(sysctl -n kern.module_path)"
 
     compopt -o filenames
-    COMPREPLY=($(compgen -f "$moddir$cur"))
-    COMPREPLY=(${COMPREPLY[@]#$moddir})
+    COMPREPLY=()
+    for i in "${moddirs[@]}"; do
+        modules=($(compgen -f "$i/$cur"))
+        modules=(${modules[@]#$i/})
+        COMPREPLY=("${COMPREPLY[@]}" "${modules[@]}")
+    done
     COMPREPLY=(${COMPREPLY[@]%.ko})
 
 } &&

--- a/completions/kldload
+++ b/completions/kldload
@@ -8,7 +8,7 @@ _kldload()
     _init_completion || return
 
     local moddirs modules i IFS=";"
-    moddirs=($(sysctl -n kern.module_path))
+    moddirs=($(kldconfig -r 2>/dev/null))
     _comp_unlocal IFS
 
     compopt -o filenames

--- a/completions/kldload
+++ b/completions/kldload
@@ -7,6 +7,11 @@ _kldload()
     local cur prev words cword
     _init_completion || return
 
+    if [[ "$cur" == */* ]]; then
+        _filedir ko
+        return
+    fi
+
     local moddirs modules i IFS=";"
     moddirs=($(kldconfig -r 2>/dev/null))
     _comp_unlocal IFS
@@ -18,6 +23,9 @@ _kldload()
         COMPREPLY+=("${modules[@]}")
     done
     COMPREPLY=(${COMPREPLY[@]%.ko})
+
+    # also add dirs in current dir
+    _filedir -d
 
 } &&
     complete -F _kldload kldload

--- a/completions/kldload
+++ b/completions/kldload
@@ -12,11 +12,10 @@ _kldload()
     _comp_unlocal IFS
 
     compopt -o filenames
-    COMPREPLY=()
     for i in "${moddirs[@]}"; do
         modules=($(compgen -f "$i/$cur"))
         modules=(${modules[@]#$i/})
-        COMPREPLY=("${COMPREPLY[@]}" "${modules[@]}")
+        COMPREPLY+=("${modules[@]}")
     done
     COMPREPLY=(${COMPREPLY[@]%.ko})
 

--- a/completions/kldload
+++ b/completions/kldload
@@ -7,8 +7,9 @@ _kldload()
     local cur prev words cword
     _init_completion || return
 
-    local moddirs modules i
-    IFS=';' read -ra moddirs <<< "$(sysctl -n kern.module_path)"
+    local moddirs modules i IFS=";"
+    moddirs=($(sysctl -n kern.module_path))
+    _comp_unlocal IFS
 
     compopt -o filenames
     COMPREPLY=()


### PR DESCRIPTION
Current completion only shows modules from `/boot/kernel/`. There are more directories with modules now in FreeBSD e.g. local modules go usually to `/boot/modules/`. Looks like all current directories are written in `sysctl` variable `kern.module_path` (see also `kldconfig(8)`). New implementation considers all these paths.

I'm not experienced in bash programming so there can be some bugs. Tested on FreeBSD 12.3.