### PR TITLE
refactor(_command_offset): refactor the adjustment of `COMP_WORDS`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2220,6 +2220,13 @@ _command_offset()
     # rewrite current completion context before invoking
     # actual command completion
 
+    # make changes to COMP_* local.  Note that bash-4.3..5.0 have a
+    # bug that `local -a arr=("${arr[@]}")` fails.  We instead first
+    # assign the values of `COMP_WORDS` to another array `comp_words`.
+    local COMP_LINE=$COMP_LINE COMP_POINT=$COMP_POINT COMP_CWORD=$COMP_CWORD
+    local -a comp_words=("${COMP_WORDS[@]}")
+    local -a COMP_WORDS=("${comp_words[@]}")
+
     # find new first word position, then
     # rewrite COMP_LINE and adjust COMP_POINT
     local word_offset=$1 i tail

--- a/bash_completion
+++ b/bash_completion
@@ -2222,24 +2222,15 @@ _command_offset()
 
     # find new first word position, then
     # rewrite COMP_LINE and adjust COMP_POINT
-    local word_offset=$1 i j
+    local word_offset=$1 i tail
     for ((i = 0; i < word_offset; i++)); do
-        for ((j = 0; j <= ${#COMP_LINE}; j++)); do
-            [[ $COMP_LINE == "${COMP_WORDS[i]}"* ]] && break
-            COMP_LINE=${COMP_LINE:1}
-            ((COMP_POINT--))
-        done
-        COMP_LINE=${COMP_LINE#"${COMP_WORDS[i]}"}
-        ((COMP_POINT -= ${#COMP_WORDS[i]}))
+        tail=${COMP_LINE#*"${COMP_WORDS[i]}"}
+        ((COMP_POINT -= ${#COMP_LINE} - ${#tail}))
+        COMP_LINE=$tail
     done
 
     # shift COMP_WORDS elements and adjust COMP_CWORD
-    for ((i = 0; i <= COMP_CWORD - word_offset; i++)); do
-        COMP_WORDS[i]=${COMP_WORDS[i + word_offset]}
-    done
-    for ((i; i <= COMP_CWORD; i++)); do
-        unset -v 'COMP_WORDS[i]'
-    done
+    COMP_WORDS=("${COMP_WORDS[@]:word_offset}")
     ((COMP_CWORD -= word_offset))
 
     COMPREPLY=()

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -12,7 +12,7 @@ def join(words):
 
 @pytest.mark.bashcomp(
     cmd=None,
-    ignore_env=r"^[+-](COMP(_(WORDS|CWORD|LINE|POINT)|REPLY)|cur|cword|words)=",
+    ignore_env=r"^[+-]COMPREPLY=",
 )
 class TestUnitCommandOffset:
     wordlist = sorted(["foo", "bar"])


### PR DESCRIPTION
Extracted from ~~#790~~ #791. This is also actually independent.

> - d2c0b4ee **simplify logic**: The original code tries to manually perform a string manipulation that can be achieved by a single parameter expansion. Also, it tries to manually perform the array compaction that can be achieved by a single parameter expansion. The behaviors of the new codes slightly differ from the original ones, but I believe the behaviors of the new codes are better:
>   - In the original code, `COMP_LINE` becomes empty when `${COMP_WORDS[i]}` is not contained in `$COMP_LINE`, though I don't think that happens as far as these variables are modified by external codes. In the new code, such a word `${COMP_WORDS[i]}` is just ignored.
>   - In the original code, the words in `COMP_WORDS` after `COMP_CWORD` is not modified, but just the word at `COMP_CWORD` and the words preceding it are shifted. For example, `COMP_WORDS=([0]=sudo [1]=A [2]=B [3]=C [4]=D)` with `COMP_CWORD=2` becomes `COMP_WORDS=([0]=A [1]=B [3]=C [4]=D)` instead of `COMP_WORDS=([0]=A [1]=B [2]=C [3]=D)`. In the new code, all the words are shifted.
> - 995db594 **localize changes to `COMP_*`**: The original implementation of `_comp_offset` breaks the state of `COMP_*` after the  completion of `_comp_offset`. Currently, it doesn't cause a problem because all the completion functions in bash-completion that use `_comp_offset` seem to return from the function immediately after the call of `_comp_offset`. But I still think we should localize the changes to `COMP_*` within `_command_offset` and functions called from it.
>   - This change might possibly break existing external completion functions if there are completion functions that use the modified values of `COMP_*` after calling `_comp_offset`.
>   - The test seems to ignore also other variables `cur`, `words`, and `cword`, and they do not seem to be modified by the current implementation of `_command_offset`.

The description is the same as was in #791.
