### PR TITLE
feat: set up drill to be completed by _known_hosts

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2186,7 +2186,7 @@ _known_hosts_real()
 
 } # _known_hosts_real()
 complete -F _known_hosts traceroute traceroute6 \
-    fping fping6 telnet rsh rlogin ftp dig mtr ssh-installkeys showmount
+    fping fping6 telnet rsh rlogin ftp dig drill mtr ssh-installkeys showmount
 
 # This meta-cd function observes the CDPATH variable, so that cd additionally
 # completes on directories under those specified in CDPATH.


### PR DESCRIPTION
Included with the ldns library, the drill tool is similar to dig and is used for DNS lookups. As such, it greatly benefits from host completion.