### PR TITLE
fix(_get_comp_words_by_ref): work around localvar_inherit

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -547,6 +547,7 @@ _get_comp_words_by_ref()
     local exclude flag i OPTIND=1
     local cur cword words=()
     local upargs=() upvars=() vcur vcword vprev vwords
+    unset -v vcur vcword vprev vwords # workaround for localvar_inherit
 
     while getopts "c:i:n:p:w:" flag "$@"; do
         case $flag in


### PR DESCRIPTION
I separate the change from ~~#790~~ #791. This is the most independent part.

> - 868e98ea **work around localvar_inherit**: This is actually not directly related to the refactoring of `_command_offset`, but I noticed this in investigating which variables can be modified by `_comp_offset` for 868e98ea. The implementation of `_get_comp_words_by_ref` assumes that the declared variables `vcur`, `vwords`, `vcword`, and `vprev` have initially unset values to later test them with `[[ -v vcur ]]`, etc., but this is not ensured when `localvar_inherit` is turned on.

The description is unchanged from that in ~~#790~~ #791.