### PR TITLE
test: create shadow completions dir for deprecated in-tree completions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,13 @@ repos:
         files: ^test/t/.+\.py$
         pass_filenames: false
 
+      - id: update-test-deprecated-links
+        name: update-test-deprecated-links
+        language: system
+        entry: make -C test/deprecated/completions update
+        files: ^completions/_
+        pass_filenames: false
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,8 @@ repos:
 
       - id: update-test-deprecated-links
         name: update-test-deprecated-links
-        language: system
-        entry: make -C test/deprecated/completions update
+        language: script
+        entry: test/deprecated/update-deprecated-links
         files: ^completions/_
         pass_filenames: false
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,8 @@ completions/Makefile
 doc/Makefile
 helpers/Makefile
 test/Makefile
+test/deprecated/Makefile
+test/deprecated/completions/Makefile
 test/t/Makefile
 test/t/unit/Makefile
 ])

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = t
+SUBDIRS = deprecated t
 
 EXTRA_DIST = config \
 	     fixtures \

--- a/test/config/bashrc
+++ b/test/config/bashrc
@@ -33,12 +33,10 @@ export BASH_COMPLETION_USER_FILE=/dev/null
 # ...and avoid stuff in BASH_COMPLETION_USER_DIR and system install locations
 # overriding in-tree completions. Setting the user dir would otherwise suffice,
 # but simple xspec completions are only installed if a separate one is not
-# found in any completion dirs. Therefore we also point the "system" dirs to
-# locations that should not yield valid completions and helpers paths either.
-export BASH_COMPLETION_USER_DIR=$(
-    cd "$SRCDIR/.." || exit 1
-    pwd
-)
+# found in *any* completion dirs, and we want to use our "shadow" completion
+# dir with which we cause loading of our in-tree deprecated completions
+# instead of possibly (system-)installed upstream ones.
+export BASH_COMPLETION_USER_DIR="$SRCDIRABS/deprecated"
 # /var/empty isn't necessarily actually always empty :P
 export BASH_COMPLETION_COMPAT_DIR=/var/empty/bash_completion.d
 export BASH_COMPLETION_COMPAT_IGNORE='*'

--- a/test/deprecated/Makefile.am
+++ b/test/deprecated/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = completions

--- a/test/deprecated/Makefile.am
+++ b/test/deprecated/Makefile.am
@@ -1,1 +1,7 @@
 SUBDIRS = completions
+
+EXTRA_DIST = \
+	update-deprecated-links
+
+update:
+	./update-deprecated-links

