### PR TITLE
fix(completions/*): skip `prev` of the form `-oOPTARG`

### DIFF
--- a/completions/a2x
+++ b/completions/a2x
@@ -5,16 +5,18 @@ _a2x()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[aDd]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --attribute | --asciidoc-opts | --dblatex-opts | --fop-opts | --help | \
-            --version | --xsltproc-opts | -!(-*)[ah])
+            --version | --xsltproc-opts | -${noargopts}[ah])
             return
             ;;
-        --destination-dir | --icons-dir | -!(-*)D)
+        --destination-dir | --icons-dir | -${noargopts}D)
             _filedir -d
             return
             ;;
-        --doctype | -!(-*)d)
+        --doctype | -${noargopts}d)
             _comp_xfunc asciidoc doctype
             return
             ;;

--- a/completions/acpi
+++ b/completions/acpi
@@ -5,11 +5,13 @@ _acpi()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[d]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hv])
+        --help | --version | -${noargopts}[hv])
             return
             ;;
-        --directory | -!(-*)d)
+        --directory | -${noargopts}d)
             _filedir -d
             return
             ;;

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -56,8 +56,10 @@ _apt_cache()
         return
     fi
 
+    local noargopts='!(-*|*[cps]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --config-file | --pkg-cache | --src-cache | -!(-*)[cps])
+        --config-file | --pkg-cache | --src-cache | -${noargopts}[cps])
             _filedir
             return
             ;;

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -67,15 +67,17 @@ _apt_get()
         return
     fi
 
+    local noargopts='!(-*|*[eoct]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --error-on | --help | --version | --option | -!(-*)[ehvo])
+        --error-on | --help | --version | --option | -${noargopts}[ehvo])
             return
             ;;
-        --config-file | -!(-*)c)
+        --config-file | -${noargopts}c)
             _filedir
             return
             ;;
-        --target-release | --default-release | -!(-*)t)
+        --target-release | --default-release | -${noargopts}t)
             COMPREPLY=($(compgen -W "$(apt-cache policy | command sed -ne \
                 's/^ *release.*[ ,]o=\(Debian\|Ubuntu\),a=\(\w*\).*/\2/p')" \
                 -- "$cur"))

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -33,15 +33,17 @@ _comp_cmd_apt_mark()
         return
     fi
 
+    local noargopts='!(-*|*[ocf]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --option | -!(-*)[hvo])
+        --help | --version | --option | -${noargopts}[hvo])
             return
             ;;
-        --config-file | -!(-*)c)
+        --config-file | -${noargopts}c)
             _filedir conf
             return
             ;;
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir
             return
             ;;

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -46,24 +46,26 @@ _aptitude()
         esac
     fi
 
+    local noargopts='!(-*|*[SwFoOt]*)'
+    # shellcheck disable=SC2254
     case $prev in
         # don't complete anything if these options are found
         autoclean | clean | forget-new | search | upgrade | update | keep-all)
             return
             ;;
-        -!(-*)S)
+        -${noargopts}S)
             _filedir
             return
             ;;
-        --display-format | --width | -!(-*)[wFo])
+        --display-format | --width | -${noargopts}[wFo])
             return
             ;;
-        --sort | -!(-*)O)
+        --sort | -${noargopts}O)
             COMPREPLY=($(compgen -W 'installsize installsizechange debsize
                 name priority version' -- "$cur"))
             return
             ;;
-        --target-release | --default-release | -!(-*)t)
+        --target-release | --default-release | -${noargopts}t)
             COMPREPLY=($(apt-cache policy |
                 command grep "release.o=Debian,a=$cur" |
                 command sed -e "s/.*a=\(\w*\).*/\1/" | uniq 2>/dev/null))

--- a/completions/arp
+++ b/completions/arp
@@ -5,20 +5,22 @@ _arp()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[iApfHt]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --device | -!(-*)i)
+        --device | -${noargopts}i)
             _available_interfaces -a
             return
             ;;
-        --protocol | -!(-*)[Ap])
+        --protocol | -${noargopts}[Ap])
             # TODO protocol/address family
             return
             ;;
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir
             return
             ;;
-        --hw-type | -!(-*)[Ht])
+        --hw-type | -${noargopts}[Ht])
             # TODO: parse from --help output?
             COMPREPLY=($(compgen -W 'ash ether ax25 netrom rose arcnet \
                 dlci fddi hippi irda x25 eui64' -- "$cur"))
@@ -34,7 +36,7 @@ _arp()
     fi
 
     local args
-    _count_args "" "@(--device|--protocol|--file|--hw-type|-!(-*)[iApfHt])"
+    _count_args "" "@(--device|--protocol|--file|--hw-type|-${noargopts}[iApfHt])"
     case $args in
         1)
             local ips=$("$1" -an | command sed -ne \

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -12,27 +12,29 @@ _asciidoc()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[abfdo]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --attribute | -!(-*)a)
+        --attribute | -${noargopts}a)
             return
             ;;
-        --backend | -!(-*)b)
+        --backend | -${noargopts}b)
             COMPREPLY=($(compgen -W 'docbook html4 xhtml11' -- "$cur"))
             return
             ;;
-        --conf-file | -!(-*)f)
+        --conf-file | -${noargopts}f)
             _filedir conf
             return
             ;;
-        --doctype | -!(-*)d)
+        --doctype | -${noargopts}d)
             _comp_xfunc_asciidoc_doctype
             return
             ;;
-        --help | -!(-*)h)
+        --help | -${noargopts}h)
             COMPREPLY=($(compgen -W 'manpage syntax topics' -- "$cur"))
             return
             ;;
-        --out-file | -!(-*)o)
+        --out-file | -${noargopts}o)
             _filedir
             return
             ;;

--- a/completions/autoscan
+++ b/completions/autoscan
@@ -5,11 +5,13 @@ _autoscan()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[BI]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
-        --prepend-include | --include | -!(-*)[BI])
+        --prepend-include | --include | -${noargopts}[BI])
             _filedir -d
             return
             ;;

--- a/completions/avahi-browse
+++ b/completions/avahi-browse
@@ -5,11 +5,13 @@ _comp_cmd_avahi_browse()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[D]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --domain | -!(-*)D)
+        --domain | -${noargopts}D)
             return
             ;;
-        --help | --version | -!(-*)[hV]*)
+        --help | --version | -${noargopts}[hV]*)
             return
             ;;
     esac
@@ -27,7 +29,7 @@ _comp_cmd_avahi_browse()
     local word
     for word in "${words[@]}"; do
         case $word in
-            --all | --browse-domains | --dump-db | -!(-*)[aDb]*)
+            --all | --browse-domains | --dump-db | -${noargopts}[aDb]*)
                 return
                 ;;
         esac

--- a/completions/bzip2
+++ b/completions/bzip2
@@ -5,11 +5,13 @@ _bzip2()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[bpn]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | -!(-*)[bhp])
+        --help | -${noargopts}[bhp])
             return
             ;;
-        -!(-*)n)
+        -${noargopts}n)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)}" -- "$cur"))
             return
             ;;

--- a/completions/ccache
+++ b/completions/ccache
@@ -14,11 +14,13 @@ _ccache()
         [[ ${COMP_WORDS[i]} == -*[oFM] ]] && ((i++))
     done
 
+    local noargopts='!(-*|*[FMo]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --max-files | --max-size | -!(-*)[hVFM])
+        --help | --version | --max-files | --max-size | -${noargopts}[hVFM])
             return
             ;;
-        --set-config | -!(-*)o)
+        --set-config | -${noargopts}o)
             if [[ $cur != *=* ]]; then
                 COMPREPLY=($(compgen -S = -W "$($1 -p 2>/dev/null |
                     awk '$3 = "=" { print $2 }')" -- "$cur"))

--- a/completions/ccze
+++ b/completions/ccze
@@ -5,28 +5,30 @@ _ccze()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[acFmop]*)'
+    # shellcheck disable=SC2254
     case $prev in
         -'?' | --help | --usage | -V | --version)
             return
             ;;
-        --argument | --color | -!(-*)[ac])
+        --argument | --color | -${noargopts}[ac])
             # TODO?
             return
             ;;
-        --rcfile | -!(-*)F)
+        --rcfile | -${noargopts}F)
             _filedir
             return
             ;;
-        --mode | -!(-*)m)
+        --mode | -${noargopts}m)
             COMPREPLY=($(compgen -W "curses ansi html" -- "$cur"))
             return
             ;;
-        --option | -!(-*)o)
+        --option | -${noargopts}o)
             local -a opts=(scroll wordcolor lookups transparent cssfile)
             COMPREPLY=($(compgen -W '${opts[@]} ${opts[@]/#/no}' -- "$cur"))
             return
             ;;
-        --plugin | -!(-*)p)
+        --plugin | -${noargopts}p)
             COMPREPLY=($(compgen -W '$("$1" --list-plugins | command \
                 sed -ne "s/^\([a-z0-9]\{1,\}\)[[:space:]]\{1,\}|.*/\1/p")' \
                 -- "$cur"))

--- a/completions/chage
+++ b/completions/chage
@@ -5,12 +5,14 @@ _chage()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[dEImMWR]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --lastday | --expiredate | --help | --inactive | --mindays | --maxdays | \
-            --warndays | -!(-*)[dEhImMW])
+            --warndays | -${noargopts}[dEhImMW])
             return
             ;;
-        --root | -!(-*)R)
+        --root | -${noargopts}R)
             _filedir -d
             return
             ;;

--- a/completions/chpasswd
+++ b/completions/chpasswd
@@ -5,16 +5,18 @@ _chpasswd()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[csR]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --crypt | -!(-*)c)
+        --crypt | -${noargopts}c)
             COMPREPLY=($(compgen -W 'DES MD5 NONE SHA256 SHA512' \
                 -- "$cur"))
             return
             ;;
-        --sha-rounds | -!(-*)s)
+        --sha-rounds | -${noargopts}s)
             return
             ;;
-        --root | -!(-*)R)
+        --root | -${noargopts}R)
             _filedir -d
             return
             ;;

--- a/completions/chrpath
+++ b/completions/chrpath
@@ -5,11 +5,13 @@ _chrpath()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[r]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --version | --help | -!(-*)[vh])
+        --version | --help | -${noargopts}[vh])
             return
             ;;
-        --replace | -!(-*)r)
+        --replace | -${noargopts}r)
             _filedir -d
             return
             ;;

--- a/completions/cpio
+++ b/completions/cpio
@@ -6,17 +6,19 @@ _cpio()
     _comp_initialize -s -n : -- "$@" || return
 
     # --name value style option
+    local noargopts='!(-*|*[HEFIR]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --format | -!(-*)H)
+        --format | -${noargopts}H)
             COMPREPLY=($(compgen -W \
                 'bin odc newc crc tar ustar hpbin hpodc' -- "$cur"))
             return
             ;;
-        --file | --pattern-file | -!(-*)[EFI])
+        --file | --pattern-file | -${noargopts}[EFI])
             _filedir
             return
             ;;
-        --owner | -!(-*)R)
+        --owner | -${noargopts}R)
             _usergroup
             return
             ;;

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -16,16 +16,18 @@ _cryptsetup()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[cslSbopitTdM]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --cipher | --hash | --*-size | --key-slot | --size | --offset | \
-            --skip | --iter-time | --timeout | --tries | -!(-*)[chslSbopitT])
+            --skip | --iter-time | --timeout | --tries | -${noargopts}[chslSbopitT])
             return
             ;;
-        --key-file | --master-key-file | --header-backup-file | -!(-*)d)
+        --key-file | --master-key-file | --header-backup-file | -${noargopts}d)
             _filedir
             return
             ;;
-        --type | -!(-*)M)
+        --type | -${noargopts}M)
             COMPREPLY=($(compgen -W "luks plain loopaes tcrypt" -- "$cur"))
             return
             ;;
@@ -47,7 +49,7 @@ _cryptsetup()
         fi
     else
         local args
-        _count_args "" "-!(-*)[chslSbopitTdM]"
+        _count_args "" "-${noargopts}[chslSbopitTdM]"
         case $arg in
             open | create | luksOpen | loopaesOpen | tcryptOpen)
                 case $args in

--- a/completions/curl
+++ b/completions/curl
@@ -5,12 +5,14 @@ _curl()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[KbcDoTCFmQreYytzuAwEdHPxX]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --abstract-unix-socket | --alt-svc | --config | --cookie | \
             --cookie-jar | --dump-header | --egd-file | --etag-compare | \
             --etag-save | --hsts | --key | --libcurl | --netrc-file | \
             --output | --proxy-key | --random-file | --trace | --trace-ascii | \
-            --unix-socket | --upload-file | -!(-*)[KbcDoT])
+            --unix-socket | --upload-file | -${noargopts}[KbcDoT])
             _filedir
             return
             ;;
@@ -29,10 +31,10 @@ _curl()
             --speed-limit | --speed-time | --telnet-option | --tftp-blksize | \
             --time-cond | --tls13-ciphers | --tlspassword | --tlsuser | \
             --url | --user | --user-agent | --version | --write-out | \
-            -!(-*)[CFmQreYytzuAVw])
+            -${noargopts}[CFmQreYytzuAVw])
             return
             ;;
-        --cacert | --cert | --proxy-cacert | --proxy-cert | -!(-*)E)
+        --cacert | --cert | --proxy-cacert | --proxy-cert | -${noargopts}E)
             _filedir '@(c?(e)rt|cer|pem|der)'
             return
             ;;
@@ -49,7 +51,7 @@ _curl()
             return
             ;;
         --data | --data-ascii | --data-binary | --data-urlencode | --header | \
-            --proxy-header | -!(-*)[dH])
+            --proxy-header | -${noargopts}[dH])
             if [[ $cur == \@* ]]; then
                 cur=${cur:1}
                 _filedir
@@ -83,7 +85,7 @@ _curl()
             COMPREPLY=($(compgen -W '$engines list' -- "$cur"))
             return
             ;;
-        --ftp-port | -!(-*)P)
+        --ftp-port | -${noargopts}P)
             _available_interfaces -a
             _known_hosts_real -- "$cur"
             _ip_addresses -a
@@ -101,7 +103,7 @@ _curl()
             _available_interfaces -a
             return
             ;;
-        --help | -!(-*)h)
+        --help | -${noargopts}h)
             local x categories=(
                 $("$1" --help non-existent-category 2>&1 |
                     awk '/^[[:space:]]/ {print $1}')
@@ -124,7 +126,7 @@ _curl()
             return
             ;;
         --preproxy | --proxy | --socks4 | --socks4a | --socks5 | \
-            --socks5-hostname | -!(-*)x)
+            --socks5-hostname | -${noargopts}x)
             _known_hosts_real -- "$cur"
             return
             ;;
