### PR TITLE
feat(__load_completion): load in-tree before system data dirs

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2587,19 +2587,28 @@ complete -F _minimal ''
 
 __load_completion()
 {
-    local -a dirs=(${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions)
     local IFS=: dir cmd="${1##*/}" compfile
     [[ $cmd ]] || return 1
-    for dir in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do
-        dirs+=($dir/bash-completion/completions)
-    done
-    _comp_unlocal IFS
-
+    # Lookup order:
+    # 1) User installed completions.
+    local -a dirs=(
+        ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
+    )
+    # 2) Completions relative to the main script. This is primarily for
+    # run-in-place-from-git-clone setups, where we want to prefer
+    # in-tree completions over ones possibly coming with a system
+    # installed bash-completion. (Due to usual install layouts, this
+    # often hits the correct completions in system installations, too.)
     if [[ $BASH_SOURCE == */* ]]; then
         dirs+=("${BASH_SOURCE%/*}/completions")
     else
         dirs+=(./completions)
     fi
+    # 3) Completions in the system data dirs.
+    for dir in ${XDG_DATA_DIRS:-/usr/local/share:/usr/share}; do
+        dirs+=($dir/bash-completion/completions)
+    done
+    _comp_unlocal IFS
 
     local backslash=
     if [[ $cmd == \\* ]]; then


### PR DESCRIPTION
This swaps the lookup order of in-tree (relative to the main script) and system data dirs. By checking in-tree completions first, before system data dirs, we support setups running directly from a git clone better, and have a more robust setup in any case.

The main script and in-tree completions should stay in sync. There might for example be internal API changes between releases which wouldn't work if the main `bash_completion` and the set of completions we ship were from different versions, e.g. from git and a release.

Refs https://github.com/scop/bash-completion/discussions/537#discussioncomment-3617912