### PR TITLE
feat(fio): more option and arg completions

### DIFF
--- a/completions/fio
+++ b/completions/fio
@@ -31,13 +31,13 @@ _fio()
             return
             ;;
         --cmdhelp)
-            ret=($("$1" --cmdhelp=all 2>/dev/null | awk '{print $1}'))
-            COMPREPLY=($(compgen -W '${ret[@]} all' -- "$cur"))
+            ret=($("$1" --cmdhelp=all 2>/dev/null | awk '{print $1}') all)
+            COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
             return
             ;;
         --enghelp)
-            _comp_cmd_fio__engines "$1"
-            COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
+            _comp_cmd_fio__engines "$1" &&
+                COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
             return
             ;;
         --eta)
@@ -98,7 +98,7 @@ _fio()
             local IFS=$'\n'
             local cmdhelp=($("$1" --cmdhelp=${prev#--} 2>/dev/null))
             _comp_unlocal IFS
-            case ${cmdhelp[*]} in
+            case ${cmdhelp[*]-} in
                 *"showing closest match"*)
                     # ignore
                     ;;
@@ -111,6 +111,7 @@ _fio()
                     #        valid values: 1024       [...]
                     #                    : 1000       [...]
                     local line="" in_values=false
+                    ret=()
                     for line in "${cmdhelp[@]}"; do
                         if $in_values; then
                             if [[ $line =~ ^[[:space:]]*:[[:space:]]*([^[:space:]]+) ]]; then
@@ -123,7 +124,7 @@ _fio()
                             ret+=("${BASH_REMATCH[1]}")
                         fi
                     done
-                    COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
+                    COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
                     return
                     ;;
             esac

--- a/completions/fio
+++ b/completions/fio
@@ -94,6 +94,41 @@ _fio()
             _gids
             return
             ;;
+        --?*)
+            local IFS=$'\n'
+            local cmdhelp=($("$1" --cmdhelp=${prev#--} 2>/dev/null))
+            _comp_unlocal IFS
+            case ${cmdhelp[*]} in
+                *"showing closest match"*)
+                    # ignore
+                    ;;
+                *" type: boolean "* | *" type: empty or boolean "*)
+                    COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+                    return
+                    ;;
+                *" valid values:"*)
+                    # For example, for --kb_base=:
+                    #        valid values: 1024       [...]
+                    #                    : 1000       [...]
+                    local line="" in_values=false
+                    for line in "${cmdhelp[@]}"; do
+                        if $in_values; then
+                            if [[ $line =~ ^[[:space:]]*:[[:space:]]*([^[:space:]]+) ]]; then
+                                ret+=("${BASH_REMATCH[1]}")
+                            else
+                                break
+                            fi
+                        elif [[ $line =~ ^[[:space:]]*valid\ values:[[:space:]]*([^[:space:]]+) ]]; then
+                            in_values=true
+                            ret+=("${BASH_REMATCH[1]}")
+                        fi
+                    done
+                    COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
+                    return
+                    ;;
+            esac
+            # else fallthrough
+            ;;
     esac
 
     $split && return

--- a/completions/fio
+++ b/completions/fio
@@ -1,5 +1,11 @@
 # fio(1) completion                                        -*- shell-script -*-
 
+_comp_cmd_fio__engines()
+{
+    local IFS=$'\n'
+    ret=($("$1" --enghelp 2>/dev/null | command sed -ne '/^[[:space:]]/p'))
+}
+
 _fio()
 {
     local cur prev words cword split
@@ -30,8 +36,8 @@ _fio()
             return
             ;;
         --enghelp)
-            # TODO print ioengine help, or list available ioengines
-            # TODO engine,help arg
+            _comp_cmd_fio__engines "$1"
+            COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
             return
             ;;
         --eta)
@@ -69,6 +75,11 @@ _fio()
             ;;
         --aux-path)
             _filedir -d
+            return
+            ;;
+        --ioengine)
+            _comp_cmd_fio__engines "$1"
+            COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
             return
             ;;
     esac

--- a/completions/fio
+++ b/completions/fio
@@ -5,6 +5,7 @@ _fio()
     local cur prev words cword split
     _init_completion -s || return
 
