### PR TITLE
refactor(builtins): parse options from `help -s` output

### DIFF
--- a/completions/bind
+++ b/completions/bind
@@ -25,7 +25,7 @@ _bind()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
         return
     fi
 

--- a/completions/declare
+++ b/completions/declare
@@ -7,7 +7,7 @@ _comp_cmd_declare()
 
     if [[ $cur == [-+]* ]]; then
         local opts
-        opts=($(_parse_usage "$1"))
+        opts=($(_parse_usage help "-s $1"))
         # Most options also have a '+' form.
         # We'll exclude the ones that don't with compgen.
         opts+=(${opts[*]/-/+})

--- a/completions/export
+++ b/completions/export
@@ -48,7 +48,7 @@ _export()
             ;;
         *)
             if [[ $cword -eq 1 && $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '-p $(_parse_usage "$1")' -- "$cur"))
+                COMPREPLY=($(compgen -W '-p $(_parse_usage help "-s $1")' -- "$cur"))
                 return
             fi
             local suffix=""

--- a/completions/pwd
+++ b/completions/pwd
@@ -11,9 +11,7 @@ _pwd()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
-    [[ ${COMPREPLY-} ]] ||
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+    COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
 } &&
     complete -F _pwd pwd
 

--- a/completions/ulimit
+++ b/completions/ulimit
@@ -27,7 +27,7 @@ _ulimit()
         done
 
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+            COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
             return
         fi
     fi


### PR DESCRIPTION
Instead of relying on undocumented `--help` or `--usage` behavior.