### PR TITLE
fix(function): suppress error messages for non-existent functions

### DIFF
--- a/completions/function
+++ b/completions/function
@@ -8,7 +8,8 @@ _function()
     if ((cword == 1)); then
         COMPREPLY=($(compgen -A function -- "$cur"))
     else
-        COMPREPLY=("() $(type -- "${words[1]}" 2>/dev/null | command sed -e 1,2d)")
+        local funcdef=$(type -- "${words[1]}" 2>/dev/null | command sed -e 1,2d)
+        COMPREPLY=("()${funcdef:+ $funcdef}")
     fi
 } &&
     complete -F _function function

--- a/completions/function
+++ b/completions/function
@@ -8,7 +8,7 @@ _function()
     if ((cword == 1)); then
         COMPREPLY=($(compgen -A function -- "$cur"))
     else
-        COMPREPLY=("() $(type -- ${words[1]} | command sed -e 1,2d)")
+        COMPREPLY=("() $(type -- "${words[1]}" 2>/dev/null | command sed -e 1,2d)")
     fi
 } &&
     complete -F _function function

--- a/test/t/test_function.py
+++ b/test/t/test_function.py
@@ -1,7 +1,19 @@
 import pytest
 
+from conftest import assert_bash_exec, assert_complete
 
+
+@pytest.mark.bashcomp(ignore_env=r"^\+declare -f fn$")
 class TestFunction:
     @pytest.mark.complete("function _parse_")
     def test_1(self, completion):
         assert completion
+
+    @pytest.mark.complete("function non_existent_function ")
+    def test_2(self, completion):
+        assert completion == "()"
+
+    def test_3(self, bash):
+        assert_bash_exec(bash, "fn() { echo; }")
+        completion = assert_complete(bash, "function fn ")
+        assert completion == "() { ^J    echo^J}"


### PR DESCRIPTION
An error message is outputted on attempting completion after non-existent function names:

```bash
$ function aaa [TAB]bash: type: aaa: not found
() 
```

This PR suppresses the error message (c343c46e).

Also, f45fc770 removes a duplicate space after the text `()` inserted for non-existent functions. With the current implementation of `master`, two spaces are inserted.