### PR TITLE
test(conftest): exclude cache variables for `diff_env`

### DIFF
--- a/test/config/bashrc
+++ b/test/config/bashrc
@@ -65,6 +65,22 @@ add_comp_wordbreak_char()
     [[ "${COMP_WORDBREAKS//[^$1]/}" ]] || COMP_WORDBREAKS+=$1
 }
 
+_comp__test_get_env()
+{
+    (
+        # Do not output the state of test variables "_comp__test_+([0-9])_*"
+        # and internal mutable variables "_comp_*_mut_*".
+        # shellcheck disable=SC2046
+        unset -v $(compgen -W '"${!_comp_@}"' -X '!_comp_@(_test_+([0-9])_*|*_mut_*)')
+
+        set -o posix
+        set
+    )
+    declare -F
+    shopt -p
+    set -o
+}
+
 # Local variables:
 # mode: shell-script
 # End:

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -709,7 +709,7 @@ def get_env(bash: pexpect.spawn) -> List[str]:
         x
         for x in assert_bash_exec(
             bash,
-            "{ (set -o posix ; set); declare -F; shopt -p; set -o; }",
+            "_comp__test_get_env",
             want_output=True,
         )
         .strip()
@@ -728,7 +728,7 @@ def diff_env(before: List[str], after: List[str], ignore: str):
         if not re.search(r"^(---|\+\+\+|@@ )", x)
         # Ignore variables expected to change:
         and not re.search(
-            r"^[-+](_|PPID|BASH_REMATCH|_comp__test_\d+_\w+)=",
+            r"^[-+](_|PPID|BASH_REMATCH|(BASH_)?LINENO)=",
             x,
             re.ASCII,
         )


### PR DESCRIPTION
Extracted from #791. Actually, this change is needed for #791, but @scop seems to be going to agree with merging this first, I separate the change here.

> - 973276a5 **ignore mut variables in diff_env (conftest)**: I'd like to cache the regular expressions constructed from `COMP_WORDBREAKS` in c59655c4. This means that the variables that hold the cache can be changed while completions, so they should be excluded from the `diff_env` test of the test suite.
>   - Failing approach: I tried to implement it by `ignore_env` or by adding the variable names in [this line](https://github.com/scop/bash-completion/commit/973276a5397daf764f0911f7a9713ec530ea7c66#diff-191cf488d891a8f1d47930268d94548184bfdf58c7cb898d59327e757c83be2bL731), but it seems to fail because the variable contains newlines so that the linewise exclusion does not work. The current exclusion mechanism based on the *linewise* `diff` does not work properly for the variables that contain multiple lines.
>   - I instead suggest excluding variables at the env output stage. Because such a code becomes long, I decided to define a helper function `_comp__test_get_env` for `get_env` in `test/config/bashrc` (just as a test helper [`add_comp_wordbreak_char`](https://github.com/scop/bash-completion/blob/40aa4dc3c75791f43f850871466039768b3048ad/test/config/bashrc#L62-L66)).
>   - A related discussion is how to tell the cache variables to the test framework.
>     - (a) Since `_comp_offset` can be called by several places, it is not useful to add the variable names to `ignore_env` of all the tests for the completions that may call `_comp_offset`.
>     - (b) As an alternate solution, we might add the variable names one by one in the helper function `_comp__test_get_env`, but that doesn't seem to be smart.
>     - (c) In the current PR, I invented a prefix `_mut_` for mutable variables to exclude them from the `diff_env` check. [The thread at #539 about "Internal variables / mutable variables (caching)"](https://github.com/scop/bash-completion/discussions/539#discussioncomment-827955) is related.
>     - (d) Another solution is to allow changing the variables `_comp_*` unlimitedly in the tests.

The description is the same as was in #791.

