### PR TITLE
fix(gcc): explicitly check existence of the commands

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1112,7 +1112,7 @@ _parse_help()
     (
         case $cmd in
             -) exec cat ;;
-            *) _comp_dequote "$cmd" && LC_ALL=C "$ret" ${2:---help} 2>&1 ;;
+            *) _comp_dequote "$cmd" && type -- "$ret" &>/dev/null && LC_ALL=C "$ret" ${2:---help} 2>&1 ;;
         esac
     ) |
         while read -r line; do
@@ -1149,7 +1149,7 @@ _parse_usage()
     (
         case $cmd in
             -) exec cat ;;
-            *) _comp_dequote "$cmd" && LC_ALL=C "$ret" ${2:---usage} 2>&1 ;;
+            *) _comp_dequote "$cmd" && type -- "$ret" &>/dev/null && LC_ALL=C "$ret" ${2:---usage} 2>&1 ;;
         esac
     ) |
         while read -r line; do

--- a/bash_completion
+++ b/bash_completion
@@ -1822,7 +1822,7 @@ _bashcomp_try_faketty()
 {
     if type unbuffer &>/dev/null; then
         unbuffer -p "$@"
-    elif script --version 2>&1 | command grep -qF util-linux; then
+    elif type script &>/dev/null && script --version 2>&1 | command grep -qF util-linux; then
         # BSD and Solaris "script" do not seem to have required features
         script -qaefc "$*" /dev/null
     else

--- a/completions/gcc
+++ b/completions/gcc
@@ -58,25 +58,25 @@ _gcc()
     complete -F _gcc gcc{,-5,-6,-7,-8} g++{,-5,-6,-7,-8} g77 g95 \
         gccgo{,-5,-6,-7,-8} gcj gfortran{,-5,-6,-7,-8} gpc &&
     {
-        if cc --version 2>/dev/null | command grep -q GCC ||
+        if type cc &>/dev/null && cc --version 2>/dev/null | command grep -q GCC ||
             [[ $(_realcommand cc) == *gcc* ]]; then
             complete -F _gcc cc
         else
             complete -F _minimal cc
         fi
-        if c++ --version 2>/dev/null | command grep -q GCC ||
+        if type c++ &>/dev/null && c++ --version 2>/dev/null | command grep -q GCC ||
             [[ $(_realcommand c++) == *g++* ]]; then
             complete -F _gcc c++
         else
             complete -F _minimal c++
         fi
-        if f77 --version 2>/dev/null | command grep -q GCC ||
+        if type f77 &>/dev/null && f77 --version 2>/dev/null | command grep -q GCC ||
             [[ $(_realcommand f77) == *gfortran* ]]; then
             complete -F _gcc f77
         else
             complete -F _minimal f77
         fi
-        if f95 --version 2>/dev/null | command grep -q GCC ||
+        if type f95 &>/dev/null && f95 --version 2>/dev/null | command grep -q GCC ||
             [[ $(_realcommand f95) == *gfortran* ]]; then
             complete -F _gcc f95
         else


### PR DESCRIPTION
When at least one of the commands `cc`, `c++`, `f77`, and `f95` is not found in the system, on the first load of `gcc` completions, `command_not_found_handle` hook (typically set by distributions) is invoked in the middle of completion, breaks the terminal layout by outputting messages, and eats user inputs.  This PR fixes the issue by checking the existence of commands before running these commands.

As suggested in #390, maybe we could ask for some support by the upstream Bash, e.g., an option to turn off the `command_not_found_handle` hook or just totally disabling `command_not_found_handle` for the programmable completions. Nonetheless, I think we can eliminate the chances of unintended `command_not_found_handle` calls for the existing Bash versions.

Refs.
- https://github.com/scop/bash-completion/pull/390
- https://github.com/akinomyoga/ble.sh/issues/192
- https://github.com/akinomyoga/ble.sh/issues/203

Sorry, this PR is again draft. I'm kind of busy so let me open the PR so I don't forget about it and revisit it later. I think I need to survey similar cases in the codebase. Also, I need to test it.