### PR TITLE
Drop unsupported formats from evince.

### DIFF
--- a/completions/evince
+++ b/completions/evince
@@ -25,7 +25,7 @@ _evince()
         return
     fi
 
-    _filedir '@(@(?(e)ps|?(E)PS|[pf]df|[PF]DF|dvi|DVI)?(.gz|.GZ|.bz2|.BZ2|.xz|.XZ)|cb[rz]|djv?(u)|gif|jp?(e)g|miff|tif?(f)|pn[gm]|p[bgp]m|bmp|xpm|ico|xwd|tga|pcx)'
+    _filedir '@(@(?(e)ps|?(E)PS|[pf]df|[PF]DF|dvi|DVI)?(.gz|.GZ|.bz2|.BZ2|.xz|.XZ)|cb[rz]|djv?(u)|tif?(f))'
 } &&
     complete -F _evince evince
 


### PR DESCRIPTION
Years ago, evince used to display many different image formats.  I
don't think it does any more.

I'm running evince 42.2 from debian testing/unstable.

I tested this with a simple image (`/usr/share/icons/cab_view.png`) and
imagemagick's "convert" tool like so:

```sh
suffixes="gif jpg png pnm pbm pgm ppm bmp xpm ico xwd tga pcx tiff miff"

for x in $suffixes; do
   convert cab_view.png cab_view.$x
   evince cab_view.$x
done
```

For all of the formats listed above except for "tiff", evince reports
"Unable to open document: …", and "File type … is not supported"

So i've removed those image formats from the evince tab completion.

----
(edited to add: i also tried with graphicsmagick's `gm convert` tool, with the same results, except that graphicsmagick wasn't able to convert to `.ico`)
