### PR TITLE
feat(cd,pushd): add option completion support

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2146,6 +2146,12 @@ _cd()
     local cur prev words cword
     _init_completion || return
 
+    if [[ $cur == -* ]]; then
+        COMPREPLY=($(compgen -W '$(_parse_help help "$1")' -- "$cur"))
+        compopt +o nospace
+        return
+    fi
+
     local IFS=$'\n' i j k
 
     compopt -o filenames

--- a/test/t/test_cd.py
+++ b/test/t/test_cd.py
@@ -24,3 +24,7 @@ class TestCd:
     @pytest.mark.complete("cd shared/default/", trail="foo")
     def test_dir_at_point(self, completion):
         assert completion == ["bar bar.d/", "foo.d/"]
+
+    @pytest.mark.complete("cd -")
+    def test_options(self, completion):
+        assert completion

--- a/test/t/test_pushd.py
+++ b/test/t/test_pushd.py
@@ -5,3 +5,7 @@ class TestPushd:
     @pytest.mark.complete("pushd ")
     def test_1(self, completion):
         assert completion
+
+    @pytest.mark.complete("pushd -")
+    def test_options(self, completion):
+        assert completion


### PR DESCRIPTION
For both of these, `help -s` output is such that `_parse_usage` doesn't do a terribly good job with it. Parse the `help` (no `-s`) output with `_parse_help` instead.