@@ -132,7 +134,7 @@ _curl()
             _comp_xfunc ssh identityfile pub
             return
             ;;
-        --request | -!(-*)X)
+        --request | -${noargopts}X)
             # TODO: these are valid for http(s) only
             COMPREPLY=($(
                 compgen -W \

--- a/completions/cvs
+++ b/completions/cvs
@@ -55,6 +55,7 @@ _cvs()
     local count mode i cvsroot cvsroots pwd
     local -a flags files entries changed newremoved
 
+    local noargopts='!(-*|*[d]*)'
     count=0
     for i in "${words[@]}"; do
         ((count == cword)) && break
@@ -63,12 +64,13 @@ _cvs()
             mode=""
         fi
         if [[ ! -v mode ]]; then
+            # shellcheck disable=SC2254
             case $i in
-                --help | -!(-*)H)
+                --help | -${noargopts}H)
                     COMPREPLY=($(compgen -W "$(_cvs_commands)" -- "$cur"))
                     return
                     ;;
-                -!(-*)d)
+                -${noargopts}d)
                     mode=cvsroot
                     cvsroot=${words[count + 1]}
                     ;;

--- a/completions/dict
+++ b/completions/dict
@@ -13,17 +13,19 @@ _dict()
 
     local host port db i
 
+    local noargopts='!(-*|*[hpdis]*)'
     for ((i = 1; i < cword; i++)); do
+        # shellcheck disable=SC2254
         case ${words[i]} in
-            --host | -!(-*)h)
+            --host | -${noargopts}h)
                 host=${words[++i]}
                 [[ $host ]] && host="-h $host"
                 ;;
-            --port | -!(-*)p)
+            --port | -${noargopts}p)
                 port=${words[++i]}
                 [[ $port ]] && port="-p $port"
                 ;;
-            --database | -!(-*)d)
+            --database | -${noargopts}d)
                 db=${words[++i]}
                 [[ $db ]] && host="-d $db"
                 ;;
@@ -35,12 +37,13 @@ _dict()
         return
     fi
 
+    # shellcheck disable=SC2254
     case $prev in
-        --database | -info | -!(-*)[di])
+        --database | -info | -${noargopts}[di])
             COMPREPLY=($(compgen -W '$(_dictdata -D)' -- "$cur"))
             return
             ;;
-        --strategy | -!(-*)s)
+        --strategy | -${noargopts}s)
             COMPREPLY=($(compgen -W '$(_dictdata -S)' -- "$cur"))
             return
             ;;

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -49,21 +49,23 @@ _dpkg()
         done
     fi
 
+    local noargopts='!(-*|*[ciAIfexXbsplWSrVLPD]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --install | --unpack | --record-avail | --contents | --info | --fsys-tarfile | \
-            --field | --control | --extract | --vextract | --raw-extract | -!(-*)[ciAIfexX])
+            --field | --control | --extract | --vextract | --raw-extract | -${noargopts}[ciAIfexX])
             _filedir '?(u|d)deb'
             return
             ;;
-        --build | --admindir | --instdir | --root | -!(-*)b)
+        --build | --admindir | --instdir | --root | -${noargopts}b)
             _filedir -d
             return
             ;;
-        --status | --print-avail | --list | -!(-*)[spl])
+        --status | --print-avail | --list | -${noargopts}[spl])
             COMPREPLY=($(_comp_xfunc apt-cache packages))
             return
             ;;
-        --show | -!(-*)W)
+        --show | -${noargopts}W)
             if [[ $1 == *dpkg-query ]]; then
                 COMPREPLY=($(_comp_xfunc apt-cache packages))
             else
@@ -71,19 +73,19 @@ _dpkg()
             fi
             return
             ;;
-        --search | -!(-*)S)
+        --search | -${noargopts}S)
             _filedir
             return
             ;;
-        --remove | --verify | -!(-*)[rV])
+        --remove | --verify | -${noargopts}[rV])
             COMPREPLY=($(_comp_xfunc_dpkg_installed_packages "$cur"))
             return
             ;;
-        --listfiles | --purge | -!(-*)[LP])
+        --listfiles | --purge | -${noargopts}[LP])
             COMPREPLY=($(_comp_xfunc_dpkg_purgeable_packages "$cur"))
             return
             ;;
-        --debug | -!(-*)D)
+        --debug | -${noargopts}D)
             COMPREPLY=($(compgen -W 'help' -- "$cur"))
             return
             ;;
@@ -131,8 +133,10 @@ _dpkg_reconfigure()
 
     local opt
 
+    local noargopts='!(-*|*[fp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --frontend | -!(-*)f)
+        --frontend | -${noargopts}f)
             _comp_expand_glob opt '/usr/share/perl5/Debconf/FrontEnd/*'
             if ((${#opt[@]})); then
                 opt=(${opt[@]##*/})
@@ -141,7 +145,7 @@ _dpkg_reconfigure()
             fi
             return
             ;;
-        --priority | -!(-*)p)
+        --priority | -${noargopts}p)
             COMPREPLY=($(compgen -W 'low medium high critical' -- "$cur"))
             return
             ;;

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -11,15 +11,17 @@ _ebtables()
     [[ ${words[*]} =~ [[:space:]]-(t|-table=?)[[:space:]]*([^[:space:]]+) ]] &&
         table="-t ${BASH_REMATCH[2]}"
 
+    local noargopts='!(-*|*[AIDPFXLZtj]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        -!(-*)[AIDPFXLZ])
+        -${noargopts}[AIDPFXLZ])
             COMPREPLY=($(compgen -W '`"$1" $table -L 2>/dev/null | \
                 command sed -ne "$chain"`' -- "$cur"))
             ;;
-        -!(-*)t)
+        -${noargopts}t)
             COMPREPLY=($(compgen -W 'nat filter broute' -- "$cur"))
             ;;
-        -!(-*)j)
+        -${noargopts}j)
             if [[ $table == "-t filter" || ! $table ]]; then
                 COMPREPLY=($(compgen -W '$targets
                 $("$1" $table -L 2>/dev/null | \

--- a/completions/evince
+++ b/completions/evince
@@ -5,10 +5,12 @@ _evince()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[pil]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help* | --sm-client-id | --class | --name | --screen | --gdk-debug | \
             --gdk-no-debug | --gtk-module | --gtk-debug | --gtk-no-debug | --page-label | \
-            --page-index | --find | --display | -!(-*)[hpil])
+            --page-index | --find | --display | -${noargopts}[hpil])
             return
             ;;
         --sm-client-state-file)

--- a/completions/faillog
+++ b/completions/faillog
@@ -5,11 +5,13 @@ _faillog()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[lmtu]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --lock-time | --maximum | --time | -!(-*)[hlmt])
+        --help | --lock-time | --maximum | --time | -${noargopts}[hlmt])
             return
             ;;
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;

--- a/completions/feh
+++ b/completions/feh
@@ -5,20 +5,22 @@ _feh()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[foO|KCjeM@TSRHWEyJabgLD~^]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
         --image-bg | -B)
             COMPREPLY=($(compgen -W 'checks white black' -- "$cur"))
             return
             ;;
-        --filelist | --output | --output-only | --start-at | -!(-*)[foO\|])
+        --filelist | --output | --output-only | --start-at | -${noargopts}[foO\|])
             _filedir
             return
             ;;
-        --caption-path | --fontpath | --output-dir | -!(-*)[KCj])
+        --caption-path | --fontpath | --output-dir | -${noargopts}[KCj])
             _filedir -d
             return
             ;;
