### PR TITLE
refactor(_command_offset): rename `{ => _comp}{_command_offset,_command,_root_command}`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2196,7 +2196,7 @@ fi
 # first complete on a command, then complete according to that command's own
 # completion definition.
 #
-_command_offset()
+_comp_command_offset()
 {
     # rewrite current completion context before invoking
     # actual command completion
@@ -2302,12 +2302,13 @@ _command_offset()
         done
     fi
 }
+_comp_deprecate_func _command_offset _comp_command_offset
 
-# A _command_offset wrapper function for use when the offset is unknown.
+# A _comp_command_offset wrapper function for use when the offset is unknown.
 # Only intended to be used as a completion function directly associated
 # with a command, not to be invoked from within other completion functions.
 #
-_command()
+_comp_command()
 {
     local offset i
 
@@ -2319,18 +2320,20 @@ _command()
             break
         fi
     done
-    _command_offset $offset
+    _comp_command_offset $offset
 }
-complete -F _command aoss command "do" else eval exec ltrace nice nohup padsp \
+_comp_deprecate_func _command _comp_command
+complete -F _comp_command aoss command "do" else eval exec ltrace nice nohup padsp \
     "then" time tsocks vsound xargs
 
-_root_command()
+_comp_root_command()
 {
     local PATH=$PATH:/sbin:/usr/sbin:/usr/local/sbin
     local root_command=$1
-    _command
+    _comp_command
 }
-complete -F _root_command fakeroot gksu gksudo kdesudo really
+_comp_deprecate_func _root_command _comp_root_command
+complete -F _comp_root_command fakeroot gksu gksudo kdesudo really
 
 # Return true if the completion should be treated as running as root
 _complete_as_root()

--- a/bash_completion
+++ b/bash_completion
@@ -2192,25 +2192,6 @@ else
     complete -F _cd -o nospace cd pushd
 fi
 
-# A _command_offset wrapper function for use when the offset is unknown.
-# Only intended to be used as a completion function directly associated
-# with a command, not to be invoked from within other completion functions.
-#
-_command()
-{
-    local offset i
-
-    # find actual offset, as position of the first non-option
-    offset=1
-    for ((i = 1; i <= COMP_CWORD; i++)); do
-        if [[ ${COMP_WORDS[i]} != -* ]]; then
-            offset=$i
-            break
-        fi
-    done
-    _command_offset $offset
-}
-
 # A meta-command completion function for commands like sudo(8), which need to
 # first complete on a command, then complete according to that command's own
 # completion definition.
@@ -2320,6 +2301,25 @@ _command_offset()
             break
         done
     fi
+}
+
+# A _command_offset wrapper function for use when the offset is unknown.
+# Only intended to be used as a completion function directly associated
+# with a command, not to be invoked from within other completion functions.
+#
+_command()
+{
+    local offset i
+
+    # find actual offset, as position of the first non-option
+    offset=1
+    for ((i = 1; i <= COMP_CWORD; i++)); do
+        if [[ ${COMP_WORDS[i]} != -* ]]; then
+            offset=$i
+            break
+        fi
+    done
+    _command_offset $offset
 }
 complete -F _command aoss command "do" else eval exec ltrace nice nohup padsp \
     "then" time tsocks vsound xargs

--- a/completions/_ionice
+++ b/completions/_ionice
@@ -31,7 +31,7 @@ _ionice()
     done
 
     if ((offset > 0)); then
-        _command_offset $offset
+        _comp_command_offset $offset
         return
     fi
 

--- a/completions/ccache
+++ b/completions/ccache
@@ -8,7 +8,7 @@ _ccache()
     local i
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* ]]; then
-            _command_offset $i
+            _comp_command_offset $i
             return
         fi
         [[ ${COMP_WORDS[i]} == -*[oFM] ]] && ((i++))

--- a/completions/find
+++ b/completions/find
@@ -11,7 +11,7 @@ _find()
     for i in ${!words[*]}; do
         if [[ ${words[i]} == -@(exec|ok)?(dir) ]]; then
             ((cword > i)) || break
-            _command_offset $((i + 1))
+            _comp_command_offset $((i + 1))
             return
         fi
     done

--- a/completions/gdb
+++ b/completions/gdb
@@ -8,7 +8,7 @@ _gdb()
     # gdb [options] --args executable-file [inferior-arguments ...]
     for ((i = 1; i < cword; i++)); do
         if [[ ${words[i]} == --args ]]; then
-            _command_offset $((i + 1))
+            _comp_command_offset $((i + 1))
             return $?
         fi
     done

--- a/completions/screen
+++ b/completions/screen
@@ -75,7 +75,7 @@ _screen_sessions()
                     ;;
             esac
 
-            _command_offset $i
+            _comp_command_offset $i
             return
         done
 

--- a/completions/strace
+++ b/completions/strace
@@ -22,7 +22,7 @@ _strace()
     done
 
     if ((offset > 0)); then
-        _command_offset $offset
+        _comp_command_offset $offset
     else
 
         case $prev in

--- a/completions/sudo
+++ b/completions/sudo
@@ -13,7 +13,7 @@ _sudo()
             if [[ ${words[i]} != -* ]]; then
                 local PATH=$PATH:/sbin:/usr/sbin:/usr/local/sbin
                 local root_command=${words[i]}
-                _command_offset $i
+                _comp_command_offset $i
                 return
             fi
             if [[ ${words[i]} == -@(!(-*)e*|-edit) ]]; then

--- a/completions/timeout
+++ b/completions/timeout
@@ -8,7 +8,7 @@ _timeout()
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* && ${COMP_WORDS[i - 1]} != = ]]; then
             if $found; then
-                _command_offset $i
+                _comp_command_offset $i
                 return
             fi
             found=true

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -8,10 +8,10 @@ _valgrind()
     local i
     # Note: intentionally using COMP_WORDS and COMP_CWORD instead of
     # words and cword here due to splitting on = causing index differences
-    # (_command_offset assumes the former).
+    # (_comp_command_offset assumes the former).
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != @([-=])* && ${COMP_WORDS[i - 1]} != = ]]; then
-            _command_offset $i
+            _comp_command_offset $i
             return
         fi
     done

--- a/completions/watch
+++ b/completions/watch
@@ -26,7 +26,7 @@ _watch()
     done
 
     if ((offset > 0)); then
-        _command_offset $offset
+        _comp_command_offset $offset
         return
     fi
 

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -8,7 +8,7 @@ _xvfb_run()
     local i
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* ]]; then
-            _command_offset $i
+            _comp_command_offset $i
             return
         fi
         [[ ${COMP_WORDS[i]} == -!(-*)[npsef] ]] && ((i++))

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -21,8 +21,8 @@ class TestUnitCommandOffset:
     def functions(self, bash):
         assert_bash_exec(
             bash,
-            "_cmd1() { _command_offset 1; }; complete -F _cmd1 cmd1; "
-            "complete -F _command meta; "
+            "_cmd1() { _comp_command_offset 1; }; complete -F _cmd1 cmd1; "
+            "complete -F _comp_command meta; "
             "_compfunc() { COMPREPLY=(%s); }" % join(self.wordlist),
         )
         completions = [


### PR DESCRIPTION
Extracted from #791.

> - cd98abd8 **move `_command`**: This just moves the position of the function. I think `_command_offset` had been sufficiently short before but now is a long function, so it shouldn't be put between `_command` and `complete -F _command` any more.
> - 15c699fd **rename `{ => _comp}{_command_offset,_command,_root_command}`**: Naming convention suggested by #539.

The description is unchanged.
