### PR TITLE
feat(openssl): recognize `storeutl`

### DIFF
--- a/completions/openssl
+++ b/completions/openssl
@@ -45,7 +45,7 @@ _openssl()
     commands='asn1parse ca ciphers crl crl2pkcs7 dgst dh dhparam dsa dsaparam
         ec ecparam enc engine errstr gendh gendsa genrsa nseq ocsp passwd
         pkcs12 pkcs7 pkcs8 prime rand req rsa rsautl s_client s_server s_time
-        sess_id smime speed spkac verify version x509 md2 md4 md5 rmd160 sha
+        sess_id smime speed spkac storeutl verify version x509 md2 md4 md5 rmd160 sha
         sha1 aes-128-cbc aes-128-ecb aes-192-cbc aes-192-ecb aes-256-cbc
         aes-256-ecb base64 bf bf-cbc bf-cfb bf-ecb bf-ofb camellia-128-cbc
         camellia-128-ecb camellia-192-cbc camellia-192-ecb camellia-256-cbc

--- a/completions/openssl
+++ b/completions/openssl
@@ -45,8 +45,8 @@ _openssl()
     commands='asn1parse ca ciphers crl crl2pkcs7 dgst dh dhparam dsa dsaparam
         ec ecparam enc engine errstr gendh gendsa genrsa nseq ocsp passwd
         pkcs12 pkcs7 pkcs8 prime rand req rsa rsautl s_client s_server s_time
-        sess_id smime speed spkac storeutl verify version x509 md2 md4 md5 rmd160 sha
-        sha1 aes-128-cbc aes-128-ecb aes-192-cbc aes-192-ecb aes-256-cbc
+        sess_id smime speed spkac storeutl verify version x509 md2 md4 md5 rmd160
+        sha sha1 aes-128-cbc aes-128-ecb aes-192-cbc aes-192-ecb aes-256-cbc
         aes-256-ecb base64 bf bf-cbc bf-cfb bf-ecb bf-ofb camellia-128-cbc
         camellia-128-ecb camellia-192-cbc camellia-192-ecb camellia-256-cbc
         camellia-256-ecb cast cast-cbc cast5-cbc cast5-cfb cast5-ecb cast5-ofb


### PR DESCRIPTION
Add `storeutl` to commands list. [Man page](https://www.openssl.org/docs/man1.1.1/man1/openssl-storeutl.html) says this command was added in OpenSSL 1.1.1.