### PR TITLE
feat(help): support options, improve quoting

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -78,9 +78,6 @@ complete -A setopt set
 # shopt completes with shopt options
 complete -A shopt shopt
 
-# helptopics
-complete -A helptopic help
-
 # unalias completes with aliases
 complete -a unalias
 

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -152,6 +152,7 @@ bashcomp_DATA = 2to3 \
 		gzip \
 		hcitool \
 		hddtemp \
+		help \
 		_hexdump \
 		hid2hci \
 		hostname \

--- a/completions/help
+++ b/completions/help
@@ -1,0 +1,17 @@
+# bash completion for help                                 -*- shell-script -*-
+
+_comp_cmd_help()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W '$(_parse_usage "$1" "-s $1")' -- "$cur"))
+        return
+    fi
+
+    local IFS=$'\t\n'
+    COMPREPLY=($(compgen -A helptopic -- "$cur"))
+    ((${#COMPREPLY[*]} != 1)) || printf -v "COMPREPLY[0]" %q "$COMPREPLY"
+}
+complete -F _comp_cmd_help help

--- a/completions/help
+++ b/completions/help
@@ -13,5 +13,5 @@ _comp_cmd_help()
     local IFS=$'\t\n'
     COMPREPLY=($(compgen -A helptopic -- "$cur"))
     ((${#COMPREPLY[*]} != 1)) || printf -v "COMPREPLY[0]" %q "$COMPREPLY"
-}
-complete -F _comp_cmd_help help
+} &&
+    complete -F _comp_cmd_help help

--- a/test/t/Makefile.am
+++ b/test/t/Makefile.am
@@ -225,6 +225,7 @@ EXTRA_DIST = \
 	test_hcitool.py \
 	test_hddtemp.py \
 	test_head.py \
+	test_help.py \
 	test_hexdump.py \
 	test_hid2hci.py \
 	test_host.py \

--- a/test/t/test_help.py
+++ b/test/t/test_help.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+class TestHelp:
+    @pytest.mark.complete("help ")
+    def test_basic(self, completion):
+        assert "help" in completion
+
+    @pytest.mark.complete("help -")
+    def test_options(self, completion):
+        assert completion
+
+    @pytest.mark.complete(r"help \(")
+    def test_parens(self, completion):
+        # Assumption: an item like "(( ... ))" exists in the output
+        assert any(
+            x.startswith(r"\(") and x.endswith(r"\)\)") for x in completion
+        )

--- a/test/t/test_help.py
+++ b/test/t/test_help.py
@@ -10,7 +10,10 @@ class TestHelp:
     def test_options(self, completion):
         assert completion
 
-    @pytest.mark.complete(r"help \(")
+    @pytest.mark.complete(
+        r"help \(",
+        skipif="! compgen -A helptopic | grep -qxF '(( ... ))'",  # bash 4.2
+    )
     def test_parens(self, completion):
         # Assumption: an item like "(( ... ))" exists in the output
         assert any(


### PR DESCRIPTION
The simple `-A helptopic` completion for does not support completion of options, and does not do a too good job with items containing parens, such as `(( ... ))` and `foo ((`.