### PR TITLE
fix(cryptsetup): update the list of actions

### DIFF
--- a/completions-core/cryptsetup.bash
+++ b/completions-core/cryptsetup.bash
@@ -91,10 +91,15 @@ _comp_cmd_cryptsetup()
             _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            _comp_compgen -- -W 'open close resize status benchmark repair
-                erase luksFormat luksAddKey luksRemoveKey luksChangeKey
-                luksKillSlot luksUUID isLuks luksDump tcryptDump luksSuspend
-                luksResume luksHeaderBackup luksHeaderRestore'
+            _comp_compgen -- -W 'benchmark bitlkClose bitlkDump bitlkOpen close
+                config convert create erase fvault2Close fvault2Dump
+                fvault2Open isLuks loopaesClose loopaesOpen luksAddKey
+                luksChangeKey luksClose luksConfig luksConvertKey luksDump
+                luksErase luksFormat luksHeaderBackup luksHeaderRestore
+                luksKillSlot luksOpen luksRemoveKey luksResume luksSuspend
+                luksUUID open plainClose plainOpen reencrypt refresh remove
+                repair resize status tcryptClose tcryptDump tcryptOpen
+                tcryptOpen_ token'
         fi
     fi
 

--- a/completions-core/cryptsetup.bash
+++ b/completions-core/cryptsetup.bash
@@ -10,6 +10,58 @@ _comp_cmd_cryptsetup__device()
     _comp_compgen -c "${cur:-/dev/}" filedir
 }
 
+_comp_cmd_cryptsetup__action()
+{
+    local REPLY IFS=$' \t\n'
+    _comp_dequote "${1-}" || return 1
+    local cmd=${REPLY:-cryptsetup}
+    local -a actions
+    _comp_split -l actions "$(
+        {
+            LC_ALL=C "$cmd" --help 2>&1 |
+                command sed -n '
+                    /^<action> is one of:$/,/^[^[:space:]]/s/^[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p
+                    /^You can also use old <action> syntax aliases:$/,/^[^[:space:]]/{/^[[:space:]]\{1,\}/!d;s///;s/[:(),[:space:]]\{1,\}/\n/gp;}
+                '
+            LC_ALL=C man cryptsetup 2>&1 |
+                _comp_awk '/^[[:space:]]+[[:alnum:]_]+([[:space:]]+(-[^[:space:].]+|<[^<>]+>|\[[^][]+\]|\(.*\)|or))+$/ && $1 != "cryptsetup" {print $1}'
+        } | sort -u
+    )"
+
+    if ((${#actions[@]} == 0)); then
+        # The fallback action list is extracted from the following sources:
+        # - https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/src/cryptsetup.c#L3154-3208 (search for "Handle aliases")
+        # - https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/src/cryptsetup.c#L2831-2867 (search for "struct action_type")
+        # - https://gitlab.com/cryptsetup/cryptsetup/-/blob/main/src/cryptsetup_args.h#L28-53 (see the macros "*_ACTION")
+        # - The outputs of "cryptsetup --help" and "man cryptsetup" for
+        #   cryptsetup-2.7.5: "fvault2Close", "fvault2Dump", "fvault2Open", and
+        #   "tcryptOpen_" are added.
+        actions=(benchmark bitlkClose bitlkDump bitlkOpen close config convert
+            create erase fvault2Close fvault2Dump fvault2Open isLuks
+            loopaesClose loopaesOpen luksAddKey luksChangeKey luksClose
+            luksConfig luksConvertKey luksDump luksErase luksFormat
+            luksHeaderBackup luksHeaderRestore luksKillSlot luksOpen
+            luksRemoveKey luksResume luksSuspend luksUUID open plainClose
+            plainOpen reencrypt refresh remove repair resize status tcryptClose
+            tcryptDump tcryptOpen tcryptOpen_ token)
+
+        # We attempt to filter the supported actions by the strings in the binary.
+        local path
+        if path=$(type -P -- "$cmd" 2>/dev/null || type -P -- cryptsetup 2>/dev/null); then
+            local filtering_pattern
+            printf -v filtering_pattern '%s\n' "${actions[@]}"
+            filtering_pattern=${filtering_pattern%$'\n'}
+
+            local filtered_actions
+            filtered_actions=$(strings "$path" 2>/dev/null | command grep -Fx "$filtering_pattern" | sort -u) &&
+                [[ $filtered_actions ]] &&
+                _comp_split -l actions "$filtered_actions"
+        fi
+    fi
+
+    _comp_compgen -- -W '"${actions[@]}"'
+}
+
 _comp_cmd_cryptsetup()
 {
     local cur prev words cword was_split comp_args
@@ -91,15 +143,7 @@ _comp_cmd_cryptsetup()
             _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            _comp_compgen -- -W 'benchmark bitlkClose bitlkDump bitlkOpen close
-                config convert create erase fvault2Close fvault2Dump
-                fvault2Open isLuks loopaesClose loopaesOpen luksAddKey
-                luksChangeKey luksClose luksConfig luksConvertKey luksDump
-                luksErase luksFormat luksHeaderBackup luksHeaderRestore
-                luksKillSlot luksOpen luksRemoveKey luksResume luksSuspend
-                luksUUID open plainClose plainOpen reencrypt refresh remove
-                repair resize status tcryptClose tcryptDump tcryptOpen
-                tcryptOpen_ token'
+            _comp_cmd_cryptsetup__action "$1"
         fi
     fi
 

--- a/test/t/test_cryptsetup.py
+++ b/test/t/test_cryptsetup.py
@@ -9,3 +9,7 @@ class TestCryptsetup:
     @pytest.mark.complete("cryptsetup -", require_cmd=True)
     def test_2(self, completion):
         assert completion
+
+    @pytest.mark.complete("cryptsetup luksE", require_cmd=True)
+    def test_github_issue758(self, completion):
+        assert completion == "rase"

--- a/test/t/test_cryptsetup.py
+++ b/test/t/test_cryptsetup.py
@@ -10,6 +10,10 @@ class TestCryptsetup:
     def test_2(self, completion):
         assert completion
 
-    @pytest.mark.complete("cryptsetup luksE", require_cmd=True)
+    @pytest.mark.complete(
+        "cryptsetup luksE",
+        require_cmd=True,
+        skipif=r'! { cryptsetup --help; man cryptsetup; } 2>/dev/null | command grep -qE "(^|[[:space:]])luksErase([[:space:]]|\$)"',
+    )
     def test_github_issue758(self, completion):
         assert completion == "rase"

--- a/test/t/test_cryptsetup.py
+++ b/test/t/test_cryptsetup.py
@@ -2,7 +2,7 @@ import pytest
 
 
 class TestCryptsetup:
-    @pytest.mark.complete("cryptsetup ")
+    @pytest.mark.complete("cryptsetup ", require_cmd=True)
     def test_1(self, completion):
         assert completion
 


### PR DESCRIPTION
Fixes #758 

@carbongreat13 Thank you for the report (#758). Can you test the behavior of the updated [compeltions/cryptsetup](https://github.com/akinomyoga/bash-completion/raw/cryptsetup-action/completions/cryptsetup)? You can download and source it as

```bash
$ curl -Lo cryptsetup https://github.com/akinomyoga/bash-completion/raw/cryptsetup-action/completions/cryptsetup
$ source cryptsetup
$ cruptsetup luksE[Tab]
```