-        --font | --menu-font | --title-font | -!(-*)[eM@])
+        --font | --menu-font | --title-font | -${noargopts}[eM@])
             # expect string like "dejavu.ttf/12"
             if [[ $cur == */* ]]; then # expect integer value
                 COMPREPLY=($(compgen -P "$cur" -W '{0..9}'))
@@ -42,7 +44,7 @@ _feh()
             compopt -o nospace
             return
             ;;
-        --theme | -!(-*)T)
+        --theme | -${noargopts}T)
             local conf_path=~/.config/feh/themes
             local theme_name theme_opts
             [[ -r $conf_path ]] || return
@@ -54,13 +56,13 @@ _feh()
             done <"$conf_path"
             return
             ;;
-        --sort | -!(-*)S)
+        --sort | -${noargopts}S)
             COMPREPLY=($(compgen -W 'name filename mtime width height
                 pixels size format' -- "$cur"))
             return
             ;;
         --reload | --limit-height | --limit-width | --thumb-height | --thumb-width | \
-            --thumb-redraw | --magick-timeout | -!(-*)[RHWEyJ])
+            --thumb-redraw | --magick-timeout | -${noargopts}[RHWEyJ])
             # expect integer value
             COMPREPLY+=($(compgen -W '{0..9}'))
             compopt -o nospace
@@ -75,16 +77,16 @@ _feh()
             fi
             return
             ;;
-        --alpha | -!(-*)a)
+        --alpha | -${noargopts}a)
             COMPREPLY=($(compgen -W '{0..255}' -- "$cur"))
             return
             ;;
-        --bg | -!(-*)b)
+        --bg | -${noargopts}b)
             _filedir
             COMPREPLY+=($(compgen -W 'trans' -- "$cur"))
             return
             ;;
-        --geometry | --max-dimension | --min-dimension | -!(-*)g)
+        --geometry | --max-dimension | --min-dimension | -${noargopts}g)
             # expect string like 640x480
             if [[ $cur && $cur != *x* ]]; then
                 COMPREPLY=(x)
@@ -94,7 +96,7 @@ _feh()
             return
             ;;
         --customlist | --index-info | --info | --slideshow-delay | --thumb-title | \
-            --title | -!(-*)[LD~^])
+            --title | -${noargopts}[LD~^])
             # argument required but no completions available
             return
             ;;

--- a/completions/file
+++ b/completions/file
@@ -5,15 +5,17 @@ _file()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[Fmfe]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --separator | -!(-*)[vF])
+        --help | --version | --separator | -${noargopts}[vF])
             return
             ;;
-        --magic-file | --files-from | -!(-*)[mf])
+        --magic-file | --files-from | -${noargopts}[mf])
             _filedir
             return
             ;;
-        --exclude | -!(-*)e)
+        --exclude | -${noargopts}e)
             COMPREPLY=($(compgen -W 'apptype ascii cdf compress elf encoding
                 soft tar text tokens troff' -- "$cur"))
             return

--- a/completions/file-roller
+++ b/completions/file-roller
@@ -7,20 +7,22 @@ _file_roller()
 
     local exts='@(7z?(.001)|ace|alz|ar|arj|[bglx]z|bz2|tb?(z)2|cab|cb[rz]|iso?(9660)|Z|t[abglx]z|cpio|deb|rar|?(g)tar|gem|lh[az]|lz[4h]|?(t)lrz|lzma|lzo|wim|swm|rpm|sit|zoo)'
 
+    local noargopts='!(-*|*[ae]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --help-all | --help-gtk | --help-sm-client | -!(-*)'?')
+        --help | --help-all | --help-gtk | --help-sm-client | -${noargopts}'?')
             return
             ;;
         --sm-client-state-file)
             _filedir
             return
             ;;
-        --add-to | -!(-*)a)
+        --add-to | -${noargopts}a)
             _filedir_xspec unzip "${@:2}"
             _filedir "$exts"
             return
             ;;
-        --extract-to | --default-dir | -!(-*)e)
+        --extract-to | --default-dir | -${noargopts}e)
             _filedir -d
             return
             ;;

--- a/completions/flake8
+++ b/completions/flake8
@@ -5,15 +5,17 @@ _flake8()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[j]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)h)
+        --help | --version | -${noargopts}h)
             return
             ;;
         --format)
             COMPREPLY=($(compgen -W 'default pylint' -- "$cur"))
             return
             ;;
-        --jobs | -!(-*)j)
+        --jobs | -${noargopts}j)
             COMPREPLY=($(compgen -W "auto {1..$(_ncpus)}" -- "$cur"))
             return
             ;;

--- a/completions/getent
+++ b/completions/getent
@@ -5,13 +5,15 @@ _getent()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[s]*)'
     local i db
     for ((i = 1; i < cword; i++)); do
+        # shellcheck disable=SC2254
         case ${words[i]} in
-            --version | --usage | --help | -!(-*)[V?])
+            --version | --usage | --help | -${noargopts}[V?])
                 return
                 ;;
-            --service | -!(-*)s)
+            --service | -${noargopts}s)
                 ((i++))
                 ;;
             -*) ;;

--- a/completions/gnome-screenshot
+++ b/completions/gnome-screenshot
@@ -5,15 +5,17 @@ _gnome_screenshot()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[def]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --help-* | --version | --delay | --display | -!(-*)[hd])
+        --help | --help-* | --version | --delay | --display | -${noargopts}[hd])
             return
             ;;
-        --border-effect | -!(-*)e)
+        --border-effect | -${noargopts}e)
             COMPREPLY=($(compgen -W 'shadow border vintage none' -- "$cur"))
             return
             ;;
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir '@(jp?(e)|pn)g'
             return
             ;;

--- a/completions/gpasswd
+++ b/completions/gpasswd
@@ -5,8 +5,10 @@ _gpasswd()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[adAM]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --add | --delete | --administrators | --members | -!(-*)[adAM])
+        --add | --delete | --administrators | --members | -${noargopts}[adAM])
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;

--- a/completions/gpg
+++ b/completions/gpg
@@ -5,9 +5,11 @@ _gpg()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[skKr]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --sign | --clear-sign | --clearsign | --decrypt-files | \
-            --load-extension | -!(-*)s)
+            --load-extension | -${noargopts}s)
             _filedir
             return
             ;;
@@ -15,7 +17,7 @@ _gpg()
             --locate-external-keys | --fingerprint | --delete-keys | \
             --delete-secret-and-public-keys | --export | --refresh-keys | \
             --search-keys | --edit-key | --sign-key | --lsign-key | \
-            --nrsign-key | --nrlsign-key | --try-secret-key | -!(-*)k)
+            --nrsign-key | --nrlsign-key | --try-secret-key | -${noargopts}k)
             # return list of public keys
             COMPREPLY=($(compgen -W "$($1 --list-keys 2>/dev/null |
                 command sed -ne \
@@ -24,13 +26,13 @@ _gpg()
             return
             ;;
         --list-secret-keys | --delete-secret-keys | --export-secret-keys | \
-            --export-secret-subkeys | -!(-*)K)
+            --export-secret-subkeys | -${noargopts}K)
             # return list of secret keys
             COMPREPLY=($(compgen -W "$($1 --list-secret-keys 2>/dev/null |
                 command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
             return
             ;;
-        --recipient | -!(-*)r)
+        --recipient | -${noargopts}r)
             COMPREPLY=($(compgen -W "$($1 --list-keys 2>/dev/null |
                 command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
             if [[ -e ~/.gnupg/gpg.conf ]]; then

--- a/completions/gpg2
+++ b/completions/gpg2
@@ -5,12 +5,14 @@ _gpg2()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[sr]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --homedir)
             _filedir -d
             return
             ;;
-        --sign | --clearsign | --options | --decrypt | -!(-*)s)
+        --sign | --clearsign | --options | --decrypt | -${noargopts}s)
             _filedir
             return
             ;;
@@ -24,7 +26,7 @@ _gpg2()
                     's@^.*\(<\([^>]*\)>\).*$@\2@p')" -- "$cur"))
             return
             ;;
-        --recipient | -!(-*)r)
+        --recipient | -${noargopts}r)
             COMPREPLY=($(compgen -W "$($1 --list-keys 2>/dev/null |
                 command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
             if [[ -e ~/.gnupg/gpg.conf ]]; then

--- a/completions/groupadd
+++ b/completions/groupadd
@@ -8,8 +8,10 @@ _groupadd()
     # TODO: if -o/--non-unique is given, could complete on existing gids
     #       with -g/--gid
 
+    local noargopts='!(-*|*[gKp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --gid | --key | --password | -!(-*)[gKp])
+        --gid | --key | --password | -${noargopts}[gKp])
             return
             ;;
     esac

--- a/completions/groupmod
+++ b/completions/groupmod
@@ -8,8 +8,10 @@ _groupmod()
     # TODO: if -o/--non-unique is given, could complete on existing gids
     #       with -g/--gid
 
+    local noargopts='!(-*|*[gnp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --gid | --help | --new-name | --password | -!(-*)[ghnp])
+        --gid | --help | --new-name | --password | -${noargopts}[ghnp])
             return
             ;;
     esac

--- a/completions/grpck
+++ b/completions/grpck
@@ -5,8 +5,10 @@ _grpck()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[R]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --root | -!(-*)R)
+        --root | -${noargopts}R)
             _filedir
             return
             ;;

--- a/completions/gzip
+++ b/completions/gzip
@@ -5,12 +5,14 @@ _gzip()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[bSACIJp]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --blocksize | --suffix | --help | --version | --alias | --comment | \
-            --iterations | --maxsplits | -!(-*)[bShVACIJ])
+            --iterations | --maxsplits | -${noargopts}[bShVACIJ])
             return
             ;;
-        --processes | -!(-*)p)
+        --processes | -${noargopts}p)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)}" -- "$cur"))
             return
             ;;

--- a/completions/hddtemp
+++ b/completions/hddtemp
@@ -5,20 +5,22 @@ _hddtemp()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[flupsS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir db
             return
             ;;
-        --listen | -!(-*)l)
+        --listen | -${noargopts}l)
             _ip_addresses
             return
             ;;
-        --unit | -!(-*)u)
+        --unit | -${noargopts}u)
             COMPREPLY=($(compgen -W 'C F' -- "$cur"))
             return
             ;;
-        --port | --separator | --syslog | --version | --help | -!(-*)[psSvh?])
+        --port | --separator | --syslog | --version | --help | -${noargopts}[psSvh?])
             return
             ;;
     esac

--- a/completions/hostname
+++ b/completions/hostname
@@ -5,11 +5,13 @@ _hostname()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[F]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
-        --file | -!(-*)F)
+        --file | -${noargopts}F)
             _filedir
             return
             ;;

--- a/completions/hping2
+++ b/completions/hping2
@@ -5,20 +5,22 @@ _hping2()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[IaoE]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --interface | -!(-*)I)
+        --interface | -${noargopts}I)
             _available_interfaces
             return
             ;;
-        --spoof | -!(-*)a)
+        --spoof | -${noargopts}a)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --tos | -!(-*)o)
+        --tos | -${noargopts}o)
             COMPREPLY=($(compgen -W '02 04 08 10'))
             return
             ;;
-        --file | -!(-*)E)
+        --file | -${noargopts}E)
             _filedir
             return
             ;;

--- a/completions/htop
+++ b/completions/htop
@@ -5,16 +5,18 @@ _htop()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[sud]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
-        --sort-key | -!(-*)s)
+        --sort-key | -${noargopts}s)
             COMPREPLY=($(compgen -W '$("$1" -s help)' -- "$cur"))
             return
             ;;
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;
-        --delay | -!(-*)d)
+        --delay | -${noargopts}d)
             # argument required but no completions available
             return
             ;;

--- a/completions/iconv
+++ b/completions/iconv
@@ -13,16 +13,18 @@ _iconv()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[fto]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --usage | --version | --unicode-subst | --byte-subst | \
-            --widechar-subst | -!(-*)[?V])
+            --widechar-subst | -${noargopts}[?V])
             return
             ;;
-        --from-code | --to-code | -!(-*)[ft])
+        --from-code | --to-code | -${noargopts}[ft])
             _comp_xfunc_iconv_charsets $1
             return
             ;;
-        --output | -!(-*)o)
+        --output | -${noargopts}o)
             _filedir
             return
             ;;

--- a/completions/idn
+++ b/completions/idn
@@ -5,11 +5,13 @@ _idn()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[p]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
-        --profile | -!(-*)p)
+        --profile | -${noargopts}p)
             COMPREPLY=($(compgen -W 'Nameprep iSCSI Nodeprep Resourceprep
                 trace SASLprep' -- "$cur"))
             return

--- a/completions/ifstat
+++ b/completions/ifstat
@@ -5,16 +5,18 @@ _ifstat()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[idstx]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --scan | --interval | -!(-*)[hvV])
+        --help | --version | --scan | --interval | -${noargopts}[hvV])
             return
             ;;
-        -!(-*)i)
+        -${noargopts}i)
             # TODO comma separated
             _available_interfaces -a
             return
             ;;
-        -!(-*)d)
+        -${noargopts}d)
             # iproute2: no completion (scan delay)
             # traditional: parse driver
             if ! {
@@ -26,7 +28,7 @@ _ifstat()
             fi
             return
             ;;
-        --noupdate | -!(-*)s)
+        --noupdate | -${noargopts}s)
             # iproute2: pass through (skip history update)
             # traditional: hostnames (snmp)
             if ! {
@@ -37,7 +39,7 @@ _ifstat()
                 return
             fi
             ;;
-        -!(-*)t)
+        -${noargopts}t)
             # iproute2: no completion (interval)
             # traditional: pass through (add timestamp)
             ! {
@@ -45,7 +47,7 @@ _ifstat()
             } |
                 command grep -q -- '-t.*--interval' || return
             ;;
-        --extended | -!(-*)x)
+        --extended | -${noargopts}x)
             # iproute2: parse xstat types
             COMPREPLY=($(compgen -W '$("$1" -x nonexistent-xstat 2>&1 |
                 awk "found { print \$1 } /supported xstats:/ { found=1 }")' \

--- a/completions/ifup
+++ b/completions/ifup
@@ -7,11 +7,13 @@ _ifupdown()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[Xoi]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --allow | --exclude | --option | -!(-*)[hVXo])
+        --help | --version | --allow | --exclude | --option | -${noargopts}[hVXo])
             return
             ;;
-        --interfaces | -!(-*)i)
+        --interfaces | -${noargopts}i)
             _filedir
             return
             ;;

--- a/completions/info
+++ b/completions/info
@@ -11,11 +11,13 @@ _info()
         return
     fi
 
+    local noargopts='!(-*|*[kndfor]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --apropos | --index-search | --node | --help | --version | -!(-*)[knhv])
+        --apropos | --index-search | --node | --help | --version | -${noargopts}[knhv])
             return
             ;;
-        -!(-*)d)
+        -${noargopts}d)
             if [[ ${1##*/} == info ]]; then
                 _filedir -d
                 return
@@ -25,7 +27,7 @@ _info()
             _filedir -d
             return
             ;;
-        --dribble | --file | --output | --restore | --raw-filename | --rcfile | -!(-*)[for])
+        --dribble | --file | --output | --restore | --raw-filename | --rcfile | -${noargopts}[for])
             _filedir
             return
             ;;

--- a/completions/inotifywait
+++ b/completions/inotifywait
@@ -16,15 +16,17 @@ _inotifywait()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[oe]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --exclude | --excludei | --format | --timefmt | --timeout | -!(-*)[ht])
+        --help | --exclude | --excludei | --format | --timefmt | --timeout | -${noargopts}[ht])
             return
             ;;
-        --fromfile | --outfile | -!(-*)o)
+        --fromfile | --outfile | -${noargopts}o)
             _filedir
             return
             ;;
-        --event | -!(-*)e)
+        --event | -${noargopts}e)
             _inotifywait_events "$1"
             return
             ;;

--- a/completions/interdiff
+++ b/completions/interdiff
@@ -5,8 +5,10 @@ _interdiff()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[Upd]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --unified | --strip-match | --drop-context | -!(-*)[Upd])
+        --unified | --strip-match | --drop-context | -${noargopts}[Upd])
             return
             ;;
     esac

--- a/completions/iperf
+++ b/completions/iperf
@@ -5,6 +5,8 @@ _iperf()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
+    local noargopts='!(-*|*[ilpwMXbntLPTZCkOSAfIoFBcxy]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --interval | --len | --port | --window | --mss | --bandwidth | \
             --num | --time | --listenport | --parallel | --ttl | --linux-congestion | --omit | \
@@ -12,10 +14,10 @@ _iperf()
             --title | --tos | --affinity | --rcv-timeout | --server-bitrate-limit | \
             --idle-timeout | --time-skew-threshold | --xbind | --nstreams | --connect-timeout | \
             --bitrate | --pacing-timer | --fq-rate | --length | --dscp | --extra-data | \
-            --username | -!(-*)[hvilpwMXbntLPTZCkOSA])
+            --username | -${noargopts}[hvilpwMXbntLPTZCkOSA])
             return
             ;;
-        --format | -!(-*)f)
+        --format | -${noargopts}f)
             local formats=$(
                 "$1" --help 2>&1 |
                     command sed -ne 's/^.*--format .*\[\([a-zA-Z]\{1,\}\)\].*/\1/p' |
@@ -24,15 +26,15 @@ _iperf()
             COMPREPLY=($(compgen -W '$formats' -- "$cur"))
             return
             ;;
-        --pidfile | -!(-*)I)
+        --pidfile | -${noargopts}I)
             _filedir pid
             return
             ;;
-        --output | --fileinput | --authorized-users-path | -!(-*)[oF])
+        --output | --fileinput | --authorized-users-path | -${noargopts}[oF])
             _filedir
             return
             ;;
-        --bind | -!(-*)B)
+        --bind | -${noargopts}B)
             _available_interfaces -a
             _ip_addresses -a
             __ltrim_colon_completions "$cur"
@@ -42,15 +44,15 @@ _iperf()
             _available_interfaces -a
             return
             ;;
-        --client | -!(-*)c)
+        --client | -${noargopts}c)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --reportexclude | -!(-*)x)
+        --reportexclude | -${noargopts}x)
             COMPREPLY=($(compgen -W 'C D M S V' -- "$cur"))
             return
             ;;
-        --reportstyle | -!(-*)y)
+        --reportstyle | -${noargopts}y)
             COMPREPLY=($(compgen -W 'C' -- "$cur"))
             return
             ;;

--- a/completions/ipv6calc
+++ b/completions/ipv6calc
@@ -5,11 +5,13 @@ _ipv6calc()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[dIOA]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
-        --debug | -!(-*)d)
+        --debug | -${noargopts}d)
             return
             ;;
-        --in | --out | --action | -!(-*)[IOA])
+        --in | --out | --action | -${noargopts}[IOA])
             # With ipv6calc < 0.73.0, -m does nothing here, so use sed instead.
             COMPREPLY=($(compgen -W "$($1 "$prev" -h 2>&1 |
                 command sed -ne 's/^[[:space:]]\{1,\}\([^[:space:]:]\{1,\}\)[[:space:]]*:.*/\1/p')" \

--- a/completions/iscsiadm
+++ b/completions/iscsiadm
@@ -5,21 +5,23 @@ _iscsiadm()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[motLU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --mode | -!(-*)m)
+        --mode | -${noargopts}m)
             COMPREPLY=($(compgen -W 'discovery node session iface fw host' \
                 -- "$cur"))
             return
             ;;
-        --op | -!(-*)o)
+        --op | -${noargopts}o)
             COMPREPLY=($(compgen -W 'new delete update show' -- "$cur"))
             return
             ;;
-        --type | -!(-*)t)
+        --type | -${noargopts}t)
             COMPREPLY=($(compgen -W 'sendtargets st slp isns fw' -- "$cur"))
             return
             ;;
-        --loginall | --logoutall | -!(-*)[LU])
+        --loginall | --logoutall | -${noargopts}[LU])
             COMPREPLY=($(compgen -W 'all manual automatic' -- "$cur"))
             return
             ;;

--- a/completions/jpegoptim
+++ b/completions/jpegoptim
@@ -5,19 +5,21 @@ _jpegoptim()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[dmTS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV]*)
+        --help | --version | -${noargopts}[hV]*)
             return
             ;;
-        --dest | -!(-*)d)
+        --dest | -${noargopts}d)
             _filedir -d
             return
             ;;
-        --max | --threshold | -!(-*)[mT])
+        --max | --threshold | -${noargopts}[mT])
             COMPREPLY=($(compgen -W '{0..100}' -- "$cur"))
             return
             ;;
-        --size | -!(-*)S)
+        --size | -${noargopts}S)
             COMPREPLY=($(compgen -W '{1..99}%' -- "$cur"))
             return
             ;;

--- a/completions/jq
+++ b/completions/jq
@@ -5,6 +5,8 @@ _jq()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[fL]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --arg | --argjson | --slurpfile | --argfile)
             return
@@ -13,11 +15,11 @@ _jq()
             COMPREPLY=($(compgen -W '{1..8}' -- "$cur"))
             return
             ;;
-        --from-file | --run-tests | -!(-*)f)
+        --from-file | --run-tests | -${noargopts}f)
             _filedir
             return
             ;;
-        -!(-*)L)
+        -${noargopts}L)
             _filedir -d
             return
             ;;
@@ -65,7 +67,7 @@ _jq()
     local args
     # TODO: DTRT with args taking 2 options
     # -f|--from-file are not counted here because they supply the filter
-    _count_args "" "@(--arg|--arg?(json|file)|--slurpfile|--indent|--run-tests|-!(-*)L)"
+    _count_args "" "@(--arg|--arg?(json|file)|--slurpfile|--indent|--run-tests|-${noargopts}L)"
 
     # 1st arg is filter
     ((args == 1)) && return

--- a/completions/killall
+++ b/completions/killall
@@ -7,15 +7,17 @@ _killall()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[Zoysu]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --context | --older-than | --younger-than | --version | -!(-*)@([Zoy]|V*))
+        --context | --older-than | --younger-than | --version | -${noargopts}@([Zoy]|V*))
             return
             ;;
