### PR TITLE
test(conftest): merge `assert_complete_at_point` to `assert_complete`

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -828,33 +828,50 @@ def assert_complete(
         for k, v in kwargs.get("shopt", {}).items():
             bash_env.shopt(k, v)
 
-        bash.send(cmd + "\t")
+        input_cmd = cmd
+        rendered_cmd = kwargs.get("rendered_cmd", cmd)
+        re_MAGIC_MARK = re.escape(MAGIC_MARK)
+
+        trail = kwargs.get("trail")
+        if trail:
+            # \002 = ^B = cursor left
+            input_cmd += trail + "\002" * len(trail)
+            rendered_cmd += trail + "\b" * len(trail)
+
+            # After reading the results, something weird happens. For most test
+            # setups, as expected (pun intended!), MAGIC_MARK follows as
+            # is. But for some others (e.g. CentOS 6, Ubuntu 14 test
+            # containers), we get MAGIC_MARK one character a time, followed
+            # each time by trail and the corresponding number of \b's. Don't
+            # know why, but accept it until/if someone finds out.  Or just be
+            # fine with it indefinitely, the visible and practical end result
+            # on a terminal is the same anyway.
+            maybe_trail = "(%s%s)?" % (re.escape(trail), "\b" * len(trail))
+            re_MAGIC_MARK = "".join(
+                re.escape(x) + maybe_trail for x in MAGIC_MARK
+            )
+
+        bash.send(input_cmd + "\t")
         # Sleep a bit if requested, to avoid `.*` matching too early
         time.sleep(kwargs.get("sleep_after_tab", 0))
-        rendered_cmd = kwargs.get("rendered_cmd", cmd)
         bash.expect_exact(rendered_cmd)
         bash.send(MAGIC_MARK)
         got = bash.expect(
             [
                 # 0: multiple lines, result in .before
-                r"\r\n"
-                + re.escape(PS1 + rendered_cmd)
-                + ".*"
-                + re.escape(MAGIC_MARK),
+                r"\r\n" + re.escape(PS1 + rendered_cmd) + ".*" + re_MAGIC_MARK,
                 # 1: no completion
-                r"^" + re.escape(MAGIC_MARK),
+                r"^" + re_MAGIC_MARK,
                 # 2: on same line, result in .match
-                r"^([^\r]+)%s$" % re.escape(MAGIC_MARK),
+                r"^([^\r]+)%s$" % re_MAGIC_MARK,
                 # 3: error messages
-                r"^([^\r].*)%s$" % re.escape(MAGIC_MARK),
+                r"^([^\r].*)%s$" % re_MAGIC_MARK,
                 pexpect.EOF,
                 pexpect.TIMEOUT,
             ]
         )
         if got == 0:
-            output = bash.before
-            if output.endswith(MAGIC_MARK):
-                output = bash.before[: -len(MAGIC_MARK)]
+            output = re.sub(re_MAGIC_MARK + "$", "", bash.before)
             return CompletionResult(output)
         elif got == 2:
             output = bash.match.group(1)
@@ -891,58 +908,7 @@ def completion(request, bash: pexpect.spawn) -> CompletionResult:
     if marker.kwargs.get("require_cmd") and not is_bash_type(bash, cmd):
         pytest.skip("Command not found")
 
-    if "trail" in marker.kwargs:
-        return assert_complete_at_point(
-            bash, cmd=marker.args[0], trail=marker.kwargs["trail"]
-        )
-
     return assert_complete(bash, marker.args[0], **marker.kwargs)
-
-
-def assert_complete_at_point(
-    bash: pexpect.spawn, cmd: str, trail: str
-) -> CompletionResult:
-    # TODO: merge to assert_complete
-    fullcmd = "%s%s%s" % (
-        cmd,
-        trail,
-        "\002" * len(trail),
-    )  # \002 = ^B = cursor left
-    bash.send(fullcmd + "\t")
-    bash.send(MAGIC_MARK)
-    bash.expect_exact(fullcmd.replace("\002", "\b"))
-
-    got = bash.expect_exact(
-        [
-            # 0: multiple lines, result in .before
-            PS1 + fullcmd.replace("\002", "\b"),
-            # 1: no completion
-            MAGIC_MARK,
-            pexpect.EOF,
-            pexpect.TIMEOUT,
-        ]
-    )
-    if got == 0:
-        output = bash.before
-        result = CompletionResult(output)
-
-        # At this point, something weird happens. For most test setups, as
-        # expected (pun intended!), MAGIC_MARK follows as is. But for some
-        # others (e.g. CentOS 6, Ubuntu 14 test containers), we get MAGIC_MARK
-        # one character a time, followed each time by trail and the corresponding
-        # number of \b's. Don't know why, but accept it until/if someone finds out.
-        # Or just be fine with it indefinitely, the visible and practical end
-        # result on a terminal is the same anyway.
-        repeat = "(%s%s)?" % (re.escape(trail), "\b" * len(trail))
-        fullexpected = "".join(
-            "%s%s" % (re.escape(x), repeat) for x in MAGIC_MARK
-        )
-        bash.expect(fullexpected)
-    else:
-        # TODO: warn about EOF/TIMEOUT?
-        result = CompletionResult()
-
-    return result
 
 
 def in_container() -> bool:


### PR DESCRIPTION
`assert_complete_at_point` does not properly clean up the command line. This may cause the failure of subsequent tests. The same cleanups as `assert_complete` should be performed for `assert_complete_at_point`. Instead of repeating the cleanup code in `assert_complete_at_point`, I have merged the special treatment of `assert_complete_at_point` in `assert_complete` as suggested in a `TODO` in the code comment. The *unintended* test failures in #810 and #811 are fixed by this PR.

