### PR TITLE
test(runLint): add check for touching POSIX mode

### DIFF
--- a/test/runLint
+++ b/test/runLint
@@ -52,3 +52,6 @@ filter_out='^(test/|bash_completion\.sh)' gitgrep ' \[ ' \
     'use [[ ]] instead of [ ]'
 
 gitgrep $cmdstart'unset [^-]' 'Explicitly specify "unset -v/-f"'
+
+gitgrep $cmdstart'((set|shopt)\s+[+-][a-z]+\s+posix\b|(local\s+)?POSIXLY_CORRECT\b)' \
+    'fiddling with posix mode breaks keybindings with some bash versions'


### PR DESCRIPTION
Problematic because it can cause keybindings to change.

https://github.com/scop/bash-completion/issues/190

As we are not running `runLint` automatically and we aren't clean per its checks anyway, this won't be catching all of it. But I guess it's better than nothing.