### PR TITLE
Add support for 7zr and 7zz

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -1,4 +1,7 @@
 /7za
+/7zr
+/7zz
+/7zzs
 /aclocal-1.1[0123456]
 /alpine
 /alternatives

--- a/completions/7z
+++ b/completions/7z
@@ -123,6 +123,6 @@ _7z()
         fi
     fi
 } &&
-    complete -F _7z 7z 7za 7zr 7zz
+    complete -F _7z 7z 7za 7zr 7zz 7zzs
 
 # ex: filetype=sh

--- a/completions/7z
+++ b/completions/7z
@@ -123,6 +123,6 @@ _7z()
         fi
     fi
 } &&
-    complete -F _7z 7z 7za
+    complete -F _7z 7z 7za 7zr 7zz
 
 # ex: filetype=sh

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -485,6 +485,7 @@ CLEANFILES = \
 	7za \
 	7zr \
 	7zz \
+	7zzs \
 	aclocal-1.10 \
 	aclocal-1.11 \
 	aclocal-1.12 \
@@ -801,7 +802,8 @@ symlinks: $(DATA)
 	$(ss) 7z \
 		7za \
 		7zr \
-		7zz
+		7zz \
+		7zzs
 	$(ss) aclocal \
 		aclocal-1.10 aclocal-1.11 aclocal-1.12 aclocal-1.13 \
 		aclocal-1.14 aclocal-1.15 aclocal-1.16

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -483,6 +483,8 @@ EXTRA_DIST = $(bashcomp_DATA)
 
 CLEANFILES = \
 	7za \
+	7zr \
+	7zz \
 	aclocal-1.10 \
 	aclocal-1.11 \
 	aclocal-1.12 \
@@ -797,7 +799,9 @@ CLEANFILES = \
 
 symlinks: $(DATA)
 	$(ss) 7z \
-		7za
+		7za \
+		7zr \
+		7zz
 	$(ss) aclocal \
 		aclocal-1.10 aclocal-1.11 aclocal-1.12 aclocal-1.13 \
 		aclocal-1.14 aclocal-1.15 aclocal-1.16


### PR DESCRIPTION
p7zip provides [7zr(1)] in addition to [7za(1)] and [7z(1)].  7zr behaves like 7z with the exception that it only supports the 7z, LZMA, and XZ formats.

Since [7-Zip 21.01 alpha], the 7-Zip project provides a command-line version of 7-Zip for Linux, [7zz(1)].  It shares nearly all of the command-line options and syntax of the p7zip port.

This PR applies the current completions for 7z to 7zr and 7zz.

**Note:** There are a few minor differences between 7zz and the others (e.g. 7zz does not support `-mh*` or `-ms*`) which will can be addressed by subsequent work.

Thanks for considering,
Kevin

[7-Zip 21.01 alpha]: https://sourceforge.net/p/sevenzip/discussion/45797/thread/d401ab2966/
[7z(1)]: https://github.com/jinfeihan57/p7zip/blob/v17.04/man1/7z.1
[7za(1)]: https://github.com/jinfeihan57/p7zip/blob/v17.04/man1/7za.1
[7zr(1)]: https://github.com/jinfeihan57/p7zip/blob/v17.04/man1/7zr.1
[7zz(1)]: https://manpages.debian.org/testing/7zip/7zz.1.en.html
