### PR TITLE
Add doas to _comp_root_command commands

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2385,7 +2385,7 @@ _comp_root_command()
     _comp_command
 }
 _comp_deprecate_func _root_command _comp_root_command
-complete -F _comp_root_command fakeroot gksu gksudo kdesudo really
+complete -F _comp_root_command doas fakeroot gksu gksudo kdesudo really
 
 # Return true if the completion should be treated as running as root
 _complete_as_root()


### PR DESCRIPTION
Allows correct completions when using 'doas' as a sudo replacement.