-        --signal | -!(-*)s)
+        --signal | -${noargopts}s)
             _signals
             return
             ;;
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             _allowed_users
             return
             ;;

--- a/completions/koji
+++ b/completions/koji
@@ -45,11 +45,13 @@ _koji()
         fi
     done
 
+    local noargopts='!(-*|*[co]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --help-commands | -!(-*)h*)
+        --help | --help-commands | -${noargopts}h*)
             return
             ;;
-        --config | --keytab | -!(-*)[co])
+        --config | --keytab | -${noargopts}[co])
             _filedir
             return
             ;;

--- a/completions/lastlog
+++ b/completions/lastlog
@@ -5,11 +5,13 @@ _lastlog()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[btu]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --before | --help | --time | -!(-*)@([bt]|h*))
+        --before | --help | --time | -${noargopts}@([bt]|h*))
             return
             ;;
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;

--- a/completions/ldapvi
+++ b/completions/ldapvi
@@ -5,12 +5,14 @@ _ldapvi()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[Y]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --sasl-mech | -!(-*)Y)
+        --sasl-mech | -${noargopts}Y)
             COMPREPLY=($(compgen -W 'EXTERNAL GSSAPI DIGEST-MD5 CRAM-MD5
                 PLAIN ANONYMOUS' -- "$cur"))
             return

--- a/completions/lftp
+++ b/completions/lftp
@@ -5,12 +5,14 @@ _lftp()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[fceups]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        -!(-*)f)
+        -${noargopts}f)
             _filedir
             return
             ;;
-        --help | --version | -!(-*)[chveups])
+        --help | --version | -${noargopts}[chveups])
             return
             ;;
     esac

--- a/completions/lrzip
+++ b/completions/lrzip
@@ -7,31 +7,33 @@ _lrzip()
 
     local xspec="*.lrz"
 
+    local noargopts='!(-*|*[SmwdoOLNp]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --suffix | --maxram | --window | \
-            -!(-*)@([Smw]|[h?V]*))
+            -${noargopts}@([Smw]|[h?V]*))
             return
             ;;
-        --decompress | -!(-*)d)
+        --decompress | -${noargopts}d)
             xspec="!"$xspec
             ;;
-        --outfile | -!(-*)o)
+        --outfile | -${noargopts}o)
             _filedir
             return
             ;;
-        --outdir | -!(-*)O)
+        --outdir | -${noargopts}O)
             _filedir -d
             return
             ;;
-        --level | -!(-*)L)
+        --level | -${noargopts}L)
             COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
             return
             ;;
-        --nice-level | -!(-*)N)
+        --nice-level | -${noargopts}N)
             COMPREPLY=($(compgen -W '{-20..19}' -- "$cur"))
             return
             ;;
-        --threads | -!(-*)p)
+        --threads | -${noargopts}p)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)}" -- "$cur"))
             return
             ;;

--- a/completions/lsscsi
+++ b/completions/lsscsi
@@ -5,11 +5,13 @@ _lsscsi()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[y]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV]*)
+        --help | --version | -${noargopts}[hV]*)
             return
             ;;
-        --sysfsroot | -!(-*)y)
+        --sysfsroot | -${noargopts}y)
             _filedir -d
             return
             ;;

--- a/completions/lsusb
+++ b/completions/lsusb
@@ -5,8 +5,10 @@ _lsusb()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[sD]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)@([sD]|[hV]*))
+        --help | --version | -${noargopts}@([sD]|[hV]*))
             return
             ;;
     esac

--- a/completions/luseradd
+++ b/completions/luseradd
@@ -5,21 +5,23 @@ _luseradd()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[culPpdksg]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --usage | --gecos | --uid | --login | --plainpassword | --password | \
             --commonname | --givenname | --surname | --roomnumber | --telephonenumber | \
-            --homephone | -!(-*)@([culPp]|[?]*))
+            --homephone | -${noargopts}@([culPp]|[?]*))
             return
             ;;
-        --directory | --skeleton | -!(-*)[dk])
+        --directory | --skeleton | -${noargopts}[dk])
             _filedir -d
             return
             ;;
-        --shell | -!(-*)s)
+        --shell | -${noargopts}s)
             _shells
             return
             ;;
-        --gid | -!(-*)g)
+        --gid | -${noargopts}g)
             _gids
             return
             ;;

--- a/completions/lvm
+++ b/completions/lvm
@@ -92,8 +92,10 @@ _pvs()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[oO]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --options | --sort | -!(-*)[oO])
+        --options | --sort | -${noargopts}[oO])
             COMPREPLY=($(compgen -W 'pv_fmt pv_uuid pv_size pv_free pv_used
                 pv_name pv_attr pv_pe_count pv_pe_alloc_count' -- "$cur"))
             return
@@ -137,8 +139,10 @@ _pvchange()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[Ax]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | --allocatable | -!(-*)[Ax])
+        --autobackup | --allocatable | -${noargopts}[Ax])
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -157,12 +161,14 @@ _pvcreate()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[M]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --restorefile)
             _filedir
             return
             ;;
-        --metadatatype | -!(-*)M)
+        --metadatatype | -${noargopts}M)
             COMPREPLY=($(compgen -W '1 2' -- "$cur"))
             return
             ;;
@@ -189,12 +195,14 @@ _pvmove()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[An]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --name | -!(-*)n)
+        --name | -${noargopts}n)
             _lvm_logicalvolumes
             return
             ;;
@@ -237,8 +245,10 @@ _vgs()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[oO]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --options | --sort | -!(-*)[oO])
+        --options | --sort | -${noargopts}[oO])
             COMPREPLY=($(compgen -W 'vg_fmt vg_uuid vg_name vg_attr vg_size
                 vg_free vg_sysid vg_extent_size vg_extent_count vg_free_count
                 max_lv max_pv pv_count lv_count snap_count vg_seqno' \
@@ -284,8 +294,10 @@ _vgchange()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[aAx]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --available | --autobackup | --resizeable | -!(-*)[aAx])
+        --available | --autobackup | --resizeable | -${noargopts}[aAx])
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -304,16 +316,18 @@ _vgcreate()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AMs]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --metadatatype | -!(-*)M)
+        --metadatatype | -${noargopts}M)
             COMPREPLY=($(compgen -W '1 2' -- "$cur"))
             return
             ;;
-        --physicalextentsize | -!(-*)s)
+        --physicalextentsize | -${noargopts}s)
             _lvm_sizes
             return
             ;;
@@ -351,8 +365,10 @@ _vgrename()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[A]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -371,8 +387,10 @@ _vgreduce()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[A]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -398,12 +416,14 @@ _vgextend()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AL]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --size | -!(-*)L)
+        --size | -${noargopts}L)
             _lvm_sizes
             return
             ;;
@@ -454,8 +474,10 @@ _vgconvert()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[M]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --metadatatype | -!(-*)M)
+        --metadatatype | -${noargopts}M)
             COMPREPLY=($(compgen -W '1 2' -- "$cur"))
             return
             ;;
@@ -482,8 +504,10 @@ _vgcfgbackup()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[f]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir
             return
             ;;
@@ -502,16 +526,18 @@ _vgcfgrestore()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[fMn]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir
             return
             ;;
-        --metadatatype | -!(-*)M)
+        --metadatatype | -${noargopts}M)
             COMPREPLY=($(compgen -W '1 2' -- "$cur"))
             return
             ;;
-        --name | -!(-*)n)
+        --name | -${noargopts}n)
             _lvm_volumegroups
             return
             ;;
@@ -530,8 +556,10 @@ _vgmerge()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[A]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -550,12 +578,14 @@ _vgsplit()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AM]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --metadatatype | -!(-*)M)
+        --metadatatype | -${noargopts}M)
             COMPREPLY=($(compgen -W '1 2' -- "$cur"))
             return
             ;;
@@ -604,8 +634,10 @@ _lvs()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[oO]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --options | --sort | -!(-*)[oO])
+        --options | --sort | -${noargopts}[oO])
             COMPREPLY=($(compgen -W 'lv_uuid lv_name lv_attr lv_minor lv_size
                 seg_count origin snap_percent segtype stripes stripesize
                 chunksize seg_start seg_size' -- "$cur"))
@@ -650,12 +682,14 @@ _lvchange()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[aACMp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --available | --autobackup | --contiguous | --persistent | -!(-*)[aACM])
+        --available | --autobackup | --contiguous | --persistent | -${noargopts}[aACM])
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --permission | -!(-*)p)
+        --permission | -${noargopts}p)
             COMPREPLY=($(compgen -W 'r rw' -- "$cur"))
             return
             ;;
@@ -674,20 +708,22 @@ _lvcreate()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[ACMZLpn]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | --contiguous | --persistent | --zero | -!(-*)[ACMZ])
+        --autobackup | --contiguous | --persistent | --zero | -${noargopts}[ACMZ])
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --size | -!(-*)L)
+        --size | -${noargopts}L)
             _lvm_sizes
             return
             ;;
-        --permission | -!(-*)p)
+        --permission | -${noargopts}p)
             COMPREPLY=($(compgen -W 'r rw' -- "$cur"))
             return
             ;;
-        --name | -!(-*)n)
+        --name | -${noargopts}n)
             _lvm_logicalvolumes
             return
             ;;
@@ -712,8 +748,10 @@ _lvremove()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[A]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -732,8 +770,10 @@ _lvrename()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[A]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
@@ -752,12 +792,14 @@ _lvreduce()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AL]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --size | -!(-*)L)
+        --size | -${noargopts}L)
             _lvm_sizes
             return
             ;;
@@ -776,12 +818,14 @@ _lvresize()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AL]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --size | -!(-*)L)
+        --size | -${noargopts}L)
             _lvm_sizes
             return
             ;;
@@ -806,12 +850,14 @@ _lvextend()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[AL]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --autobackup | -!(-*)A)
+        --autobackup | -${noargopts}A)
             COMPREPLY=($(compgen -W 'y n' -- "$cur"))
             return
             ;;
-        --size | -!(-*)L)
+        --size | -${noargopts}L)
             _lvm_sizes
             return
             ;;

--- a/completions/lzip
+++ b/completions/lzip
@@ -7,19 +7,21 @@ _lzip()
 
     local decompress=false
 
+    local noargopts='!(-*|*[bmsSBdno]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --member-size | --match-length | --dictionary-size | \
-            --volume-size | --data-size | -!(-*)@([bmsSB]|[hV]*))
+            --volume-size | --data-size | -${noargopts}@([bmsSB]|[hV]*))
             return
             ;;
-        --decompress-!(-*)d)
+        --decompress-${noargopts}d)
             decompress=true
             ;;
-        --threads-!(-*)n)
+        --threads-${noargopts}n)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)}" -- "$cur"))
             return
             ;;
-        --output-!(-*)o)
+        --output-${noargopts}o)
             _filedir
             return
             ;;

--- a/completions/lzop
+++ b/completions/lzop
@@ -5,8 +5,10 @@ _lzop()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[oS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --output | -!(-*)o)
+        --output | -${noargopts}o)
             _filedir
             return
             ;;
@@ -14,7 +16,7 @@ _lzop()
             _filedir -d
             return
             ;;
-        --suffix | -!(-*)S)
+        --suffix | -${noargopts}S)
             return
             ;;
     esac

--- a/completions/make
+++ b/completions/make
@@ -94,24 +94,26 @@ _make()
 
     local makef makef_dir=("-C" ".") i
 
+    local noargopts='!(-*|*[foWICmEDVxj]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --file | --makefile | --old-file | --assume-old | --what-if | --new-file | \
-            --assume-new | -!(-*)[foW])
+            --assume-new | -${noargopts}[foW])
             _filedir
             return
             ;;
-        --include-dir | --directory | -!(-*)[ICm])
+        --include-dir | --directory | -${noargopts}[ICm])
             _filedir -d
             return
             ;;
-        -!(-*)E)
+        -${noargopts}E)
             COMPREPLY=($(compgen -v -- "$cur"))
             return
             ;;
-        --eval | -!(-*)[DVx])
+        --eval | -${noargopts}[DVx])
             return
             ;;
-        --jobs | -!(-*)j)
+        --jobs | -${noargopts}j)
             COMPREPLY=($(compgen -W "{1..$(($(_ncpus) * 2))}" -- "$cur"))
             return
             ;;

--- a/completions/man
+++ b/completions/man
@@ -9,34 +9,36 @@ _man()
     local manext="@([0-9]*([a-z])|[lnp]|man)?($comprsuffix)"
     local mansect="@([0-9]*([a-z])|[lnp])"
 
+    local noargopts='!(-*|*[ClMSsPpLmerRE]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --config-file | -!(-*)C)
+        --config-file | -${noargopts}C)
             _filedir conf
             return
             ;;
-        --local-file | -!(-*)l)
+        --local-file | -${noargopts}l)
             _filedir "$manext"
             return
             ;;
-        --manpath | -!(-*)M)
+        --manpath | -${noargopts}M)
             _filedir -d
             return
             ;;
-        --sections | -!(-*)[Ss])
+        --sections | -${noargopts}[Ss])
             _comp_delimited : -W '{1..9}'
             return
             ;;
-        --pager | -!(-*)P)
+        --pager | -${noargopts}P)
             compopt -o filenames
             COMPREPLY=($(compgen -c -- "$cur"))
             return
             ;;
-        --preprocessor | -!(-*)p)
+        --preprocessor | -${noargopts}p)
             COMPREPLY=($(compgen -W 'e p t g r v' -- "$cur"))
             return
             ;;
         --locale | --systems | --extension | --prompt | --recode | --encoding | \
-            -!(-*)[LmerRE])
+            -${noargopts}[LmerRE])
             return
             ;;
     esac

--- a/completions/mc
+++ b/completions/mc
@@ -5,12 +5,14 @@ _mc()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[evlPCD]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --edit | --view | --ftplog | --printwd | -!(-*)[evlP])
+        --edit | --view | --ftplog | --printwd | -${noargopts}[evlP])
             _filedir
             return
             ;;
-        --help | --help-* | --version | --colors | --debuglevel | -!(-*)[hVCD])
+        --help | --help-* | --version | --colors | --debuglevel | -${noargopts}[hVCD])
             return
             ;;
     esac

--- a/completions/mdadm
+++ b/completions/mdadm
@@ -4,13 +4,15 @@ _mdadm_raid_level()
 {
     local mode
 
+    local noargopts='!(-*|*[CB]*)'
     for ((i = 1; i < cword; i++)); do
+        # shellcheck disable=SC2254
         case ${words[i]} in
-            -!(-*)C* | --create)
+            -${noargopts}C* | --create)
                 mode=create
                 break
                 ;;
