### PR TITLE
perf(__parse_options): do not set noglob inside __parse_options

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1005,10 +1005,7 @@ __parse_options()
 
     # Take first found long option, or first one (short) if not found.
     option=
-    local reset=$(shopt -po noglob)
-    set -o noglob
     local -a array=($1)
-    $reset
     for i in "${array[@]}"; do
         case "$i" in
             ---*) break ;;


### PR DESCRIPTION
noglob is already set in _parse_help and _parse_usage (the only functions that are calling __parse_options), thus setting it in __parse_options is redundant.

`reset=$(shopt -po noglob)` seems to result in subshell creation, which can take significant time in some cases (in my case, the problem was due to huge history list). Since we create this subshell for every line of help output, overhead quickly adds up.

On my machine, this change cuts completion generation time for rsync from ~270ms to ~30ms.