### PR TITLE
fix(man): avoid duplicated man page and dir completions

### DIFF
--- a/completions/man
+++ b/completions/man
@@ -99,12 +99,12 @@ _man()
     fi
 
     # shellcheck disable=SC2053
-    if [[ $prev != $mansect ]]; then
-        # File based completion for the rest, prepending ./ if needed
+    if [[ $prev != $mansect && -z ${COMPREPLY-} ]]; then
+        # File based completion, prepending ./ if needed
         # (man 1.6f needs that for man pages in current dir)
-        local i start=${#COMPREPLY[@]}
+        local i
         _filedir "$manext"
-        for ((i = start; i < ${#COMPREPLY[@]}; i++)); do
+        for i in "${!COMPREPLY[@]}"; do
             [[ ${COMPREPLY[i]} == */* ]] || COMPREPLY[i]=./${COMPREPLY[i]}
         done
     fi


### PR DESCRIPTION
If a directory with the same name as an already found man page candidate from manpath is present, they both end up in completions as a duplicate with the trailing slash included.

To work around, skip file based completion altogether when a man page from manpath is among found candidates. A workaround for the workaround, i.e. "forcing" file based completion, is to prefix the argument with a `./`.

Closes https://github.com/scop/bash-completion/issues/420