### PR TITLE
feat(reportbug): parse various option args from option help

### DIFF
--- a/completions/reportbug
+++ b/completions/reportbug
@@ -27,39 +27,17 @@ _reportbug()
                 done)' -- "$cur"))
             return
             ;;
-        --bts | -!(-*)B)
-            COMPREPLY=($(compgen -W "debian guug kde mandrake help" -- \
-                "$cur"))
+        --tag | --ui | --interface | --type | --bts | --severity | --mode | -!(-*)[TutBS])
+            COMPREPLY+=($(
+                compgen -W \
+                    '$("$1" $prev help 2>&1 | sed -ne /^[[:space:]]/p)' \
+                    -- "$cur"
+            ))
             return
             ;;
         --editor | --mua | --mbox-reader-cmd | -!(-*)e)
             compopt -o filenames
             COMPREPLY=($(compgen -c -- "$cur"))
-            return
-            ;;
-        --mode)
-            COMPREPLY=($(compgen -W "novice standard expert" -- "$cur"))
-            return
-            ;;
-        --severity | -!(-*)S)
-            COMPREPLY=($(compgen -W "grave serious important normal minor
-                wishlist" -- "$cur"))
-            return
-            ;;
-        --ui | --interface | -!(-*)u)
-            COMPREPLY=($(compgen -W "newt text gnome" -- "$cur"))
-            return
-            ;;
-        --type | -!(-*)t)
-            COMPREPLY=($(compgen -W "gnats debbugs" -- "$cur"))
-            return
-            ;;
-        --tag | -!(-*)T)
-            COMPREPLY=($(compgen -W "none woody potato sarge sarge-ignore
-                etch etch-ignore lenny lenny-ignore sid experimental confirmed
-                d-i fixed fixed-in-experimental fixed-upstream help l10n
-                moreinfo patch pending security unreproducible upstream wontfix
-                ipv6 lfs" -- "$cur"))
             return
             ;;
         --from-buildd)

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -30,7 +30,7 @@ _reportbug()
         --tag | --ui | --interface | --type | --bts | --severity | --mode | -!(-*)[TutBS])
             COMPREPLY+=($(
                 compgen -W \
-                    '$("$1" $prev help 2>&1 | sed -ne /^[[:space:]]/p)' \
+                    '$("$1" $prev help 2>&1 </dev/null | sed -ne "/^[[:space:]]/p")' \
                     -- "$cur"
             ))
             return

--- a/test/t/test_reportbug.py
+++ b/test/t/test_reportbug.py
@@ -5,3 +5,7 @@ class TestReportbug:
     @pytest.mark.complete("reportbug --m", require_cmd=True)
     def test_1(self, completion):
         assert completion
+
+    @pytest.mark.complete("reportbug --bts=", require_cmd=True)
+    def test_bts(self, completion):
+        assert "default" in completion


### PR DESCRIPTION
Closes https://github.com/scop/bash-completion/pull/753

It's unfortunate that the help output goes to stderr, but I suppose this is good enough.