### PR TITLE
fix(man,info): avoid unexpected code execution and add failglob fixes

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -580,7 +580,8 @@ _comp__get_cword_at_cursor()
         ((index < 0)) && index=0
     fi
 
-    local "$2" "$3" "$4" && _comp_upvars -a${#words[@]} "$2" ${words+"${words[@]}"} \
+    local IFS=$' \t\n'
+    local "$2" "$3" "$4" && _comp_upvars -a${#words[@]} "$2" ${words[@]+"${words[@]}"} \
         -v "$3" "$cword" -v "$4" "${cur:0:index}"
 }
 

--- a/bash_completion
+++ b/bash_completion
@@ -655,19 +655,19 @@ _comp_get_words()
 
     [[ $vcur ]] && {
         upvars+=("$vcur")
-        upargs+=(-v $vcur "$cur")
+        upargs+=(-v "$vcur" "$cur")
     }
     [[ $vcword ]] && {
         upvars+=("$vcword")
-        upargs+=(-v $vcword "$cword")
+        upargs+=(-v "$vcword" "$cword")
     }
     [[ $vprev && $cword -ge 1 ]] && {
         upvars+=("$vprev")
-        upargs+=(-v $vprev "${words[cword - 1]}")
+        upargs+=(-v "$vprev" "${words[cword - 1]}")
     }
     [[ $vwords ]] && {
         upvars+=("$vwords")
-        upargs+=(-a${#words[@]} $vwords ${words+"${words[@]}"})
+        upargs+=(-a"${#words[@]}" "$vwords" ${words+"${words[@]}"})
     }
 
     ((${#upvars[@]})) && local "${upvars[@]}" && _comp_upvars "${upargs[@]}"

--- a/completions/info
+++ b/completions/info
@@ -49,26 +49,26 @@ _info()
         infopath=$INFOPATH
     fi
 
-    infopath=$infopath:
-    if [[ $cur ]]; then
-        infopath="${infopath//://$cur* }"
-    else
-        infopath="${infopath//:// }"
+    _comp_split -F : infopath "$infopath"
+    if ((${#infopath[@]})); then
+        infopath=("${infopath[@]/%//$cur*}")
+        local IFS=
+        _comp_expand_glob COMPREPLY '${infopath[@]}'
+        _comp_unlocal IFS
+
+        if ((${#COMPREPLY[@]})); then
+            # weed out directory path names and paths to info pages
+            COMPREPLY=(${COMPREPLY[@]##*/?(:)})
+            # weed out info dir file
+            for i in ${!COMPREPLY[*]}; do
+                [[ ${COMPREPLY[i]} == dir ]] && unset -v 'COMPREPLY[i]'
+            done
+            # strip suffix from info pages
+            COMPREPLY=(${COMPREPLY[@]%.@(gz|bz2|xz|lzma)})
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
+        fi
     fi
-
-    # redirect stderr for when path doesn't exist
-    COMPREPLY=($(eval command ls "$infopath" 2>/dev/null))
-    # weed out directory path names and paths to info pages
-    COMPREPLY=(${COMPREPLY[@]##*/?(:)})
-    # weed out info dir file
-    for i in ${!COMPREPLY[*]}; do
-        [[ ${COMPREPLY[i]} == dir ]] && unset -v 'COMPREPLY[i]'
-    done
-    # strip suffix from info pages
-    COMPREPLY=(${COMPREPLY[@]%.@(gz|bz2|xz|lzma)})
-    ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
-
 } &&
     complete -F _info info pinfo
 

--- a/completions/info
+++ b/completions/info
@@ -57,16 +57,13 @@ _info()
         _comp_unlocal IFS
 
         if ((${#COMPREPLY[@]})); then
-            # weed out directory path names and paths to info pages
-            COMPREPLY=(${COMPREPLY[@]##*/?(:)})
-            # weed out info dir file
-            for i in ${!COMPREPLY[*]}; do
-                [[ ${COMPREPLY[i]} == dir ]] && unset -v 'COMPREPLY[i]'
-            done
+            # weed out directory path names and paths to info pages (empty
+            # elements will be removed by the later `compgen -X ''`)
+            COMPREPLY=("${COMPREPLY[@]##*/?(:)}")
             # strip suffix from info pages
-            COMPREPLY=(${COMPREPLY[@]%.@(gz|bz2|xz|lzma)})
-            ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
+            COMPREPLY=("${COMPREPLY[@]%.@(gz|bz2|xz|lzma)}")
+            # weed out info dir file with -X 'dir'
+            _comp_split -l COMPREPLY "$(compgen -W '"${COMPREPLY[@]%.*}"' -X '@(|dir)' -- "${cur//\\\\/}")"
         fi
     fi
 } &&

--- a/completions/man
+++ b/completions/man
@@ -77,27 +77,22 @@ _man()
     # shellcheck disable=SC2053
     [[ $prev == $mansect ]] && sect=$prev || sect='*'
 
-    manpath=$manpath:
-    if [[ $cur ]]; then
-        manpath="${manpath//://*man$sect/$cur* } ${manpath//://*cat$sect/$cur* }"
-    else
-        manpath="${manpath//://*man$sect/ } ${manpath//://*cat$sect/ }"
-    fi
+    _comp_split -F : manpath "$manpath"
+    if ((${#manpath[@]})); then
+        manpath=("${manpath[@]/%//*man$sect/$cur*}" "${manpath[@]/%//*cat$sect/$cur*}")
+        local IFS=
+        _comp_expand_glob COMPREPLY '${manpath[@]}'
+        _comp_unlocal IFS
 
-    local IFS=$' \t\n' reset=$(shopt -p failglob)
-    shopt -u failglob
-    # redirect stderr for when path doesn't exist
-    COMPREPLY=($(eval command ls "$manpath" 2>/dev/null))
-    $reset
-
-    if ((${#COMPREPLY[@]} != 0)); then
-        # weed out directory path names and paths to man pages
-        COMPREPLY=(${COMPREPLY[@]##*/?(:)})
-        # strip suffix from man pages
-        ((${#COMPREPLY[@]})) &&
-            COMPREPLY=(${COMPREPLY[@]%$comprsuffix})
-        ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
+        if ((${#COMPREPLY[@]} != 0)); then
+            # weed out directory path names and paths to man pages
+            COMPREPLY=(${COMPREPLY[@]##*/?(:)})
+            # strip suffix from man pages
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=(${COMPREPLY[@]%$comprsuffix})
+            ((${#COMPREPLY[@]})) &&
+                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
+        fi
     fi
 
     # shellcheck disable=SC2053

--- a/completions/man
+++ b/completions/man
@@ -85,13 +85,12 @@ _man()
         _comp_unlocal IFS
 
         if ((${#COMPREPLY[@]} != 0)); then
-            # weed out directory path names and paths to man pages
-            COMPREPLY=(${COMPREPLY[@]##*/?(:)})
+            # weed out directory path names and paths to man pages (empty
+            # elements will be removed by the later `compgen -X ''`)
+            COMPREPLY=("${COMPREPLY[@]##*/?(:)}")
             # strip suffix from man pages
-            ((${#COMPREPLY[@]})) &&
-                COMPREPLY=(${COMPREPLY[@]%$comprsuffix})
-            ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%.*}"' -- "${cur//\\\\/}"))
+            COMPREPLY=("${COMPREPLY[@]%$comprsuffix}")
+            _comp_split -l COMPREPLY "$(compgen -W '"${COMPREPLY[@]%.*}"' -X '' -- "${cur//\\\\/}")"
         fi
     fi
 

--- a/completions/ri
+++ b/completions/ri
@@ -3,7 +3,7 @@
 
 _ri_get_methods()
 {
-    local regex
+    local regex IFS=$' \t\n'
 
     if [[ $ri_version == integrated ]]; then
         if [[ ! $separator ]]; then

--- a/test/t/test_info.py
+++ b/test/t/test_info.py
@@ -10,3 +10,11 @@ class TestInfo:
     @pytest.mark.complete("info -", require_cmd=True)
     def test_2(self, completion):
         assert completion
+
+    @pytest.mark.complete(
+        "info nonexistent-nam",
+        env=dict(INFOPATH="'$(echo malicious code >/dev/tty)'"),
+    )
+    def test_infopath_code_injection(self, completion):
+        # no completion, no space appended
+        assert not completion

--- a/test/t/test_man.py
+++ b/test/t/test_man.py
@@ -148,3 +148,11 @@ class TestMan:
     )
     def test_zstd_arbitrary_sectsuffix(self, completion):
         assert completion == "e"
+
+    @pytest.mark.complete(
+        "man bash-completion-testcas",
+        env=dict(MANPATH="'$(echo malicious code >/dev/tty)'"),
+    )
+    def test_manpath_code_injection(self, completion):
+        # no completion, no space appended
+        assert not completion


### PR DESCRIPTION
For the problem of the code execution, see the test 74d837e456a7be230908b52de098011db2823ef6. The change of the fix is explained in the commit message of 8b12bf82c27bd7085f2249adea873c6a2761871b. The third commit e7e84d475b3497142d44446c0dbd7d42f0e5e87b contains fixes for failglob, IFS, etc., and refactoring.