--- a/test/deprecated/completions/Makefile.am
+++ b/test/deprecated/completions/Makefile.am
@@ -1,0 +1,47 @@
+EXTRA_DIST = \
+	adb \
+	cal \
+	chfn \
+	chsh \
+	dmesg \
+	eject \
+	hexdump \
+	hwclock \
+	ionice \
+	look \
+	mock \
+	modules \
+	mount \
+	mount.linux \
+	newgrp \
+	nmcli \
+	op \
+	renice \
+	repomanage \
+	reptyr \
+	rfkill \
+	rtcwake \
+	runuser \
+	slackpkg \
+	su \
+	svn \
+	svnadmin \
+	svnlook \
+	udevadm \
+	umount \
+	umount.linux \
+	write \
+	xm \
+	yum
+
+update:
+	for f in *; do \
+		case $$f in \
+			Makefile*|README.md) ;; \
+			*) git rm -f $$f ;; \
+		esac \
+	done
+	for f in ../../../completions/_*; do \
+		ln -sf $$f $${f##*/_}; \
+		git add $${f##*/_}; \
+	done

--- a/test/deprecated/completions/Makefile.am
+++ b/test/deprecated/completions/Makefile.am
@@ -33,15 +33,3 @@ EXTRA_DIST = \
 	write \
 	xm \
 	yum
-
-update:
-	for f in *; do \
-		case $$f in \
-			Makefile*|README.md) ;; \
-			*) git rm -f $$f ;; \
-		esac \
-	done
-	for f in ../../../completions/_*; do \
-		ln -sf $$f $${f##*/_}; \
-		git add $${f##*/_}; \
-	done

--- a/test/deprecated/completions/README.md
+++ b/test/deprecated/completions/README.md
@@ -1,0 +1,8 @@
+# test/deprecated/completions
+
+This directory should contain a non-underscore prefixed symlink to
+corresponding underscore prefixed, deprecated completions we have in the tree.
+
+The test suite sets up loading of completions so that this dir is preferred
+over system install locations, in order to test our deprecated in-tree
+completions over possibly installed non-deprecated out-of-tree ones.

--- a/test/deprecated/completions/adb
+++ b/test/deprecated/completions/adb
@@ -1,0 +1,1 @@
+../../../completions/_adb

--- a/test/deprecated/completions/cal
+++ b/test/deprecated/completions/cal
@@ -1,0 +1,1 @@
+../../../completions/_cal

--- a/test/deprecated/completions/chfn
+++ b/test/deprecated/completions/chfn
@@ -1,0 +1,1 @@
+../../../completions/_chfn

--- a/test/deprecated/completions/chsh
+++ b/test/deprecated/completions/chsh
@@ -1,0 +1,1 @@
+../../../completions/_chsh

--- a/test/deprecated/completions/dmesg
+++ b/test/deprecated/completions/dmesg
@@ -1,0 +1,1 @@
+../../../completions/_dmesg

--- a/test/deprecated/completions/eject
+++ b/test/deprecated/completions/eject
@@ -1,0 +1,1 @@
+../../../completions/_eject

--- a/test/deprecated/completions/hexdump
+++ b/test/deprecated/completions/hexdump
@@ -1,0 +1,1 @@
+../../../completions/_hexdump

--- a/test/deprecated/completions/hwclock
+++ b/test/deprecated/completions/hwclock
@@ -1,0 +1,1 @@
+../../../completions/_hwclock

--- a/test/deprecated/completions/ionice
+++ b/test/deprecated/completions/ionice
@@ -1,0 +1,1 @@
+../../../completions/_ionice

--- a/test/deprecated/completions/look
+++ b/test/deprecated/completions/look
@@ -1,0 +1,1 @@
+../../../completions/_look

--- a/test/deprecated/completions/mock
+++ b/test/deprecated/completions/mock
@@ -1,0 +1,1 @@
+../../../completions/_mock

--- a/test/deprecated/completions/modules
+++ b/test/deprecated/completions/modules
@@ -1,0 +1,1 @@
+../../../completions/_modules

--- a/test/deprecated/completions/mount
+++ b/test/deprecated/completions/mount
@@ -1,0 +1,1 @@
+../../../completions/_mount

--- a/test/deprecated/completions/mount.linux
+++ b/test/deprecated/completions/mount.linux
@@ -1,0 +1,1 @@
+../../../completions/_mount.linux

--- a/test/deprecated/completions/newgrp
+++ b/test/deprecated/completions/newgrp
@@ -1,0 +1,1 @@
+../../../completions/_newgrp

--- a/test/deprecated/completions/nmcli
+++ b/test/deprecated/completions/nmcli
@@ -1,0 +1,1 @@
+../../../completions/_nmcli

--- a/test/deprecated/completions/op
+++ b/test/deprecated/completions/op
@@ -1,0 +1,1 @@
+../../../completions/_op

--- a/test/deprecated/completions/renice
+++ b/test/deprecated/completions/renice
@@ -1,0 +1,1 @@
+../../../completions/_renice

--- a/test/deprecated/completions/repomanage
+++ b/test/deprecated/completions/repomanage
@@ -1,0 +1,1 @@
+../../../completions/_repomanage

--- a/test/deprecated/completions/reptyr
+++ b/test/deprecated/completions/reptyr
@@ -1,0 +1,1 @@
+../../../completions/_reptyr

--- a/test/deprecated/completions/rfkill
+++ b/test/deprecated/completions/rfkill
@@ -1,0 +1,1 @@
+../../../completions/_rfkill

--- a/test/deprecated/completions/rtcwake
+++ b/test/deprecated/completions/rtcwake
@@ -1,0 +1,1 @@
+../../../completions/_rtcwake

--- a/test/deprecated/completions/runuser
+++ b/test/deprecated/completions/runuser
@@ -1,0 +1,1 @@
+../../../completions/_runuser

--- a/test/deprecated/completions/slackpkg
+++ b/test/deprecated/completions/slackpkg
@@ -1,0 +1,1 @@
+../../../completions/_slackpkg

--- a/test/deprecated/completions/su
+++ b/test/deprecated/completions/su
@@ -1,0 +1,1 @@
+../../../completions/_su

--- a/test/deprecated/completions/svn
+++ b/test/deprecated/completions/svn
@@ -1,0 +1,1 @@
+../../../completions/_svn

--- a/test/deprecated/completions/svnadmin
+++ b/test/deprecated/completions/svnadmin
@@ -1,0 +1,1 @@
+../../../completions/_svnadmin

--- a/test/deprecated/completions/svnlook
+++ b/test/deprecated/completions/svnlook
@@ -1,0 +1,1 @@
+../../../completions/_svnlook

--- a/test/deprecated/completions/udevadm
+++ b/test/deprecated/completions/udevadm
@@ -1,0 +1,1 @@
+../../../completions/_udevadm

--- a/test/deprecated/completions/umount
+++ b/test/deprecated/completions/umount
@@ -1,0 +1,1 @@
+../../../completions/_umount

--- a/test/deprecated/completions/umount.linux
+++ b/test/deprecated/completions/umount.linux
@@ -1,0 +1,1 @@
+../../../completions/_umount.linux

--- a/test/deprecated/completions/write
+++ b/test/deprecated/completions/write
@@ -1,0 +1,1 @@
+../../../completions/_write

--- a/test/deprecated/completions/xm
+++ b/test/deprecated/completions/xm
@@ -1,0 +1,1 @@
+../../../completions/_xm

--- a/test/deprecated/completions/yum
+++ b/test/deprecated/completions/yum
@@ -1,0 +1,1 @@
+../../../completions/_yum

--- a/test/deprecated/update-deprecated-links
+++ b/test/deprecated/update-deprecated-links
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/completions"
+for f in *; do
+    case $f in
+        Makefile* | README.md) ;;
+        *) git rm -f $f ;;
+    esac
+done
+for f in ../../../completions/_*; do
+    ln -sf $f ${f##*/_}
+    git add --verbose ${f##*/_}
+done


### PR DESCRIPTION
We want to test our deprecated completions instead of possibly non-deprecated out of tree ones installed in system dirs.

Create a dir for them, symlink all of them without the underscore deprecation marker there, and inject the dir to the test suite's load path.

Closes https://github.com/scop/bash-completion/issues/836