### PR TITLE
feat(_comp_looks_like_path): new utility, use it

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -390,6 +390,14 @@ _comp_expand_glob()
     return 0
 }
 
+# Check if the argument looks like a path.
+# @param $1 thing to check
+# @return True (0) if it does, False (> 0) otherwise
+_comp_looks_like_path()
+{
+    [[ ${1-} == @(*/|[.~])* ]]
+}
+
 # Reassemble command line words, excluding specified characters from the
 # list of word completion separators (COMP_WORDBREAKS).
 # @param $1 chars  Characters out of $COMP_WORDBREAKS which should

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -39,7 +39,7 @@ _apt_get()
                     awk '$1 == "Source:" { print $2 }' | sort -u)" -- "$cur"))
                 ;;
             install | reinstall)
-                if [[ $cur == */* ]]; then
+                if _comp_looks_like_path "$cur"; then
                     _filedir deb
                     return
                 elif [[ $cur == *=* ]]; then
@@ -58,7 +58,7 @@ _apt_get()
                 ;;&
             build-dep)
                 _filedir -d
-                [[ $cur != */* ]] || return
+                _comp_looks_like_path "$cur" && return
                 ;;&
             *)
                 COMPREPLY+=($(_comp_xfunc apt-cache packages))

--- a/completions/gdb
+++ b/completions/gdb
@@ -17,7 +17,7 @@ _gdb()
     if ((cword == 1)); then
         local IFS
         compopt -o filenames
-        if [[ $cur == */* ]]; then
+        if _comp_looks_like_path "$cur"; then
             # compgen -c works as expected if $cur contains any slashes.
             IFS=$'\n'
             COMPREPLY=($(PATH="$PATH:." compgen -d -c -- "$cur"))

--- a/completions/kldload
+++ b/completions/kldload
@@ -7,7 +7,7 @@ _kldload()
     local cur prev words cword
     _init_completion || return
 
-    if [[ "$cur" == */* ]]; then
+    if _comp_looks_like_path "$cur"; then
         _filedir ko
         return
     fi

--- a/completions/man
+++ b/completions/man
@@ -52,7 +52,7 @@ _man()
     fi
 
     # file based completion if parameter looks like a path
-    if [[ $cur == @(*/|[.~])* ]]; then
+    if _comp_looks_like_path "$cur"; then
         _filedir "$manext"
         return
     fi

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -24,7 +24,7 @@ _pydoc()
 
     COMPREPLY=($(compgen -W 'keywords topics modules' -- "$cur"))
 
-    if [[ $cur != @(.|*/)* ]]; then
+    if ! _comp_looks_like_path "$cur"; then
         local python=python
         [[ ${1##*/} == *3* ]] && python=python3
         _comp_xfunc python modules $python

--- a/completions/pylint
+++ b/completions/pylint
@@ -107,7 +107,7 @@ _pylint()
         return
     fi
 
-    [[ $cur == @(.|*/)* ]] || _comp_xfunc python modules $python
+    _comp_looks_like_path "$cur" || _comp_xfunc python modules $python
     _filedir py
 } &&
     complete -F _pylint pylint pylint-2 pylint-3

--- a/completions/removepkg
+++ b/completions/removepkg
@@ -9,7 +9,7 @@ _removepkg()
         return
     fi
 
-    if [[ $cur == */* ]]; then
+    if _comp_looks_like_path "$cur"; then
         _filedir
         return
     fi

--- a/completions/rpm
+++ b/completions/rpm
@@ -92,7 +92,7 @@ _rpm()
             ;;
         --whatenhances | --whatprovides | --whatrecommends | --whatrequires | \
             --whatsuggests | --whatsupplements)
-            if [[ $cur == */* ]]; then
+            if _comp_looks_like_path "$cur"; then
                 _filedir
             else
                 # complete on capabilities

--- a/completions/ssh
+++ b/completions/ssh
@@ -580,12 +580,11 @@ _scp()
                 COMPREPLY=("${COMPREPLY[@]/%/ }")
                 return
                 ;;
-            */* | [.~]*)
-                # not a known host, pass through
-                ;;
             *)
-                _known_hosts_real ${ipvx-} -c -a \
-                    ${configfile:+-F "$configfile"} -- "$cur"
+                if ! _comp_looks_like_path "$cur"; then
+                    _known_hosts_real ${ipvx-} -c -a \
+                        ${configfile:+-F "$configfile"} -- "$cur"
+                fi
                 ;;
         esac
     fi

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -61,7 +61,7 @@ _vpnc()
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --long-help)' -- "$cur"))
-    elif [[ $cur == */* ]]; then
+    elif _comp_looks_like_path "$cur"; then
         # explicit filename
         _filedir conf
     else

--- a/test/t/unit/test_unit_looks_like_path.py
+++ b/test/t/unit/test_unit_looks_like_path.py
@@ -1,0 +1,31 @@
+import pytest
+
+from conftest import TestUnitBase, assert_bash_exec
+
+
+@pytest.mark.bashcomp(cmd=None)
+class TestUnitQuote(TestUnitBase):
+    @pytest.mark.parametrize(
+        "thing_looks_like",
+        (
+            ("", False),
+            ("foo", False),
+            ("/foo", True),
+            ("foo/", True),
+            ("foo/bar", True),
+            (".", True),
+            ("../", True),
+            ("~", True),
+            ("~foo", True),
+        ),
+    )
+    def test_1(self, bash, thing_looks_like):
+        thing, looks_like = thing_looks_like
+        output = assert_bash_exec(
+            bash,
+            f"_comp_looks_like_path '{thing}'; printf %s $?",
+            want_output=True,
+            want_newline=False,
+        )
+        is_zero = output.strip() == "0"
+        assert (looks_like and is_zero) or (not looks_like and not is_zero)


### PR DESCRIPTION
Be more consistent with how we test this across the tree.

`apt-get`, `gdb`, `kldload`, `pydoc`, `pylint`, `removepkg`, `rpm`, `scp`, and `vpnc` gained better recognition of various kinds of paths as the result.