-            -!(-*)B* | --build)
+            -${noargopts}B* | --build)
                 mode=build
                 break
                 ;;
@@ -72,24 +74,26 @@ _mdadm()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[cblpaU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --config | --bitmap | --backup-file | -!(-*)[cb])
+        --config | --bitmap | --backup-file | -${noargopts}[cb])
             _filedir
             return
             ;;
-        --level | -!(-*)l)
+        --level | -${noargopts}l)
             _mdadm_raid_level
             return
             ;;
-        --layout | --parity | -!(-*)p)
+        --layout | --parity | -${noargopts}p)
             _mdadm_raid_layout
             return
             ;;
-        --auto | -!(-*)a)
+        --auto | -${noargopts}a)
             _mdadm_auto_flag
             return
             ;;
-        --update | -!(-*)U)
+        --update | -${noargopts}U)
             _mdadm_update_flag
             return
             ;;
@@ -105,14 +109,15 @@ _mdadm()
             COMPREPLY=($(compgen -W "$options --assemble --build --create
                 --monitor --grow" -- "$cur"))
         else
+            # shellcheck disable=SC2254
             case ${words[cword - 1]} in
-                --assemble | -!(-*)A*)
+                --assemble | -${noargopts}A*)
                     COMPREPLY=($(compgen -W "$options --uuid= --super-minor=
                         --name= --force --run --no-degraded --auto= --bitmap=
                         --backup-file= --update= --auto-update-homehost" \
                         -- "$cur"))
                     ;;
-                --build | --create | --grow | -!(-*)[BCG]*)
+                --build | --create | --grow | -${noargopts}[BCG]*)
                     COMPREPLY=($(compgen -W "$options --raid-devices=
                         --spare-devices= --size= --chunk= --rounding= --level=
                         --layout= --parity= --bitmap= --bitmap-chunk=
@@ -120,7 +125,7 @@ _mdadm()
                         --backup-file= --name= --run --force --auto=" \
                         -- "$cur"))
                     ;;
-                --follow | --monitor | -!(-*)F)
+                --follow | --monitor | -${noargopts}F)
                     COMPREPLY=($(compgen -W "$options --mail --program
                         --alert --syslog --delay --daemonise --pid-file
                         --oneshot --test" -- "$cur"))

--- a/completions/mii-tool
+++ b/completions/mii-tool
@@ -5,13 +5,15 @@ _mii_tool()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[FA]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --force | -!(-*)F)
+        --force | -${noargopts}F)
             COMPREPLY=($(compgen -W '100baseTx-FD 100baseTx-HD 10baseT-FD
                 10baseT-HD' -- "$cur"))
             return
             ;;
-        --advertise | -!(-*)A)
+        --advertise | -${noargopts}A)
             COMPREPLY=($(compgen -W '100baseT4 100baseTx-FD 100baseTx-HD
                 10baseT-FD 10baseT-HD' -- "$cur"))
             return

--- a/completions/minicom
+++ b/completions/minicom
@@ -5,16 +5,18 @@ _minicom()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[acSCp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --attrib | --color | -!(-*)[ac])
+        --attrib | --color | -${noargopts}[ac])
             COMPREPLY=($(compgen -W 'on off' -- "$cur"))
             return
             ;;
-        --script | --capturefile | -!(-*)[SC])
+        --script | --capturefile | -${noargopts}[SC])
             _filedir
             return
             ;;
-        --ptty | -!(-*)p)
+        --ptty | -${noargopts}p)
             _comp_expand_glob COMPREPLY '/dev/tty*'
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}}' \

--- a/completions/mktemp
+++ b/completions/mktemp
@@ -5,11 +5,13 @@ _mktemp()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[p]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
         --help | --version | --suffix)
             return
             ;;
-        --tmpdir | -!(-*)p)
+        --tmpdir | -${noargopts}p)
             _filedir -d
             return
             ;;

--- a/completions/modinfo
+++ b/completions/modinfo
@@ -5,19 +5,21 @@ _modinfo()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[Fkb]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
-        --field | -!(-*)F)
+        --field | -${noargopts}F)
             COMPREPLY=($(compgen -W 'alias author depends description
                 filename firmware intree license name parm release_date
                 retpoline sig_hashalgo sig_key signat signer softdep srcversion
                 staging vermagic version' -- "${cur,,}"))
             return
             ;;
-        --set-version | -!(-*)k)
+        --set-version | -${noargopts}k)
             _kernel_versions
             return
             ;;
-        --basedir | -!(-*)b)
+        --basedir | -${noargopts}b)
             _filedir -d
             return
             ;;
@@ -35,7 +37,7 @@ _modinfo()
 
     local i version=$(uname -r)
     for ((i = ${#words[@]} - 1; i > 0; i--)); do
-        if [[ ${words[i]} == -@(!(-*)k*|-set-version) ]]; then
+        if [[ ${words[i]} == -@(${noargopts}k*|-set-version) ]]; then
             version=${words[i + 1]}
             break
         fi

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -5,19 +5,21 @@ _modprobe()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[CdtS]*)'
+    # shellcheck disable=SC2254
     case "$prev" in
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
-        --config | -!(-*)C)
+        --config | -${noargopts}C)
             _filedir
             return
             ;;
-        --dirname | --type | -!(-*)[dt])
+        --dirname | --type | -${noargopts}[dt])
             _filedir -d
             return
             ;;
-        --set-version | -!(-*)S)
+        --set-version | -${noargopts}S)
             _kernel_versions
             return
             ;;
@@ -42,20 +44,21 @@ _modprobe()
 
     local i mode=insert module="" version=$(uname -r)
     for ((i = 1; i < cword; i++)); do
+        # shellcheck disable=SC2254
         case "${words[i]}" in
-            --remove | -!(-*)r*)
+            --remove | -${noargopts}r*)
                 mode=remove
                 ;;
-            --list | -!(-*)l*)
+            --list | -${noargopts}l*)
                 mode=list
                 ;;
             --dump-modversions)
                 mode="file"
                 ;;
-            --set-version | -!(-*)S)
+            --set-version | -${noargopts}S)
                 version=${words[i + 1]} # -S is not $prev and not $cur
                 ;;
-            --config | --dirname | --type | -!(-*)[Cdt])
+            --config | --dirname | --type | -${noargopts}[Cdt])
                 ((i++)) # skip option and its argument
                 ;;
             -*)

--- a/completions/mr
+++ b/completions/mr
@@ -64,12 +64,14 @@ _mr()
     fi
 
     # Complete top-level options and commands.
+    local noargopts='!(-*|*[cd]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --config | -!(-*)c)
+        --config | -${noargopts}c)
             _filedir
             return
             ;;
-        --directory | -!(-*)d)
+        --directory | -${noargopts}d)
             _filedir -d
             return
             ;;

--- a/completions/mypy
+++ b/completions/mypy
@@ -8,10 +8,12 @@ _mypy()
     [[ $cword -gt 2 && ${words[cword - 2]} == --shadow-file ]] &&
         prev=--shadow-file # hack; takes two args
 
+    local noargopts='!(-*|*[pcm]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --python-version | --platform | --always-true | \
             --always-false | --@(dis|en)able-error-code | --find-occurrences | \
-            --exclude | --package | --command | -!(-*)[hVpc])
+            --exclude | --package | --command | -${noargopts}[hVpc])
             return
             ;;
         --config-file)
@@ -30,7 +32,7 @@ _mypy()
             _filedir -d
             return
             ;;
-        --custom-typing-module | --module | -!(-*)m)
+        --custom-typing-module | --module | -${noargopts}m)
             _comp_xfunc python modules
             return
             ;;

--- a/completions/mysql
+++ b/completions/mysql
@@ -18,17 +18,19 @@ _mysql()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[uDhSPeI]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;
-        --database | -!(-*)D)
+        --database | -${noargopts}D)
             COMPREPLY=($(compgen -W "$(mysqlshow 2>/dev/null | command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" -- "$cur"))
             return
             ;;
 
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
@@ -41,7 +43,7 @@ _mysql()
             _filedir -d
             return
             ;;
-        --socket | -!(-*)S)
+        --socket | -${noargopts}S)
             _filedir sock
             return
             ;;
@@ -64,10 +66,10 @@ _mysql()
         --port | --set-variable | --ssl-cipher | --connect_timeout | \
             --max_allowed_packet | --prompt | --net_buffer_length | --select_limit | \
             --max_join_size | --server-arg | --debug | --delimiter | --execute | --pager | \
-            -!(-*)[Pe])
+            -${noargopts}[Pe])
             return
             ;;
-        --help | --version | -!(-*)[?IV])
+        --help | --version | -${noargopts}[?IV])
             return
             ;;
     esac

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -5,12 +5,14 @@ _mysqladmin()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[uhScPOiw]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --user | -!(-*)u)
+        --user | -${noargopts}u)
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
@@ -22,7 +24,7 @@ _mysqladmin()
             _comp_xfunc mysql character_sets
             return
             ;;
-        --socket | -!(-*)S)
+        --socket | -${noargopts}S)
             _filedir sock
             return
             ;;
@@ -39,10 +41,10 @@ _mysqladmin()
             return
             ;;
         --count | --port | --set-variable | --sleep | --ssl-cipher | --wait | \
-            --connect_timeout | --shutdown_timeout | -!(-*)[cPOiw])
+            --connect_timeout | --shutdown_timeout | -${noargopts}[cPOiw])
             return
             ;;
-        --help | --version | -!(-*)[?V])
+        --help | --version | -${noargopts}[?V])
             return
             ;;
     esac

--- a/completions/oggdec
+++ b/completions/oggdec
@@ -5,19 +5,21 @@ _oggdec()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[beso]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV]*)
+        --help | --version | -${noargopts}[hV]*)
             return
             ;;
-        --bits | -!(-*)b)
+        --bits | -${noargopts}b)
             COMPREPLY=($(compgen -W "8 16" -- "$cur"))
             return
             ;;
-        --endianness | --sign | -!(-*)[es])
+        --endianness | --sign | -${noargopts}[es])
             COMPREPLY=($(compgen -W "0 1" -- "$cur"))
             return
             ;;
-        --output | -!(-*)o)
+        --output | -${noargopts}o)
             _filedir wav
             return
             ;;

--- a/completions/passwd
+++ b/completions/passwd
@@ -5,9 +5,11 @@ _passwd()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[nxwi]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --minimum | --maximum | --warning | --inactive | --help | --usage | \
-            -!(-*)[nxwi?])
+            -${noargopts}[nxwi?])
             return
             ;;
     esac

--- a/completions/patch
+++ b/completions/patch
@@ -5,20 +5,22 @@ _patch()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[pDBYzgFiorVd]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --strip | --ifdef | --prefix | --basename-prefix | --suffix | --get | \
-            -!(-*)[pDBYzg])
+            -${noargopts}[pDBYzg])
             return
             ;;
-        --fuzz | -!(-*)F)
+        --fuzz | -${noargopts}F)
             COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
             return
             ;;
-        --input | -!(-*)i)
+        --input | -${noargopts}i)
             _filedir '@(?(d)patch|dif?(f))'
             return
             ;;
-        --output | --reject-file | -!(-*)[or])
+        --output | --reject-file | -${noargopts}[or])
             [[ ! $cur || $cur == - ]] && COMPREPLY=(-)
             _filedir
             return
@@ -28,11 +30,11 @@ _patch()
                 -- "$cur"))
             return
             ;;
-        --version-control | -!(-*)V)
+        --version-control | -${noargopts}V)
             COMPREPLY=($(compgen -W 'simple numbered existing' -- "$cur"))
             return
             ;;
-        --directory | -!(-*)d)
+        --directory | -${noargopts}d)
             _filedir -d
             return
             ;;

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -5,19 +5,21 @@ _pgrep()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[cdgJMNstTzFGPuU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --delimiter | --pgroup | --session | --terminal | -!(-*)[cdgJMNstTz])
+        --delimiter | --pgroup | --session | --terminal | -${noargopts}[cdgJMNstTz])
             return
             ;;
         --signal)
             _signals
             return
             ;;
-        --pidfile | -!(-*)F)
+        --pidfile | -${noargopts}F)
             _filedir
             return
             ;;
-        --group | -!(-*)G)
+        --group | -${noargopts}G)
             _gids
             return
             ;;
@@ -25,11 +27,11 @@ _pgrep()
             COMPREPLY=($(compgen -W 'any none' -- "$cur"))
             return
             ;;
-        --parent | --ns | -!(-*)P)
+        --parent | --ns | -${noargopts}P)
             _pids
             return
             ;;
-        --euid | --uid | -!(-*)[uU])
+        --euid | --uid | -${noargopts}[uU])
             _uids
             return
             ;;

--- a/completions/pidof
+++ b/completions/pidof
@@ -5,11 +5,13 @@ _pidof()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[o]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | -V | --version | -!(-*)[hV]*)
+        --help | -V | --version | -${noargopts}[hV]*)
             return
             ;;
-        --omit-pid | -!(-*)o)
+        --omit-pid | -${noargopts}o)
             _pids
             return
             ;;

--- a/completions/psql
+++ b/completions/psql
@@ -23,17 +23,19 @@ _createdb()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[hUOpDET]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --username | --owner | -!(-*)[UO])
+        --username | --owner | -${noargopts}[UO])
             _pg_users
             return
             ;;
         --help | --version | --port | --tablespace | --encoding | --template | \
-            -!(-*)[pDET])
+            -${noargopts}[pDET])
             return
             ;;
     esac
@@ -56,15 +58,17 @@ _createuser()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[pchU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --port | --connection-limit | -!(-*)[pc])
+        --help | --version | --port | --connection-limit | -${noargopts}[pc])
             return
             ;;
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --username | -!(-*)U)
+        --username | -${noargopts}U)
             _pg_users
             return
             ;;
@@ -86,12 +90,14 @@ _dropdb()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[hU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --username | -!(-*)U)
+        --username | -${noargopts}U)
             _pg_users
             return
             ;;
@@ -118,15 +124,17 @@ _dropuser()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[phU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --port | -!(-*)p)
+        --help | --version | --port | -${noargopts}p)
             return
             ;;
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --username | -!(-*)U)
+        --username | -${noargopts}U)
             _pg_users
             return
             ;;
@@ -150,26 +158,28 @@ _psql()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[hUdofLcFpPRTv]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --host | -!(-*)h)
+        --host | -${noargopts}h)
             _known_hosts_real -- "$cur"
             return
             ;;
-        --username | -!(-*)U)
+        --username | -${noargopts}U)
             _pg_users
             return
             ;;
-        --dbname | -!(-*)d)
+        --dbname | -${noargopts}d)
             _pg_databases
             return
             ;;
