### PR TITLE
fix(xdg-mime): mime type array index expansion

### DIFF
--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -9,7 +9,7 @@ _xdg_mime_mimetype()
             command cd "$d" 2>/dev/null || exit 1
             compgen -f -o plusdirs -X "!*.xml" -- "$cur"
         )) || continue
-        for i in "${!arr[*]}"; do
+        for i in "${!arr[@]}"; do
             case ${arr[i]} in
                 packages*) unset -v "arr[i]" ;; # not a MIME type dir
                 *.xml) arr[i]=${arr[i]%.xml} ;;


### PR DESCRIPTION
Broken by https://github.com/scop/bash-completion/pull/827#discussion_r1031166072