### PR TITLE
dpkg: Replace grep|grep|awk with single invocation of awk

### DIFF
--- a/completions/dpkg
+++ b/completions/dpkg
@@ -13,12 +13,18 @@ if _comp_have_command grep-status; then
 else
     _comp_xfunc_dpkg_installed_packages()
     {
-	command awk -F'\n' '-vRS=' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+	command awk -F '\n' -v RS='' "
+		\$1 ~ /Package: $1/ &&
+		\$2 ~ /ok installed|half-installed|unpacked|half-configured|^Essential: yes/
+		{ print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-	command awk awk -F'\n' '-vRS=' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+	command awk -F '\n' -v RS='' "
+		\$1 ~ /Package: $1/ &&
+		\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/
+		{ print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 fi
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -13,18 +13,20 @@ if _comp_have_command grep-status; then
 else
     _comp_xfunc_dpkg_installed_packages()
     {
-	command awk -F '\n' -v RS='' "
-		\$1 ~ /Package: $1/ &&
-		\$2 ~ /ok installed|half-installed|unpacked|half-configured|^Essential: yes/
-		{ print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+        command awk -F '\n' -v RS='' "
+            \$1 ~ /Package: $1/ &&
+            \$2 ~ /ok installed|half-installed|unpacked|half-configured|^Essential: yes/ {
+                print(substr(\$1, 10));
+            }" /var/lib/dpkg/status 2>/dev/null
     }
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-	command awk -F '\n' -v RS='' "
-		\$1 ~ /Package: $1/ &&
-		\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/
-		{ print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+        command awk -F'\n' -vRS='' "
+            \$1 ~ /Package: $1/ &&
+            \$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/ {
+                print(substr(\$1, 10));
+            }" /var/lib/dpkg/status 2>/dev/null
     }
 fi
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -13,20 +13,12 @@ if _comp_have_command grep-status; then
 else
     _comp_xfunc_dpkg_installed_packages()
     {
-        command grep -A 1 "Package: ${1-}" /var/lib/dpkg/status 2>/dev/null |
-            command grep -B 1 -Ee "ok installed|half-installed|unpacked| \
-            half-configured" \
-                -Ee "^Essential: yes" |
-            awk "/Package: ${1-}/ { print \$2 }" 2>/dev/null
+	command awk -F'\n' '-vRS=\n\n' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-        command grep -A 1 "Package: ${1-}" /var/lib/dpkg/status 2>/dev/null |
-            command grep -B 1 -Ee "ok installed|half-installed|unpacked| \
-            half-configured|config-files" \
-                -Ee "^Essential: yes" |
-            awk "/Package: ${1-}/ { print \$2 }" 2>/dev/null
+	command awk awk -F'\n' '-vRS=\n\n' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 fi
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -13,12 +13,12 @@ if _comp_have_command grep-status; then
 else
     _comp_xfunc_dpkg_installed_packages()
     {
-	command awk -F'\n' '-vRS=\n\n' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+	command awk -F'\n' '-vRS=' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-	command awk awk -F'\n' '-vRS=\n\n' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
+	command awk awk -F'\n' '-vRS=' "\$1 ~ /Package: $1/ && (\$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files/ || \$2 ~ /^Essential: yes/) {print(substr(\$1, 10)); }" /var/lib/dpkg/status 2>/dev/null
     }
 fi
 


### PR DESCRIPTION
Instead of piping one grep to another, then piping that to awk, simply make one call to awk with appropriate matching. This makes the completion slightly more efficient (only one process is spawned instead of three), and removes a dependency on GNU grep's non-standard -A and -B options.