-        --output | --file | --log-file | -!(-*)[ofL])
+        --output | --file | --log-file | -${noargopts}[ofL])
             _filedir
             return
             ;;
         --help | --version | --command | --field-separator | --port | --pset | \
             --record-separator | --table-attr | --set | --variable | \
-            -!(-*)[?VcFpPRTv])
+            -${noargopts}[?VcFpPRTv])
             return
             ;;
     esac

--- a/completions/pv
+++ b/completions/pv
@@ -5,17 +5,19 @@ _pv()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[VAFDiwHNLBRPd]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --last-written | --format | --delay-start | \
             --interval | --width | --height | --name | --rate-limit | \
-            --buffer-size | -!(-*)[hVAFDiwHNLB])
+            --buffer-size | -${noargopts}[hVAFDiwHNLB])
             return
             ;;
-        --remote | -!(-*)R)
+        --remote | -${noargopts}R)
             _pids
             return
             ;;
-        --pidfile | --watchfd | -!(-*)[Pd])
+        --pidfile | --watchfd | -${noargopts}[Pd])
             _filedir pid
             return
             ;;

--- a/completions/pwgen
+++ b/completions/pwgen
@@ -5,11 +5,13 @@ _pwgen()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[NH]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --num-passwords | --help | -!(-*)[Nh])
+        --num-passwords | --help | -${noargopts}[Nh])
             return
             ;;
-        --sha1 | -!(-*)H)
+        --sha1 | -${noargopts}H)
             _filedir
             return
             ;;

--- a/completions/pylint
+++ b/completions/pylint
@@ -27,6 +27,8 @@ _pylint()
     local python=python
     [[ ${1##*/} == *3* ]] && python=python3
 
+    local noargopts='!(-*|*[edisrjf]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --version | --help | --long-help | --init-hook | \
             --ignore | --evaluation | --max-line-length | \
@@ -42,18 +44,18 @@ _pylint()
             --ignored-classes | --generated-members | \
             --overgeneral-exceptions | --ignore-iface-methods | \
             --defining-attr-methods | --valid-classmethod-first-arg | \
-            --valid-metaclass-classmethod-first-arg | -!(-*)[h])
+            --valid-metaclass-classmethod-first-arg | -${noargopts}[h])
             return
             ;;
         --fail-on | --help-msg)
             _comp_cmd_pylint_message_ids "$1"
             return
             ;;
-        --enable | -!(-*)e)
+        --enable | -${noargopts}e)
             _comp_cmd_pylint_message_ids "$1" Disabled
             return
             ;;
-        --disable | -!(-*)d)
+        --disable | -${noargopts}d)
             _comp_cmd_pylint_message_ids "$1" Enabled
             COMPREPLY+=($(compgen -W 'all' -- "$cur"))
             return
@@ -65,7 +67,7 @@ _pylint()
         --persistent | --include-ids | --symbols | --files-output | \
             --reports | --comment | --ignore-comments | --ignore-docstrings | \
             --ignore-imports | --init-import | --ignore-mixin-members | \
-            --zope | --suggestion-mode | -!(-*)[isr])
+            --zope | --suggestion-mode | -${noargopts}[isr])
             COMPREPLY=($(compgen -W 'yes no' -- "$cur"))
             return
             ;;
@@ -75,7 +77,7 @@ _pylint()
                 _comp_delimited , -W '"${COMPREPLY[@]}"'
             return
             ;;
-        --jobs | -!(-*)j)
+        --jobs | -${noargopts}j)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)}" -- "$cur"))
             return
             ;;
@@ -87,7 +89,7 @@ _pylint()
             ((${#COMPREPLY[@]} == 1)) && COMPREPLY=(${COMPREPLY/#/$prefix})
             return
             ;;
-        --format | -!(-*)f)
+        --format | -${noargopts}f)
             COMPREPLY=($(compgen -W 'text parseable colorized json msvs' \
                 -- "$cur"))
             return

--- a/completions/pytest
+++ b/completions/pytest
@@ -13,9 +13,11 @@ _pytest()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
+    local noargopts='!(-*|*[kmorpWn]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --maxfail | --report | --junit-prefix | --doctest-glob | \
-            -!(-*)[hkmorp])
+            -${noargopts}[hkmorp])
             return
             ;;
         --import-mode)
@@ -77,11 +79,11 @@ _pytest()
             _filedir py
             return
             ;;
-        --pythonwarnings | -!(-*)W)
+        --pythonwarnings | -${noargopts}W)
             _comp_xfunc python warning_actions
             return
             ;;
-        --numprocesses | -!(-*)n)
+        --numprocesses | -${noargopts}n)
             COMPREPLY=($(compgen -W "{1..$(_ncpus)} auto" -- "$cur"))
             return
             ;;

--- a/completions/pytest
+++ b/completions/pytest
@@ -13,7 +13,7 @@ _pytest()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
-    local noargopts='!(-*|*[kmorpWn]*)'
+    local noargopts='!(-*|*[kmorpcWn]*)'
     # shellcheck disable=SC2254
     case $prev in
         --help | --maxfail | --report | --junit-prefix | --doctest-glob | \
@@ -57,7 +57,7 @@ _pytest()
             _filedir log
             return
             ;;
-        --ignore)
+        --ignore | -${noargopts}c)
             _filedir
             return
             ;;

--- a/completions/python
+++ b/completions/python
@@ -29,24 +29,26 @@ _python()
             ;;
     esac
 
+    local noargopts='!(-*|*[cmQWX]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[?hVc])
+        --help | --version | -${noargopts}[?hVc])
             return
             ;;
-        -!(-*)m)
+        -${noargopts}m)
             _comp_xfunc_python_modules "$1"
             return
             ;;
-        -!(-*)Q)
+        -${noargopts}Q)
             COMPREPLY=($(compgen -W "old new warn warnall" -P "$prefix" \
                 -- "$cur"))
             return
             ;;
-        -!(-*)W)
+        -${noargopts}W)
             _comp_xfunc_python_warning_actions
             return
             ;;
-        -!(-*)X)
+        -${noargopts}X)
             COMPREPLY=($(compgen -W "$("$1" -h 2>&1 |
                 awk '$1 == "-X" && $2 ~ /:$/ {
                     sub(":$","",$2); sub("=.*","=",$2); print $2

--- a/completions/querybts
+++ b/completions/querybts
@@ -5,13 +5,15 @@ _querybts()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[Bu]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --bts | -!(-*)B)
+        --bts | -${noargopts}B)
             COMPREPLY=($(compgen -W "debian guug kde mandrake help" \
                 -- "$cur"))
             return
             ;;
-        --ui | --interface | -!(-*)u)
+        --ui | --interface | -${noargopts}u)
             COMPREPLY=($(compgen -W "newt text gnome" -- "$cur"))
             return
             ;;

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -5,20 +5,22 @@ _reportbug()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[CefKHPsoiATjVuQtBS]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --class | --header | --pseudo-header | --mirror | --list-cc | \
             --subject | --http_proxy | --proxy | --email | --realname | \
             --smtpuser | --smtppasswd | --replyto | --reply-to | \
             --justification | --package-version | --body | --body-file | \
             --timeout | --max-attachment-size | --envelope-from | \
-            -!(-*)[CHPsjV])
+            -${noargopts}[CHPsjV])
             return
             ;;
         --filename | --include | --mta | --output | --attach | -[fioA])
             _filedir
             return
             ;;
-        --keyid | -!(-*)K)
+        --keyid | -${noargopts}K)
             COMPREPLY=($(compgen -W '$(IFS=: ; \
                 gpg --list-keys --with-colons 2>/dev/null \
                 | while read -ra row ; do
@@ -27,15 +29,15 @@ _reportbug()
                 done)' -- "$cur"))
             return
             ;;
-        --tag | --ui | --interface | --type | --bts | --severity | --mode | -!(-*)[TutBS])
+        --tag | --ui | --interface | --type | --bts | --severity | --mode | -${noargopts}[TutBS])
             COMPREPLY+=($(
                 compgen -W \
-                    '$("$1" $prev help 2>&1 </dev/null | sed -ne "/^[[:space:]]/p")' \
+                    '$("$1" $prev help 2>&1 | sed -ne "/^[[:space:]]/p")' \
                     -- "$cur"
             ))
             return
             ;;
-        --editor | --mua | --mbox-reader-cmd | -!(-*)e)
+        --editor | --mua | --mbox-reader-cmd | -${noargopts}e)
             compopt -o filenames
             COMPREPLY=($(compgen -c -- "$cur"))
             return

--- a/completions/ri
+++ b/completions/ri
@@ -38,15 +38,17 @@ _ri()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
+    local noargopts='!(-*|*[wfd]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --width | -!(-*)[hw])
+        --help | --width | -${noargopts}[hw])
             return
             ;;
-        --format | -!(-*)f)
+        --format | -${noargopts}f)
             COMPREPLY=($(compgen -W 'ansi bs html rdoc' -- "$cur"))
             return
             ;;
-        --doc-dir | -!(-*)d)
+        --doc-dir | -${noargopts}d)
             _filedir -d
             return
             ;;

--- a/completions/rpm
+++ b/completions/rpm
@@ -67,12 +67,14 @@ _rpm()
         return
     fi
 
+    local noargopts='!(-*|*[rED]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --dbpath | --excludepath | --prefix | --relocate | --root | -!(-*)r)
+        --dbpath | --excludepath | --prefix | --relocate | --root | -${noargopts}r)
             _filedir -d
             return
             ;;
-        --eval | -!(-*)E)
+        --eval | -${noargopts}E)
             _rpm_macros $1
             return
             ;;
@@ -111,7 +113,7 @@ _rpm()
             fi
             return
             ;;
-        --define | --fileid | --hdrid | --pkgid | -!(-*)D)
+        --define | --fileid | --hdrid | --pkgid | -${noargopts}D)
             # argument required but no completions available
             return
             ;;
@@ -245,8 +247,10 @@ _rpmbuild()
     local rpm="${1%build*}"
     [[ $rpm == "$1" ]] || ! type $rpm &>/dev/null && rpm=
 
+    local noargopts='!(-*|*[rED]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --buildroot | --root | --dbpath | -!(-*)r)
+        --buildroot | --root | --dbpath | -${noargopts}r)
             _filedir -d
             return
             ;;
@@ -254,7 +258,7 @@ _rpmbuild()
             _rpm_buildarchs $rpm
             return
             ;;
-        --eval | -!(-*)E)
+        --eval | -${noargopts}E)
             _rpm_macros $rpm
             return
             ;;
@@ -269,7 +273,7 @@ _rpmbuild()
                     command sed -ne 's/^brp-//p')" -- "$cur"))
             fi
             ;;
-        --define | --with | --without | -!(-*)D)
+        --define | --with | --without | -${noargopts}D)
             return
             ;;
     esac

--- a/completions/rsync
+++ b/completions/rsync
@@ -5,6 +5,8 @@ _rsync()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
+    local noargopts='!(-*|*[Te]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --config | --password-file | --include-from | --exclude-from | \
             --files-from | --log-file | --write-batch | --only-write-batch | \
@@ -14,12 +16,12 @@ _rsync()
             return
             ;;
         --temp-dir | --compare-dest | --backup-dir | --partial-dir | \
-            --copy-dest | --link-dest | -!(-*)T)
+            --copy-dest | --link-dest | -${noargopts}T)
             compopt +o nospace
             _filedir -d
             return
             ;;
-        --rsh | -!(-*)e)
+        --rsh | -${noargopts}e)
             compopt +o nospace
             COMPREPLY=($(compgen -W 'rsh ssh' -- "$cur"))
             return

--- a/completions/scrub
+++ b/completions/scrub
@@ -5,18 +5,20 @@ _scrub()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[bsDpX]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --version | --help | --blocksize | --device-size | --dirent | \
-            -!(-*)[vhbsD])
+            -${noargopts}[vhbsD])
             return
             ;;
-        --pattern | -!(-*)p)
+        --pattern | -${noargopts}p)
             COMPREPLY=($(compgen -W '$("$1" --help 2>&1 |
                 awk "/^Available/{flag=1;next}/^ /&&flag{print \$1}")' \
                 -- "$cur"))
             return
             ;;
-        --freespace | -!(-*)X)
+        --freespace | -${noargopts}X)
             _filedir -d
             return
             ;;

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -12,38 +12,40 @@ _shellcheck()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[eifCsoPW]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --version | -!(-*)V*)
+        --version | -${noargopts}V*)
             return
             ;;
-        --exclude | --include | -!(-*)[ei])
+        --exclude | --include | -${noargopts}[ei])
             return
             ;;
-        --format | -!(-*)f)
+        --format | -${noargopts}f)
             local args=$("$1" --format=nonexistent-format /dev/null 2>&1 |
                 command sed -ne '/^Supported formats/,//p' |
                 command sed -ne '/^[[:space:]]/p')
             COMPREPLY=($(compgen -W '$args' -- "$cur"))
             return
             ;;
-        --color | -!(-*)C)
+        --color | -${noargopts}C)
             _shellcheck_optarg "$1" --color
             return
             ;;
-        --shell | -!(-*)s)
+        --shell | -${noargopts}s)
             _shellcheck_optarg "$1" --shell
             return
             ;;
-        --enable | -!(-*)o)
+        --enable | -${noargopts}o)
             COMPREPLY=($(compgen -W 'all' -- "$cur")) # TODO others?
             return
             ;;
-        --source-path | -!(-*)P)
+        --source-path | -${noargopts}P)
             _filedir -d
             COMPREPLY+=($(compgen -W 'SCRIPTDIR' -- "$cur"))
             return
             ;;
-        --wiki-link-count | -!(-*)W)
+        --wiki-link-count | -${noargopts}W)
             return
             ;;
     esac

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -8,18 +8,20 @@ _sitecopy()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[dgrp]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --debug | -!(-*)d)
+        --debug | -${noargopts}d)
             COMPREPLY=($(compgen -W "socket files rcfile ftp http httpbody
                 rsh sftp xml xmlparse cleartext" -- "$cur"))
             compopt -o nospace
             return
             ;;
-        --logfile | --rcfile | -!(-*)[gr])
+        --logfile | --rcfile | -${noargopts}[gr])
             _filedir
             return
             ;;
-        --storepath | -!(-*)p)
+        --storepath | -${noargopts}p)
             _filedir -d
             return
             ;;

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -96,55 +96,57 @@ _smartctl()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[qdTbrnsoSlvFPBt]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --quietmode | -!(-*)q)
+        --quietmode | -${noargopts}q)
             _smartctl_quietmode
             ;;
-        --device | -!(-*)d)
+        --device | -${noargopts}d)
             _smartctl_device
             return
             ;;
-        --tolerance | -!(-*)T)
+        --tolerance | -${noargopts}T)
             _smartctl_tolerance
             return
             ;;
-        --badsum | -!(-*)b)
+        --badsum | -${noargopts}b)
             _smartctl_badsum
             return
             ;;
