### PR TITLE
chore(typos): add config, filter out false positives

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,41 @@
+[default.extend-identifiers]
+# https://github.com/crate-ci/typos/issues/436
+BRE = "BRE"
+
+[default.extend-words]
+# completions/ri
+ane = "ane"
+# completions/chage, test/t/Makefile.am, test/t/test_chage.py,
+# test/test-cmd-list.txt
+chage = "chage"
+# test/t/test_ccache.py
+clea = "clea"
+# test/t/test_pylint_3.py
+clien = "clien"
+# completions/openssl
+ede = "ede"
+# completions/make
+fo = "fo"
+# test/t/test_ccache.py
+hel = "hel"
+# completions/ip
+iif = "iif"
+# completions/tcpdump
+inout = "inout"
+# test/t/unit/test_unit_expand_glob.py
+ket = "ket"
+# completions/tshark, test/t/test_screen.py
+nd = "nd"
+# completions/mplayer
+oly = "oly"
+# test/t/unit/test_unit_find_unique_completion_pair.py
+ot = "ot"
+# completions/modinfo
+parm = "parm"
+# completions/wget
+referer = "referer"
+# completions/ps
+ser = "ser"
+
+[files]
+extend-exclude = ["CHANGELOG.md"]


### PR DESCRIPTION
Unfortunately `typos` lacks ability to filter out false positives on per file (or line) basis at the moment, so we end up going global with all exclusions.