### PR TITLE
fix(__load_completion): do not warn when completing `.` first time

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2560,7 +2560,9 @@ __load_completion()
             compfile="$dir/$compfile"
             # Avoid trying to source dirs; https://bugzilla.redhat.com/903540
             if [[ -d $compfile ]]; then
-                echo "bash_completion: $compfile: is a directory" >&2
+                # Do not warn with . or .. (especially the former is common)
+                [[ $compfile == */.?(.) ]] ||
+                    echo "bash_completion: $compfile: is a directory" >&2
             elif [[ -e $compfile ]] && . "$compfile"; then
                 [[ $backslash ]] && $(complete -p "$cmd") "\\$cmd"
                 return 0


### PR DESCRIPTION
ca361be02a92e30a3d26d376b30faf268853e836 enables warnings about trying to source directories when loading completions. That's useful, but triggers the errors in the common case of trying to source something, `. `<kbd>Tab</kbd>

Special case `.` (and for completeness, even though not that interesting, `..`) so we don't issue the warning about them.