-        --report | -!(-*)r)
+        --report | -${noargopts}r)
             _smartctl_report
             return
             ;;
-        --nocheck | -!(-*)n)
+        --nocheck | -${noargopts}n)
             _smartctl_powermode
             return
             ;;
-        --smart | --offlineauto | --saveauto | -!(-*)[soS])
+        --smart | --offlineauto | --saveauto | -${noargopts}[soS])
             _smartctl_feature
             return
             ;;
-        --log | -!(-*)l)
+        --log | -${noargopts}l)
             _smartctl_log
             return
             ;;
-        --vendorattribute | -!(-*)v)
+        --vendorattribute | -${noargopts}v)
             _smartctl_vendorattribute
             return
             ;;
-        --firmwarebug | -!(-*)F)
+        --firmwarebug | -${noargopts}F)
             _smartctl_firmwarebug
             return
             ;;
-        --presets | -!(-*)P)
+        --presets | -${noargopts}P)
             _smartctl_presets
             return
             ;;
-        --drivedb | -!(-*)B)
+        --drivedb | -${noargopts}B)
             _smartctl_drivedb
             return
             ;;
-        --test | -!(-*)t)
+        --test | -${noargopts}t)
             _smartctl_test
             return
             ;;

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -44,54 +44,56 @@ _smbclient()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[RtsAlDOTWdLSpMIbUniTcm]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --name-resolve | -!(-*)R)
+        --name-resolve | -${noargopts}R)
             _samba_resolve_order
             return
             ;;
-        -!(-*)t)
+        -${noargopts}t)
             COMPREPLY=($(compgen -W 'SJIS EUC JIS7 JIS8 JUNET HEX CAP' \
                 -- "$cur"))
             return
             ;;
-        --configfile | --authentication-file | -!(-*)[sA])
+        --configfile | --authentication-file | -${noargopts}[sA])
             _filedir
             return
             ;;
-        --log-basename | --directory | -!(-*)[lD])
+        --log-basename | --directory | -${noargopts}[lD])
             _filedir -d
             return
             ;;
-        --socket-options | -!(-*)O)
+        --socket-options | -${noargopts}O)
             _samba_sockopts
             return
             ;;
-        -!(-*)T)
+        -${noargopts}T)
             COMPREPLY=($(compgen -W 'c x I X F b g q r N a' -- "$cur"))
             return
             ;;
-        --workgroup | -!(-*)W)
+        --workgroup | -${noargopts}W)
             _samba_domains
             return
             ;;
-        --debuglevel | -!(-*)d)
+        --debuglevel | -${noargopts}d)
             _samba_debuglevel
             return
             ;;
-        --list | -!(-*)L)
+        --list | -${noargopts}L)
             _samba_hosts
             return
             ;;
-        --signing | -!(-*)S)
+        --signing | -${noargopts}S)
             _samba_signing
             return
             ;;
         --port | --message | --ip-address | --send-buffer | --user | \
             --netbiosname | --scope | --tar | --command | --max-protocol | \
-            -!(-*)[pMIbUniTcm])
+            -${noargopts}[pMIbUniTcm])
             return
             ;;
-        --help | --version | -!(-*)[?V])
+        --help | --version | -${noargopts}[?V])
             return
             ;;
     esac
@@ -110,20 +112,22 @@ _smbget()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[ofdwupb]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --outputfile | --rcfile | -!(-*)[of])
+        --outputfile | --rcfile | -${noargopts}[of])
             _filedir
             return
             ;;
-        --debuglevel | -!(-*)d)
+        --debuglevel | -${noargopts}d)
             _samba_debuglevel
             return
             ;;
-        --workgroup | -!(-*)w)
+        --workgroup | -${noargopts}w)
             _samba_domains
             return
             ;;
-        --username | --password | --blocksize | -!(-*)[upb])
+        --username | --password | --blocksize | -${noargopts}[upb])
             return
             ;;
     esac
@@ -142,16 +146,18 @@ _smbcacls()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[AsldOWDMaSCGniU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --configfile | --authentication-file | -!(-*)[As])
+        --configfile | --authentication-file | -${noargopts}[As])
             _filedir
             return
             ;;
-        --log-basename | -!(-*)l)
+        --log-basename | -${noargopts}l)
             _filedir -d
             return
             ;;
-        --debuglevel | -!(-*)d)
+        --debuglevel | -${noargopts}d)
             _samba_debuglevel
             return
             ;;
@@ -159,16 +165,16 @@ _smbcacls()
             _samba_signing
             return
             ;;
-        --socket-options | -!(-*)O)
+        --socket-options | -${noargopts}O)
             _samba_sockopts
             return
             ;;
-        --workgroup | -!(-*)W)
+        --workgroup | -${noargopts}W)
             _samba_domains
             return
             ;;
         --help | --usage | --delete | --modify | --add | --set | --chown | \
-            --chgrp | --netbiosname | --scope | --user | -!(-*)[?DMaSCGniU])
+            --chgrp | --netbiosname | --scope | --user | -${noargopts}[?DMaSCGniU])
             return
             ;;
     esac
@@ -187,16 +193,18 @@ _smbcquotas()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[sAldUuS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --configfile | --authentication-file | -!(-*)[sA])
+        --configfile | --authentication-file | -${noargopts}[sA])
             _filedir
             return
             ;;
-        --log-basename | -!(-*)l)
+        --log-basename | -${noargopts}l)
             _filedir -d
             return
             ;;
-        --debuglevel | -!(-*)d)
+        --debuglevel | -${noargopts}d)
             _samba_debuglevel
             return
             ;;
@@ -204,7 +212,7 @@ _smbcquotas()
             _samba_signing
             return
             ;;
-        --help | --usage | --user | --set | -!(-*)[?UuS])
+        --help | --usage | --user | --set | -${noargopts}[?UuS])
             return
             ;;
     esac
@@ -289,24 +297,26 @@ _smbtree()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[sAldSU]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --configfile | --authentication-file | -!(-*)[sA])
+        --configfile | --authentication-file | -${noargopts}[sA])
             _filedir
             return
             ;;
-        --log-basename | -!(-*)l)
+        --log-basename | -${noargopts}l)
             _filedir -d
             return
             ;;
-        --debuglevel | -!(-*)d)
+        --debuglevel | -${noargopts}d)
             _samba_debuglevel
             return
             ;;
-        --signing | -!(-*)S)
+        --signing | -${noargopts}S)
             _samba_signing
             return
             ;;
-        --help | --usage | --user | -!(-*)[?U])
+        --help | --usage | --user | -${noargopts}[?U])
             return
             ;;
     esac

--- a/completions/ss
+++ b/completions/ss
@@ -5,21 +5,23 @@ _ss()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[fADF]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
-        --family | -!(-*)f)
+        --family | -${noargopts}f)
             COMPREPLY=($(compgen -W 'unix inet inet6 link netlink' \
                 -- "$cur"))
             return
             ;;
-        --query | -!(-*)A)
+        --query | -${noargopts}A)
             _comp_delimited , -W "$("$1" --help |
                 command sed -e 's/|/ /g' -ne 's/.*QUERY := {\([^}]*\)}.*/\1/p')"
             return
             ;;
-        --diag | --filter | -!(-*)[DF])
+        --diag | --filter | -${noargopts}[DF])
             _filedir
             return
             ;;

--- a/completions/strings
+++ b/completions/strings
@@ -5,22 +5,24 @@ _strings()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[nstTe]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --bytes | --output-separator | -arch | \
-            -!(-*)[hvVns])
+            -${noargopts}[hvVns])
             return
             ;;
-        --radix | -!(-*)t)
+        --radix | -${noargopts}t)
             COMPREPLY=($(compgen -W 'o d x' -- "$cur"))
             return
             ;;
-        --target | -!(-*)T)
+        --target | -${noargopts}T)
             COMPREPLY=($(compgen -W '$(LC_ALL=C "$1" --help 2>/dev/null | \
                 command sed -ne "s/: supported targets: \(.*\)/\1/p")' \
                 -- "$cur"))
             return
             ;;
-        --encoding | -!(-*)e)
+        --encoding | -${noargopts}e)
             COMPREPLY=($(
                 IFS=, compgen -W \
                     '$(LC_ALL=C "$1" --help 2>/dev/null | \

--- a/completions/sudo
+++ b/completions/sudo
@@ -8,6 +8,7 @@ _sudo()
     local i mode=normal
     [[ $1 == *sudoedit ]] && mode=edit
 
+    local noargopts='!(-*|*[uUgCp]*)'
     [[ $mode == normal ]] &&
         for ((i = 1; i <= cword; i++)); do
             if [[ ${words[i]} != -* ]]; then
@@ -16,24 +17,27 @@ _sudo()
                 _comp_command_offset $i
                 return
             fi
-            if [[ ${words[i]} == -@(!(-*)e*|-edit) ]]; then
+            # shellcheck disable=SC2254
+            if [[ ${words[i]} == -@(${noargopts}e*|-edit) ]]; then
                 mode=edit
                 break
             fi
-            [[ ${words[i]} == -@(user|other-user|group|close-from|prompt|!(-*)[uUgCp]) ]] &&
+            # shellcheck disable=SC2254
+            [[ ${words[i]} == -@(user|other-user|group|close-from|prompt|${noargopts}[uUgCp]) ]] &&
                 ((i++))
         done
 
+    # shellcheck disable=SC2254
     case "$prev" in
-        --user | --other-user | -!(-*)[uU])
+        --user | --other-user | -${noargopts}[uU])
             COMPREPLY=($(compgen -u -- "$cur"))
             return
             ;;
-        --group | -!(-*)g)
+        --group | -${noargopts}g)
             COMPREPLY=($(compgen -g -- "$cur"))
             return
             ;;
-        --close-from | --prompt | -!(-*)[Cp])
+        --close-from | --prompt | -${noargopts}[Cp])
             return
             ;;
     esac

--- a/completions/sysctl
+++ b/completions/sysctl
@@ -5,11 +5,13 @@ _sysctl()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[rpf]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --pattern | -!(-*)[hVr])
+        --help | --version | --pattern | -${noargopts}[hVr])
             return
             ;;
-        --load | -!(-*)[pf])
+        --load | -${noargopts}[pf])
             _filedir conf
             return
             ;;

--- a/completions/tar
+++ b/completions/tar
@@ -524,17 +524,19 @@ _gtar()
         # Handle all options *REQUIRING* argument.  Optional arguments are up to
         # user (TODO: is there any sane way to deal with this?).  This case
         # statement successes only if there already is PREV.
+        local noargopts='!(-*|*[TXgCFIfH]*)'
+        # shellcheck disable=SC2254
         case $prev in
             --add-file | --exclude | --exclude-ignore | \
                 --exclude-ignore-recursive | --exclude-tag | \
                 --exclude-tag-all | --exclude-tag-under | --files-from | \
                 --exclude-from | --listed-incremental | --group-map | \
                 --mtime | --owner-map | --volno-file | --newer | \
-                --after-date | --index-file | -!(-*)[TXg])
+                --after-date | --index-file | -${noargopts}[TXg])
                 _filedir
                 break
                 ;;
-            --directory | -!(-*)C)
+            --directory | -${noargopts}C)
                 _filedir -d
                 break
                 ;;
@@ -544,7 +546,7 @@ _gtar()
                 ;;
             --to-command | --info-script | --new-volume-script | \
                 --rmt-command | --rsh-command | --use-compress-program | \
-                -!(-*)[FI])
+                -${noargopts}[FI])
                 compopt -o filenames
                 COMPREPLY=($(compgen -c -- "$cur"))
                 break
@@ -565,11 +567,11 @@ _gtar()
                 COMPREPLY=($(compgen -W 'none name inode' -- "$cur"))
                 break
                 ;;
-            --file | -!(-*)f)
+            --file | -${noargopts}f)
                 __tar_file_option "$ext"
                 break
                 ;;
-            --format | -!(-*)H)
+            --format | -${noargopts}H)
                 COMPREPLY=($(compgen -W 'gnu oldgnu pax posix ustar v7' \
                     -- "$cur"))
                 break
@@ -606,7 +608,7 @@ _gtar()
                 # Most probably, when code goes here, the PREV variable contains
                 # some string from "$long_arg_none" and we want continue.
                 ;;
-            -!(-*)[a-zA-Z0-9?])
+            -${noargopts}[a-zA-Z0-9?])
                 # argument required but no completion yet
                 [[ $short_arg_req =~ ${prev##-} ]] && break
                 ;;

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -5,43 +5,45 @@ _tcpdump()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[rwFVimTzZBcCDEGMsWyjQ]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        -!(-*)[rwFV])
+        -${noargopts}[rwFV])
             _filedir
             return
             ;;
-        --interface | -!(-*)i)
+        --interface | -${noargopts}i)
             _available_interfaces -a
             return
             ;;
-        -!(-*)m)
+        -${noargopts}m)
             _filedir mib
             return
             ;;
-        -!(-*)T)
+        -${noargopts}T)
             COMPREPLY=($(compgen -W 'aodv carp cnfp lmp pgm pgm_zmtp1 radius
                 resp rpc rtcp rtp rtcp snmp tftp vat vxlan wb zmtp1' \
                 -- "$cur"))
             return
             ;;
-        -!(-*)z)
+        -${noargopts}z)
             compopt -o filenames
             COMPREPLY=($(compgen -c -- "$cur"))
             return
             ;;
-        --relinquish-privileges | -!(-*)Z)
+        --relinquish-privileges | -${noargopts}Z)
             _allowed_users
             return
             ;;
-        -!(-*)[BcCDEGMsWy])
+        -${noargopts}[BcCDEGMsWy])
             return
             ;;
-        --time-stamp-type | -!(-*)j)
+        --time-stamp-type | -${noargopts}j)
             COMPREPLY=($(compgen -W 'host host_lowprec host_hiprec adapter
                 adapter_unsynced' -- "$cur"))
             return
             ;;
-        --direction | -!(-*)Q)
+        --direction | -${noargopts}Q)
             COMPREPLY=($(compgen -W 'in out inout' -- "$cur"))
             return
             ;;

--- a/completions/timeout
+++ b/completions/timeout
@@ -5,6 +5,7 @@ _timeout()
     local cur prev words cword split comp_args i found=false
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[ks]*)'
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* && ${COMP_WORDS[i - 1]} != = ]]; then
             if $found; then
@@ -13,14 +14,16 @@ _timeout()
             fi
             found=true
         fi
-        [[ ${COMP_WORDS[i]} == -@(-kill-after|-signal|!(-*)[ks]) ]] && ((i++))
+        # shellcheck disable=SC2254
+        [[ ${COMP_WORDS[i]} == -@(-kill-after|-signal|${noargopts}[ks]) ]] && ((i++))
     done
 
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --kill-after | -!(-*)k)
+        --help | --version | --kill-after | -${noargopts}k)
             return
             ;;
