### PR TITLE
fix(_command_offset): support quoting of the command name in `complete -p` (bash 5.2)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2231,7 +2231,9 @@ _comp_command_offset()
         compopt -o filenames
         COMPREPLY=($(compgen -d -c -- "$cur"))
     else
-        local cmd=${COMP_WORDS[0]} compcmd=${COMP_WORDS[0]}
+        local ret
+        _comp_dequote "${COMP_WORDS[0]}" || ret=${COMP_WORDS[0]}
+        local cmd=$ret compcmd=$ret
         local cspec=$(complete -p "$cmd" 2>/dev/null)
 
         # If we have no completion for $cmd yet, see if we have for basename
@@ -2294,7 +2296,7 @@ _comp_command_offset()
                 done
             else
                 cspec=${cspec#complete}
-                cspec=${cspec%%"$compcmd"}
+                cspec=${cspec%%@("$compcmd"|"'${compcmd//\'/\'\\\'\'}'")}
                 COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
             fi
             break

--- a/bash_completion
+++ b/bash_completion
@@ -2297,7 +2297,9 @@ _comp_command_offset()
             else
                 cspec=${cspec#complete}
                 cspec=${cspec%%@("$compcmd"|"'${compcmd//\'/\'\\\'\'}'")}
-                COMPREPLY=($(eval compgen "$cspec" -- '$cur'))
+                local result=$(eval compgen "$cspec" -- '$cur')
+                local IFS=$'\n'
+                COMPREPLY=($result)
             fi
             break
         done

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -2,7 +2,7 @@ from shlex import quote
 
 import pytest
 
-from conftest import assert_bash_exec, assert_complete
+from conftest import assert_bash_exec, assert_complete, bash_env_saved
 
 
 def join(words):
@@ -43,6 +43,7 @@ class TestUnitCommandOffset:
         assert_bash_exec(
             bash, "complete -W %s 'cmd!'" % quote(join(self.wordlist))
         )
+        assert_bash_exec(bash, 'complete -W \'"$word1" "$word2"\' cmd6')
 
     def test_1(self, bash, functions):
         assert_complete(bash, 'cmd1 "/tmp/aaa bbb" ')
@@ -82,3 +83,9 @@ class TestUnitCommandOffset:
 
     def test_cmd_specialchar(self, bash, functions):
         assert assert_complete(bash, "meta 'cmd!' ") == self.wordlist
+
+    def test_space(self, bash, functions):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.write_variable("word1", "a b c")
+            bash_env.write_variable("word2", "d e f")
+            assert assert_complete(bash, "meta cmd6 ") == ["a b c", "d e f"]

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -72,3 +72,6 @@ class TestUnitCommandOffset:
         cleared before the retry.
         """
         assert assert_complete(bash, "meta %s " % cmd) == expected_completion
+
+    def test_cmd_quoted(self, bash, functions):
+        assert assert_complete(bash, "meta 'cmd2' ") == self.wordlist

--- a/test/t/unit/test_unit_command_offset.py
+++ b/test/t/unit/test_unit_command_offset.py
@@ -25,13 +25,13 @@ class TestUnitCommandOffset:
             "complete -F _comp_command meta; "
             "_compfunc() { COMPREPLY=(%s); }" % join(self.wordlist),
         )
+
         completions = [
             'complete -F _compfunc "${COMP_WORDS[0]}"',
             'complete -W %s "${COMP_WORDS[0]}"' % quote(join(self.wordlist)),
             'COMPREPLY=(dummy); complete -r "${COMP_WORDS[0]}"',
             "COMPREPLY+=(${#COMPREPLY[@]})",
         ]
-
         for idx, comp in enumerate(completions, 2):
             assert_bash_exec(
                 bash,
@@ -39,6 +39,10 @@ class TestUnitCommandOffset:
                 "complete -F _cmd%(idx)s cmd%(idx)s"
                 % {"idx": idx, "comp": comp},
             )
+
+        assert_bash_exec(
+            bash, "complete -W %s 'cmd!'" % quote(join(self.wordlist))
+        )
 
     def test_1(self, bash, functions):
         assert_complete(bash, 'cmd1 "/tmp/aaa bbb" ')
@@ -75,3 +79,6 @@ class TestUnitCommandOffset:
 
     def test_cmd_quoted(self, bash, functions):
         assert assert_complete(bash, "meta 'cmd2' ") == self.wordlist
+
+    def test_cmd_specialchar(self, bash, functions):
+        assert assert_complete(bash, "meta 'cmd!' ") == self.wordlist


### PR DESCRIPTION
Bash 5.2 starts to quote the command name in `complete -p` if necessary.