### PR TITLE
refactor(dpkg): replace grep|grep|awk with pure awk

### DIFF
--- a/completions/dpkg
+++ b/completions/dpkg
@@ -13,20 +13,20 @@ if _comp_have_command grep-status; then
 else
     _comp_xfunc_dpkg_installed_packages()
     {
-        command grep -A 1 "Package: ${1-}" /var/lib/dpkg/status 2>/dev/null |
-            command grep -B 1 -Ee "ok installed|half-installed|unpacked| \
-            half-configured" \
-                -Ee "^Essential: yes" |
-            awk "/Package: ${1-}/ { print \$2 }" 2>/dev/null
+        command awk -F '\n' -v RS='' "
+            \$1 ~ /Package: $1/ &&
+            \$2 ~ /ok installed|half-installed|unpacked|half-configured|^Essential: yes/ {
+                print(substr(\$1, 10));
+            }" /var/lib/dpkg/status 2>/dev/null
     }
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-        command grep -A 1 "Package: ${1-}" /var/lib/dpkg/status 2>/dev/null |
-            command grep -B 1 -Ee "ok installed|half-installed|unpacked| \
-            half-configured|config-files" \
-                -Ee "^Essential: yes" |
-            awk "/Package: ${1-}/ { print \$2 }" 2>/dev/null
+        command awk -F'\n' -vRS='' "
+            \$1 ~ /Package: $1/ &&
+            \$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/ {
+                print(substr(\$1, 10));
+            }" /var/lib/dpkg/status 2>/dev/null
     }
 fi
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -22,7 +22,7 @@ else
 
     _comp_xfunc_dpkg_purgeable_packages()
     {
-        command awk -F'\n' -vRS='' "
+        command awk -F '\n' -v RS='' "
             index(\$1, \"Package: ${1-}\") == 1 &&
             \$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/ {
                 print(substr(\$1, 10));

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -14,7 +14,7 @@ else
     _comp_xfunc_dpkg_installed_packages()
     {
         command awk -F '\n' -v RS='' "
-            \$1 ~ /Package: $1/ &&
+            index(\$1, \"Package: ${1-}\") == 1 &&
             \$2 ~ /ok installed|half-installed|unpacked|half-configured|^Essential: yes/ {
                 print(substr(\$1, 10));
             }" /var/lib/dpkg/status 2>/dev/null

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -23,7 +23,7 @@ else
     _comp_xfunc_dpkg_purgeable_packages()
     {
         command awk -F'\n' -vRS='' "
-            \$1 ~ /Package: $1/ &&
+            index(\$1, \"Package: ${1-}\") == 1 &&
             \$2 ~ /ok installed|half-installed|unpacked|half-configured|config-files|^Essential: yes/ {
                 print(substr(\$1, 10));
             }" /var/lib/dpkg/status 2>/dev/null


### PR DESCRIPTION
Instead of piping one grep to another, then piping that to awk, simply make one call to awk with appropriate matching. This makes the completion slightly more efficient (only one process is spawned instead of three), and removes a dependency on GNU grep's non-standard -A and -B options.