-        --signal | -!(-*)s)
+        --signal | -${noargopts}s)
             _signals
             return
             ;;

--- a/completions/tox
+++ b/completions/tox
@@ -11,12 +11,14 @@ _tox()
         return
     fi
 
+    local noargopts='!(-*|*[nice]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --help | --version | --num | --index-url | --hashseed | --force-dep | \
-            -!(-*)[hni])
+            -${noargopts}[hni])
             return
             ;;
-        -!(-*)c)
+        -${noargopts}c)
             _filedir ini
             return
             ;;
@@ -24,7 +26,7 @@ _tox()
             _filedir
             return
             ;;
-        -!(-*)e)
+        -${noargopts}e)
             local envs=$(
                 {
                     "$1" --listenvs-all || "$1" --listenvs

--- a/completions/tree
+++ b/completions/tree
@@ -5,15 +5,17 @@ _comp_cmd_tree()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[LPIHTo]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        -!(-*)[LPIHT] | --filelimit | --timefmt | --help | --version)
+        -${noargopts}[LPIHT] | --filelimit | --timefmt | --help | --version)
             return
             ;;
         --charset)
             _comp_xfunc iconv charsets
             return
             ;;
-        -!(-*)o)
+        -${noargopts}o)
             _filedir
             return
             ;;

--- a/completions/truncate
+++ b/completions/truncate
@@ -5,11 +5,13 @@ _comp_cmd_truncate()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[sr]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        -!(-*)s | --size | --help | --version)
+        -${noargopts}s | --size | --help | --version)
             return
             ;;
-        -!(-*)r | --reference)
+        -${noargopts}r | --reference)
             _filedir
             return
             ;;

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -5,15 +5,17 @@ _unpack200()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[Hl]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[?hVJ])
+        --help | --version | -${noargopts}[?hVJ])
             return
             ;;
-        --deflate-hint | -!(-*)H)
+        --deflate-hint | -${noargopts}H)
             COMPREPLY=($(compgen -W 'true false keep' -- "$cur"))
             return
             ;;
-        --log-file | -!(-*)l)
+        --log-file | -${noargopts}l)
             COMPREPLY=($(compgen -W '-' -- "$cur"))
             _filedir log
             return

--- a/completions/useradd
+++ b/completions/useradd
@@ -17,31 +17,33 @@ _useradd()
         [[ $word != -@(R|-root) ]] || chroot=
     done
 
+    local noargopts='!(-*|*[cefKpubdkRgGZs]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --comment | --help | --expiredate | --inactive | --key | --password | \
-            --uid | -!(-*)[chefKpu])
+            --uid | -${noargopts}[chefKpu])
             return
             ;;
-        --base-dir | --home-dir | --skel | --root | -!(-*)[bdkR])
+        --base-dir | --home-dir | --skel | --root | -${noargopts}[bdkR])
             _filedir -d
             return
             ;;
-        --gid | -!(-*)g)
+        --gid | -${noargopts}g)
             _gids
             COMPREPLY+=($(compgen -g))
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
-        --groups | -!(-*)G)
+        --groups | -${noargopts}G)
             _comp_delimited , -g
             return
             ;;
-        --selinux-user | -!(-*)Z)
+        --selinux-user | -${noargopts}Z)
             _comp_selinux_users
             return
             ;;
-        --shell | -!(-*)s)
+        --shell | -${noargopts}s)
             _shells "${chroot-}"
             return
             ;;

--- a/completions/userdel
+++ b/completions/userdel
@@ -5,11 +5,13 @@ _userdel()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[R]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | -!(-*)h)
+        --help | -${noargopts}h)
             return
             ;;
-        --root | -!(-*)R)
+        --root | -${noargopts}R)
             _filedir -d
             return
             ;;

--- a/completions/usermod
+++ b/completions/usermod
@@ -17,31 +17,33 @@ _usermod()
         [[ $word != -@(R|-root) ]] || chroot=
     done
 
+    local noargopts='!(-*|*[cdeflpugGRZs]*)'
+    # shellcheck disable=SC2254
     case $prev in
         --comment | --home | --expiredate | --inactive | --help | --login | \
-            --password | --uid | -!(-*)[cdefhlpu])
+            --password | --uid | -${noargopts}[cdefhlpu])
             return
             ;;
-        --gid | -!(-*)g)
+        --gid | -${noargopts}g)
             _gids
             COMPREPLY+=($(compgen -g))
             ((${#COMPREPLY[@]})) &&
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
             return
             ;;
-        --groups | -!(-*)G)
+        --groups | -${noargopts}G)
             _comp_delimited , -g
             return
             ;;
-        --root | -!(-*)R)
+        --root | -${noargopts}R)
             _filedir -d
             return
             ;;
-        --selinux-user | -!(-*)Z)
+        --selinux-user | -${noargopts}Z)
             _comp_selinux_users
             return
             ;;
-        --shell | -!(-*)s)
+        --shell | -${noargopts}s)
             _shells "${chroot-}"
             return
             ;;

--- a/completions/vipw
+++ b/completions/vipw
@@ -5,11 +5,13 @@ _vipw()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[R]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | -!(-*)h)
+        --help | -${noargopts}h)
             return
             ;;
-        --root | -!(-*)R | -d)
+        --root | -${noargopts}R | -d)
             _filedir -d
             return
             ;;

--- a/completions/vmstat
+++ b/completions/vmstat
@@ -5,11 +5,13 @@ _vmstat()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local noargopts='!(-*|*[cMNnwpS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | --partition | -!(-*)[hVcMNnwp])
+        --help | --version | --partition | -${noargopts}[hVcMNnwp])
             return
             ;;
-        --unit | -!(-*)S)
+        --unit | -${noargopts}S)
             [[ $OSTYPE == *linux* ]] &&
                 COMPREPLY=($(compgen -W 'k K m M' -- "$cur"))
             return

--- a/completions/watch
+++ b/completions/watch
@@ -8,12 +8,14 @@ _watch()
     _comp_initialize -s -- "$@" || return
 
     local offset=0 i
+    local noargopts='!(-*|*[dn]*)'
+    # shellcheck disable=SC2254
     for ((i = 1; i <= cword; i++)); do
         case ${words[i]} in
-            --help | --version | -!(-*)h)
+            --help | --version | -${noargopts}h)
                 return
                 ;;
-            --interval | -!(-*)n)
+            --interval | -${noargopts}n)
                 ((i++))
                 continue
                 ;;
@@ -30,13 +32,14 @@ _watch()
         return
     fi
 
+    # shellcheck disable=SC2254
     case $prev in
-        --differences | -!(-*)d)
+        --differences | -${noargopts}d)
             [[ $cur != -* ]] &&
                 COMPREPLY=($(compgen -W 'cumulative' -- "$cur"))
             return
             ;;
-        --interval | -!(-*)n)
+        --interval | -${noargopts}n)
             return
             ;;
     esac

--- a/completions/wget
+++ b/completions/wget
@@ -5,8 +5,10 @@ _wget()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[DPoaOitTwlQeBUARIX]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --version | --help | -!(-*)[hV])
+        --version | --help | -${noargopts}[hV])
             return
             ;;
         --progress)
@@ -17,7 +19,7 @@ _wget()
             _ip_addresses
             return
             ;;
-        --domains | --exclude-domains | -!(-*)D)
+        --domains | --exclude-domains | -${noargopts}D)
             _known_hosts_real -- "$cur"
             return
             ;;
@@ -60,18 +62,18 @@ _wget()
             COMPREPLY=($(compgen -W 'IPv4 IPv6 none' -- "$cur"))
             return
             ;;
-        --directory-prefix | --ca-directory | --warc-tempdir | -!(-*)P)
+        --directory-prefix | --ca-directory | --warc-tempdir | -${noargopts}P)
             _filedir -d
             return
             ;;
         --output-file | --append-output | --config | --load-cookies | \
             --save-cookies | --post-file | --certificate | --ca-certificate | \
             --private-key | --random-file | --egd-file | --warc-file | \
-            --warc-dedup | -!(-*)[oa])
+            --warc-dedup | -${noargopts}[oa])
             _filedir
             return
             ;;
-        --output-document | --input-file | -!(-*)[Oi])
+        --output-document | --input-file | -${noargopts}[Oi])
             _filedir && [[ $cur == - || ! $cur ]] && COMPREPLY+=(-)
             return
             ;;
@@ -100,13 +102,13 @@ _wget()
             ;;
         --tries | --timeout | --dns-timeout | --connect-timeout | \
             --read-timeout | --wait | --waitretry | --cut-dirs | \
-            --max-redirect | --level | -!(-*)[tTwl])
+            --max-redirect | --level | -${noargopts}[tTwl])
             # expect integer number
             COMPREPLY+=($(compgen -P "$cur" -W "{0..9}"))
             compopt -o nospace
             return
             ;;
-        --quota | --limit-rate | --warc-max-size | -!(-*)Q)
+        --quota | --limit-rate | --warc-max-size | -${noargopts}Q)
             # expect size
             if [[ $cur == *[km] ]]; then
                 COMPREPLY=($(compgen -W "$cur"))
@@ -143,7 +145,7 @@ _wget()
             type -P xauth &>/dev/null && _comp_xfunc iconv charsets
             return
             ;;
-        --execute | -!(-*)e)
+        --execute | -${noargopts}e)
             return # TODO base=STR
             ;;
         --report-speed)
@@ -158,7 +160,7 @@ _wget()
             --proxy-password | --default-page | --referer | --user-agent | \
             --post-data | --warc-header | --accept | --reject | \
             --accept-regex | --reject-regex | --include-directories | \
-            --exclude-directories | -!(-*)[BUARIX])
+            --exclude-directories | -${noargopts}[BUARIX])
             # argument required but no completions available
             return
             ;;

--- a/completions/wol
+++ b/completions/wol
@@ -5,11 +5,13 @@ _wol()
     local cur prev words cword split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
+    local noargopts='!(-*|*[pwhif]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --version | --help | --port | --passwd | --wait | -!(-*)[Vpw])
+        --version | --help | --port | --passwd | --wait | -${noargopts}[Vpw])
             return
             ;;
-        --host | --ipaddr | -!(-*)[hi])
+        --host | --ipaddr | -${noargopts}[hi])
             # Broadcast addresses
             local PATH=$PATH:/sbin
             COMPREPLY=($({
@@ -22,7 +24,7 @@ _wol()
             _known_hosts_real -- "$cur"
             return
             ;;
-        --file | -!(-*)f)
+        --file | -${noargopts}f)
             _filedir
             return
             ;;

--- a/completions/xmms
+++ b/completions/xmms
@@ -5,11 +5,13 @@ _xmms()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[SRA]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --version | -!(-*)[hv])
+        --help | --version | -${noargopts}[hv])
             return
             ;;
-        --toggle-shuffle | --toggle-repeat | --toggle-advance | -!(-*)[SRA])
+        --toggle-shuffle | --toggle-repeat | --toggle-advance | -${noargopts}[SRA])
             COMPREPLY=($(compgen -W 'on off' -- "$cur"))
             return
             ;;

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -5,20 +5,23 @@ _xvfb_run()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*[npsef]*)'
     local i
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* ]]; then
             _comp_command_offset $i
             return
         fi
-        [[ ${COMP_WORDS[i]} == -!(-*)[npsef] ]] && ((i++))
+        # shellcheck disable=SC2254
+        [[ ${COMP_WORDS[i]} == -${noargopts}[npsef] ]] && ((i++))
     done
 
+    # shellcheck disable=SC2254
     case $prev in
-        --help | --server-num | --xauth-protocol | --server-args | -!(-*)[hnps])
+        --help | --server-num | --xauth-protocol | --server-args | -${noargopts}[hnps])
             return
             ;;
-        --error-file | --auth-file | -!(-*)[ef])
+        --error-file | --auth-file | -${noargopts}[ef])
             _filedir
             return
             ;;

--- a/completions/xz
+++ b/completions/xz
@@ -7,31 +7,33 @@ _xz()
 
     local xspec="*.@(xz|lzma|txz|tlz)"
 
+    local noargopts='!(-*|*[CFTMS]*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --decompress | --list | --test | -!(-*)[dlt]*)
+        --decompress | --list | --test | -${noargopts}[dlt]*)
             xspec="!"$xspec
             ;;
         --files | --files0)
             _filedir
             return
             ;;
-        --check | -!(-*)C)
+        --check | -${noargopts}C)
             COMPREPLY=($(compgen -W 'crc32 crc64 sha256 none' -- "$cur"))
             return
             ;;
-        --format | -!(-*)F)
+        --format | -${noargopts}F)
             COMPREPLY=($(compgen -W 'auto xz lzma raw' -- "$cur"))
             return
             ;;
-        --threads | -!(-*)T)
+        --threads | -${noargopts}T)
             COMPREPLY=($(compgen -W "{0..$(_ncpus)}" -- "$cur"))
             return
             ;;
         --memlimit | --memlimit-compress | --memlimit-decompress | --memory | \
-            --suffix | --delta | --lzma1 | --lzma2 | -!(-*)[MS])
+            --suffix | --delta | --lzma1 | --lzma2 | -${noargopts}[MS])
             return
             ;;
-        --help | --long-help | --version | --info-memory | -!(-*)[hHV])
+        --help | --long-help | --version | --info-memory | -${noargopts}[hHV])
             return
             ;;
     esac

--- a/completions/xzdec
+++ b/completions/xzdec
@@ -5,11 +5,13 @@ _xzdec()
     local cur prev words cword split comp_args
     _comp_initialize -s -- "$@" || return
 
+    local noargopts='!(-*|*M*)'
+    # shellcheck disable=SC2254
     case $prev in
-        --memory | -!(-*)M)
+        --memory | -${noargopts}M)
             return
             ;;
-        --help | --version | -!(-*)[hV])
+        --help | --version | -${noargopts}[hV])
             return
             ;;
     esac


### PR DESCRIPTION
I'm not sure if this is what was intended, but this is a possible fix to https://github.com/scop/bash-completion/pull/852#discussion_r1052164007 (which is causing the test failures in #861 and #546). This properly handles the completion of the form `-oOPTARG [TAB]`, yet this does not handle the completion of the form `-oOPTAR[TAB]`.

I also thought about the possibility of modifying `__reassemble_comp_words_by_ref` so that `-o` and `OPTARG` in a single word `-oOPTARG` would be generated as separate words in `words`, but this can make the processing more complicated. For example, we need to prefix `-o` for the completion of `OPTARG` if `-o` and `OPTARG` originally come from a single word, etc.

**Edit**:

- Commit 1fcbe442aecc61686901b0f375dd9302ca0dd344 is an additional change to the `pytest` completion.