### PR TITLE
fix(_command_offset): fix offset mismatching for words vs COMP_WORDS (use COMP_WORDS)

### DIFF
--- a/completions/_ionice
+++ b/completions/_ionice
@@ -9,8 +9,8 @@ _comp_cmd_ionice()
     _comp_initialize -- "$@" || return
 
     local offset=0 i
-    for ((i = 1; i <= cword; i++)); do
-        case ${words[i]} in
+    for ((i = 1; i <= COMP_CWORD; i++)); do
+        case ${COMP_WORDS[i]} in
             -h)
                 return
                 ;;
@@ -26,6 +26,7 @@ _comp_cmd_ionice()
                 continue
                 ;;
         esac
+        [[ ${COMP_WORDS[i - 1]} == = ]] && continue
         offset=$i
         break
     done

--- a/completions/find
+++ b/completions/find
@@ -8,9 +8,9 @@ _comp_cmd_find()
     _comp_initialize -- "$@" || return
 
     local i
-    for i in ${!words[*]}; do
-        if [[ ${words[i]} == -@(exec|ok)?(dir) ]]; then
-            ((cword > i)) || break
+    for i in ${!COMP_WORDS[*]}; do
+        if [[ ${COMP_WORDS[i]} == -@(exec|ok)?(dir) ]]; then
+            ((COMP_CWORD > i)) || break
             _comp_command_offset $((i + 1))
             return
         fi

--- a/completions/find
+++ b/completions/find
@@ -8,9 +8,8 @@ _comp_cmd_find()
     _comp_initialize -- "$@" || return
 
     local i
-    for i in ${!COMP_WORDS[*]}; do
+    for ((i = 1; i < COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} == -@(exec|ok)?(dir) ]]; then
-            ((COMP_CWORD > i)) || break
             _comp_command_offset $((i + 1))
             return
         fi

--- a/completions/gdb
+++ b/completions/gdb
@@ -6,8 +6,8 @@ _comp_cmd_gdb()
     _comp_initialize -- "$@" || return
 
     # gdb [options] --args executable-file [inferior-arguments ...]
-    for ((i = 1; i < cword; i++)); do
-        if [[ ${words[i]} == --args ]]; then
+    for ((i = 1; i < COMP_CWORD; i++)); do
+        if [[ ${COMP_WORDS[i]} == --args ]]; then
             _comp_command_offset $((i + 1))
             return $?
         fi

--- a/completions/screen
+++ b/completions/screen
@@ -64,8 +64,8 @@ _screen_sessions()
         fi
 
         local i
-        for ((i = 1; i <= cword; i++)); do
-            case ${words[i]} in
+        for ((i = 1; i <= COMP_CWORD; i++)); do
+            case ${COMP_WORDS[i]} in
                 -*[rRdDxscTehpSt])
                     ((i++))
                     continue

--- a/completions/strace
+++ b/completions/strace
@@ -7,8 +7,8 @@ _strace()
 
     # check if we're still completing strace
     local offset=0 i
-    for ((i = 1; i <= cword; i++)); do
-        case ${words[i]} in
+    for ((i = 1; i <= COMP_CWORD; i++)); do
+        case ${COMP_WORDS[i]} in
             -o | -e | -p)
                 ((i++))
                 continue
@@ -17,6 +17,7 @@ _strace()
                 continue
                 ;;
         esac
+        [[ ${COMP_WORDS[i - 1]} == = ]] && continue
         offset=$i
         break
     done

--- a/completions/sudo
+++ b/completions/sudo
@@ -10,20 +10,20 @@ _sudo()
 
     local noargopts='!(-*|*[uUgCp]*)'
     [[ $mode == normal ]] &&
-        for ((i = 1; i <= cword; i++)); do
-            if [[ ${words[i]} != -* ]]; then
+        for ((i = 1; i <= COMP_CWORD; i++)); do
+            if [[ ${COMP_WORDS[i]} != -* && ${COMP_WORDS[i - 1]} != = ]]; then
                 local PATH=$PATH:/sbin:/usr/sbin:/usr/local/sbin
-                local root_command=${words[i]}
+                local root_command=${COMP_WORDS[i]}
                 _comp_command_offset $i
                 return
             fi
             # shellcheck disable=SC2254
-            if [[ ${words[i]} == -@(${noargopts}e*|-edit) ]]; then
+            if [[ ${COMP_WORDS[i]} == -@(${noargopts}e*|-edit) ]]; then
                 mode=edit
                 break
             fi
             # shellcheck disable=SC2254
-            [[ ${words[i]} == -@(user|other-user|group|close-from|prompt|${noargopts}[uUgCp]) ]] &&
+            [[ ${COMP_WORDS[i]} == -@(user|other-user|group|close-from|prompt|${noargopts}[uUgCp]) ]] &&
                 ((i++))
         done
 

--- a/completions/sudo
+++ b/completions/sudo
@@ -23,7 +23,7 @@ _sudo()
                 break
             fi
             # shellcheck disable=SC2254
-            [[ ${COMP_WORDS[i]} == -@(user|other-user|group|close-from|prompt|${noargopts}[uUgCp]) ]] &&
+            [[ ${COMP_WORDS[i]} == @(--@(user|other-user|group|close-from|prompt)|-${noargopts}[uUgCp]) ]] &&
                 ((i++))
         done
 

--- a/completions/watch
+++ b/completions/watch
@@ -10,8 +10,8 @@ _watch()
     local offset=0 i
     local noargopts='!(-*|*[dn]*)'
     # shellcheck disable=SC2254
-    for ((i = 1; i <= cword; i++)); do
-        case ${words[i]} in
+    for ((i = 1; i <= COMP_CWORD; i++)); do
+        case ${COMP_WORDS[i]} in
             --help | --version | -${noargopts}h)
                 return
                 ;;
@@ -23,6 +23,7 @@ _watch()
                 continue
                 ;;
         esac
+        [[ ${COMP_WORDS[i - 1]} == = ]] && continue
         offset=$i
         break
     done


### PR DESCRIPTION
Fixes #722

This PR tries to fix it so that `_command_offset` receives the offset in `COMP_WORDS` but not the offset in `words`. However, another option is to make `command_offset` receive the offset in `words` and convert it to the one in `COMP_WORDS` inside `_command_offset`. I have also made the patch for that option (acf6411c).

This PR also includes a fix (addf7233) and an improvement (6755e497) on codes calculating the offset.


