### PR TITLE
feat(7z): complete h i and rn commands

### DIFF
--- a/completions/7z
+++ b/completions/7z
@@ -11,7 +11,7 @@ _7z()
     fi
 
     local mode
-    [[ ${words[1]} == [adu] ]] && mode=w || mode=r
+    [[ ${words[1]} == @(a|d|rn|u) ]] && mode=w || mode=r
 
     case $cur in
         -ao*)

--- a/completions/7z
+++ b/completions/7z
@@ -6,7 +6,7 @@ _7z()
     _init_completion -n = || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'a b d e l t u x' -- "$cur"))
+        COMPREPLY=($(compgen -W 'a b d e h i l rn t u x' -- "$cur"))
         return
     fi
 


### PR DESCRIPTION
These were added to the help output of p7zip 15.09 and are present in all versions of 7zz.

Thanks,
Kevin