+    local ret
     case $prev in
         --help | --version)
             return
@@ -24,8 +25,8 @@ _fio()
             return
             ;;
         --cmdhelp)
-            # TODO more commands?
-            COMPREPLY=($(compgen -W "all" -- "$cur"))
+            ret=($("$1" --cmdhelp=all 2>/dev/null | awk '{print $1}'))
+            COMPREPLY=($(compgen -W '${ret[@]} all' -- "$cur"))
             return
             ;;
         --enghelp)
@@ -75,7 +76,13 @@ _fio()
     $split && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        COMPREPLY=($(
+            compgen -W '
+                      $(_parse_help "$1")
+                      $("$1" --cmdhelp=all 2>/dev/null | \
+                             awk "{printf \"--%s=\n\", \$1}")
+            ' -- "$cur"
+        ))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/fio
+++ b/completions/fio
@@ -4,6 +4,7 @@ _comp_cmd_fio__engines()
 {
     local IFS=$'\n'
     ret=($("$1" --enghelp 2>/dev/null | command sed -ne '/^[[:space:]]/p'))
+    return $((!${#ret[*]}))
 }
 
 _fio()
@@ -78,8 +79,8 @@ _fio()
             return
             ;;
         --ioengine)
-            _comp_cmd_fio__engines "$1"
-            COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
+            _comp_cmd_fio__engines "$1" &&
+                COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
             return
             ;;
         --exec_postrun | --exec_prerun)

--- a/completions/fio
+++ b/completions/fio
@@ -82,6 +82,18 @@ _fio()
             COMPREPLY=($(compgen -W '${ret[@]}' -- "$cur"))
             return
             ;;
+        --exec_postrun | --exec_prerun)
+            COMPREPLY=($(compgen -c -- "$cur"))
+            return
+            ;;
+        --uid)
+            _uids
+            return
+            ;;
+        --gid)
+            _gids
+            return
+            ;;
     esac
 
     $split && return

--- a/test/t/test_fio.py
+++ b/test/t/test_fio.py
@@ -13,3 +13,8 @@ class TestFio:
     @pytest.mark.complete("fio --debug=foo,")
     def test_3(self, completion):
         assert completion
+
+    @pytest.mark.complete("fio --ioengin", require_cmd=True)
+    def test_cmdhelp_all(self, completion):
+        """Test we got a "known present" option from --cmdhelp=all."""
+        assert completion == "e=" or "e" in completion

--- a/test/t/test_fio.py
+++ b/test/t/test_fio.py
@@ -18,3 +18,8 @@ class TestFio:
     def test_cmdhelp_all(self, completion):
         """Test we got a "known present" option from --cmdhelp=all."""
         assert completion == "e=" or "e" in completion
+
+    @pytest.mark.complete("fio --ioengine=", require_cmd=True)
+    def test_enghelp(self, completion):
+        """Test --enghelp parsing."""
+        assert completion

--- a/test/t/test_fio.py
+++ b/test/t/test_fio.py
@@ -23,3 +23,19 @@ class TestFio:
     def test_enghelp(self, completion):
         """Test --enghelp parsing."""
         assert completion
+
+    @pytest.mark.complete("fio --unlink=", require_cmd=True)
+    def test_cmdhelp_boolean(self, completion):
+        """Test --cmdhelp=COMMAND boolean parsing."""
+        assert completion == "0 1".split()
+
+    @pytest.mark.complete("fio --kb_base=", require_cmd=True)
+    def test_cmdhelp_valid_values(self, completion):
+        """Test --cmdhelp=COMMAND valid values parsing."""
+        # We expect kb_base args to be stable, no additions/removals.
+        assert completion == "1000 1024".split()
+
+    @pytest.mark.complete("fio --non_exist3nt_option=", require_cmd=True)
+    def test_cmdhelp_nonexistent(self, completion):
+        """Test --cmdhelp=COMMAND errors out gracefully."""
+        assert not completion


### PR DESCRIPTION
The majority of options are actually not available from `--help`, but rather `--cmdhelp=all`.

Support some option arguments "natively", some per `--cmdhelp=COMMAND` output, and engines from `--enghelp` output.
