### PR TITLE
fix(_comp_command_offset): fix offset mismatching for words vs COMP_WORDS (use words)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2353,6 +2353,12 @@ _comp_command_offset()
 #
 _comp_command()
 {
+    # We unset the shell variable `words` locally to tell
+    # `_comp_command_offset` that the index is intended to be that in
+    # `COMP_WORDS` instead of `words`.
+    local words
+    unset -v words
+
     local offset i
 
     # find actual offset, as position of the first non-option

--- a/bash_completion
+++ b/bash_completion
@@ -2206,6 +2206,30 @@ _known_hosts_real()
 complete -F _known_hosts traceroute traceroute6 \
     fping fping6 telnet rsh rlogin ftp dig drill mtr ssh-installkeys showmount
 
+# Convert the word index in `words` to the index in `COMP_WORDS`.
+# @param $1           Index in the array WORDS.
+# @var[in,opt] words  Words that contain reassmbled words.
+# @var[in,opt] cword  Current word index in WORDS.
+#                     WORDS and CWORD, if any, are expected to be created by
+#                     _comp__reassemble_words.
+#
+_comp__find_original_word()
+{
+    ret=$1
+
+    # If CWORD or WORDS are undefined, we return the first argument without any
+    # processing.
+    [[ -v cword && -v words ]] || return 0
+
+    local reassembled_offset=$1 i=0 j
+    for ((j = 0; j < reassembled_offset; j++)); do
+        local word=${words[j]}
+        while [[ $word && i -lt ${#COMP_WORDS[@]} && $word == *"${COMP_WORDS[i]}"* ]]; do
+            word=${word#*"${COMP_WORDS[i++]}"}
+        done
+    done
+    ret=$i
+}
 # A meta-command completion function for commands like sudo(8), which need to
 # first complete on a command, then complete according to that command's own
 # completion definition.
@@ -2214,6 +2238,11 @@ _comp_command_offset()
 {
     # rewrite current completion context before invoking
     # actual command completion
+
+    # obtain the word index in COMP_WORDS
+    local ret
+    _comp__find_original_word "$1"
+    local word_offset=$ret
 
     # make changes to COMP_* local.  Note that bash-4.3..5.0 have a
     # bug that `local -a arr=("${arr[@]}")` fails.  We instead first
@@ -2224,7 +2253,7 @@ _comp_command_offset()
 
     # find new first word position, then
     # rewrite COMP_LINE and adjust COMP_POINT
-    local word_offset=$1 i tail
+    local i tail
     for ((i = 0; i < word_offset; i++)); do
         tail=${COMP_LINE#*"${COMP_WORDS[i]}"}
         ((COMP_POINT -= ${#COMP_LINE} - ${#tail}))
@@ -2244,7 +2273,6 @@ _comp_command_offset()
         compopt -o filenames
         _comp_compgen COMPREPLY -d -c -- "$cur"
     else
-        local ret
         _comp_dequote "${COMP_WORDS[0]}" || ret=${COMP_WORDS[0]}
         local cmd=$ret compcmd=$ret
         local cspec=$(complete -p "$cmd" 2>/dev/null)

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -245,4 +245,17 @@ _cd()
     _comp_cmd_cd "$@"
 }
 
+# @deprecated Use `_comp_command_offset` instead.  Note that the new interface
+# `_comp_command_offset` is changed to receive an index in `words` instead of
+# that in `COMP_WORDS` as `_command_offset` did.
+_command_offset()
+{
+    # We unset the shell variable `words` locally to tell
+    # `_comp_command_offset` that the index is intended to be that in
+    # `COMP_WORDS` instead of `words`.
+    local words
+    unset -v words
+    _comp_command_offset "$@"
+}
+
 # ex: filetype=sh

--- a/completions/ccache
+++ b/completions/ccache
@@ -6,12 +6,12 @@ _comp_cmd_ccache()
     _comp_initialize -s -- "$@" || return
 
     local i
-    for ((i = 1; i <= COMP_CWORD; i++)); do
-        if [[ ${COMP_WORDS[i]} != -* ]]; then
+    for ((i = 1; i <= cword; i++)); do
+        if [[ ${words[i]} != -* ]]; then
             _comp_command_offset $i
             return
         fi
-        [[ ${COMP_WORDS[i]} == -*[oFM] ]] && ((i++))
+        [[ ${words[i]} == -*[oFM] ]] && ((i++))
     done
 
     local noargopts='!(-*|*[FMo]*)'

--- a/completions/find
+++ b/completions/find
@@ -8,9 +8,8 @@ _comp_cmd_find()
     _comp_initialize -- "$@" || return
 
     local i
-    for i in ${!words[*]}; do
+    for ((i = 1; i < cword; i++)); do
         if [[ ${words[i]} == -@(exec|ok)?(dir) ]]; then
-            ((cword > i)) || break
             _comp_command_offset $((i + 1))
             return
         fi

--- a/completions/timeout
+++ b/completions/timeout
@@ -6,8 +6,8 @@ _comp_cmd_timeout()
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[ks]*)'
-    for ((i = 1; i <= COMP_CWORD; i++)); do
-        if [[ ${COMP_WORDS[i]} != -* && ${COMP_WORDS[i - 1]} != = ]]; then
+    for ((i = 1; i <= cword; i++)); do
+        if [[ ${words[i]} != -* ]]; then
             if [[ $found ]]; then
                 _comp_command_offset $i
                 return
@@ -15,7 +15,7 @@ _comp_cmd_timeout()
             found=set
         fi
         # shellcheck disable=SC2254
-        [[ ${COMP_WORDS[i]} == -@(-kill-after|-signal|${noargopts}[ks]) ]] && ((i++))
+        [[ ${words[i]} == -@(-kill-after|-signal|${noargopts}[ks]) ]] && ((i++))
     done
 
     # shellcheck disable=SC2254

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -6,11 +6,8 @@ _comp_cmd_valgrind()
     _comp_initialize -s -- "$@" || return
 
     local i
-    # Note: intentionally using COMP_WORDS and COMP_CWORD instead of
-    # words and cword here due to splitting on = causing index differences
-    # (_comp_command_offset assumes the former).
-    for ((i = 1; i <= COMP_CWORD; i++)); do
-        if [[ ${COMP_WORDS[i]} != @([-=])* && ${COMP_WORDS[i - 1]} != = ]]; then
+    for ((i = 1; i <= cword; i++)); do
+        if [[ ${words[i]} != @([-=])* ]]; then
             _comp_command_offset $i
             return
         fi

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -7,13 +7,13 @@ _comp_cmd_xvfb_run()
 
     local noargopts='!(-*|*[npsef]*)'
     local i
-    for ((i = 1; i <= COMP_CWORD; i++)); do
-        if [[ ${COMP_WORDS[i]} != -* ]]; then
+    for ((i = 1; i <= cword; i++)); do
+        if [[ ${words[i]} != -* ]]; then
             _comp_command_offset $i
             return
         fi
         # shellcheck disable=SC2254
-        [[ ${COMP_WORDS[i]} == -${noargopts}[npsef] ]] && ((i++))
+        [[ ${words[i]} == -${noargopts}[npsef] ]] && ((i++))
     done
 
     # shellcheck disable=SC2254


### PR DESCRIPTION
Fixes #722.

This fixes it the other way around as #802. Now `_comp_command_offset` receives the index in `words` instead of that in `COMP_WORDS`.