### PR TITLE
feat(jq): support jsonl files as well as json

### DIFF
--- a/completions/jq
+++ b/completions/jq
@@ -31,7 +31,7 @@ _jq()
                 return
                 ;;
             --slurpfile | --argfile)
-                _filedir json
+                _filedir 'json?(l)'
                 return
                 ;;
         esac
@@ -72,7 +72,7 @@ _jq()
     # 1st arg is filter
     ((args == 1)) && return
     # 2... are input files
-    _filedir json
+    _filedir 'json?(l)'
 
 } &&
     complete -F _jq jq


### PR DESCRIPTION
`jq` support `jsonl` files just as well as plain JSON, so this just adds support for that file extension. This follows the pattern I saw in other completions, though it is my first commit here, so just let me know if something is off (or change it). 

I am not sure this counts as a "feature" but no other prefix seemed obviously appropriate.