### PR TITLE
refactor: rename `_quote_readline_by_ref => _comp_quote_compgen`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -135,14 +135,6 @@ _comp_quote()
     ret=\'${1//\'/\'\\\'\'}\'
 }
 
-# @see _comp_quote_compgen()
-quote_readline()
-{
-    local ret
-    _comp_quote_compgen "$1"
-    printf %s "$ret"
-} # quote_readline()
-
 # shellcheck disable=SC1003
 _comp_dequote__initialize()
 {
@@ -2360,11 +2352,15 @@ _filedir_xspec()
 
     _tilde "$cur" || return
 
+    local ret
+    _comp_quote_compgen "$cur"
+    local quoted=$ret
+
     local IFS=$'\n' xspec=${_xspecs[${1##*/}]} tmp
     local -a toks
 
     toks=($(
-        compgen -d -- "$(quote_readline "$cur")" | {
+        compgen -d -- "$quoted" | {
             while read -r tmp; do
                 printf '%s\n' "$tmp"
             done
@@ -2383,7 +2379,7 @@ _filedir_xspec()
     xspec="$matchop($xspec|${xspec^^})"
 
     toks+=($(
-        eval compgen -f -X "'!$xspec'" -- '$(quote_readline "$cur")' | {
+        eval compgen -f -X "'!$xspec'" -- '$quoted' | {
             while read -r tmp; do
                 [[ $tmp ]] && printf '%s\n' "$tmp"
             done
@@ -2395,7 +2391,7 @@ _filedir_xspec()
         ${#toks[@]} -lt 1 ]] && {
         local reset=$(shopt -po noglob)
         set -o noglob
-        toks+=($(compgen -f -- "$(quote_readline "$cur")"))
+        toks+=($(compgen -f -- "$quoted"))
         IFS=' '
         $reset
         IFS=$'\n'

--- a/bash_completion
+++ b/bash_completion
@@ -135,11 +135,11 @@ _comp_quote()
     ret=\'${1//\'/\'\\\'\'}\'
 }
 
-# @see _quote_readline_by_ref()
+# @see _comp_quote_compgen()
 quote_readline()
 {
     local ret
-    _quote_readline_by_ref "$1" ret
+    _comp_quote_compgen "$1" ret
     printf %s "$ret"
 } # quote_readline()
 
@@ -637,7 +637,7 @@ __ltrim_colon_completions()
 # - https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01944.html
 # @param $1  Argument to quote
 # @param $2  Name of variable to return result to
-_quote_readline_by_ref()
+_comp_quote_compgen()
 {
     if [[ $1 == \'* ]]; then
         # Leave out first character
@@ -656,7 +656,7 @@ _quote_readline_by_ref()
             local "$2" && _comp_upvars -v "$2" "$value"
         fi
     fi
-} # _quote_readline_by_ref()
+} # _comp_quote_compgen()
 
 # This function performs file and directory completion. It's better than
 # simply using 'compgen -f', because it honours spaces in filenames.
@@ -682,7 +682,7 @@ _filedir()
         IFS=$'\n'
     else
         local quoted
-        _quote_readline_by_ref "${cur-}" quoted
+        _comp_quote_compgen "${cur-}" quoted
 
         # Munge xspec to contain uppercase version too
         # https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00036.html

--- a/bash_completion
+++ b/bash_completion
@@ -139,7 +139,7 @@ _comp_quote()
 quote_readline()
 {
     local ret
-    _comp_quote_compgen "$1" ret
+    _comp_quote_compgen "$1"
     printf %s "$ret"
 } # quote_readline()
 
@@ -624,7 +624,7 @@ __ltrim_colon_completions()
 
 # This function quotes the argument in a way so that readline dequoting
 # results in the original argument.  This is necessary for at least
-# `compgen' which requires its arguments quoted/escaped:
+# `compgen` which requires its arguments quoted/escaped:
 #
 #     $ ls "a'b/"
 #     c
@@ -635,25 +635,25 @@ __ltrim_colon_completions()
 # See also:
 # - https://lists.gnu.org/archive/html/bug-bash/2009-03/msg00155.html
 # - https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01944.html
-# @param $1  Argument to quote
-# @param $2  Name of variable to return result to
+# @param $1      Argument to quote
+# @var[out] ret  Quoted result is stored in this variable
+# shellcheck disable=SC2178 # The assignment is not intended for the global "ret"
 _comp_quote_compgen()
 {
     if [[ $1 == \'* ]]; then
         # Leave out first character
-        printf -v "$2" %s "${1:1}"
+        ret=${1:1}
     else
-        printf -v "$2" %q "$1"
+        printf -v ret %q "$1"
 
         # If result becomes quoted like this: $'string', re-evaluate in order
         # to drop the additional quoting.  See also:
         # https://www.mail-archive.com/bash-completion-devel@lists.alioth.debian.org/msg01942.html
-        if [[ ${!2} == \$\'*\' ]]; then
-            local value=${!2:2:-1} # Strip beginning $' and ending '.
-            value=${value//'%'/%%} # Escape % for printf format.
+        if [[ $ret == \$\'*\' ]]; then
+            local value=${ret:2:-1} # Strip beginning $' and ending '.
+            value=${value//'%'/%%}  # Escape % for printf format.
             # shellcheck disable=SC2059
-            printf -v value "$value" # Decode escape sequences of \....
-            local "$2" && _comp_upvars -v "$2" "$value"
+            printf -v ret "$value" # Decode escape sequences of \....
         fi
     fi
 } # _comp_quote_compgen()
@@ -681,8 +681,9 @@ _filedir()
         $reset
         IFS=$'\n'
     else
-        local quoted
-        _comp_quote_compgen "${cur-}" quoted
+        local ret
+        _comp_quote_compgen "${cur-}"
+        local quoted=$ret
 
         # Munge xspec to contain uppercase version too
         # https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00036.html

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -13,6 +13,7 @@ _comp_deprecate_func _upvars _comp_upvars
 _comp_deprecate_func __reassemble_comp_words_by_ref _comp__reassemble_words
 _comp_deprecate_func __get_cword_at_cursor_by_ref _comp__get_cword_at_cursor
 _comp_deprecate_func _get_comp_words_by_ref _comp_get_words
+_comp_deprecate_func _quote_readline_by_ref _comp_quote_compgen
 
 # Backwards compatibility for compat completions that use have().
 # @deprecated should no longer be used; generally not needed with dynamically

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -13,7 +13,6 @@ _comp_deprecate_func _upvars _comp_upvars
 _comp_deprecate_func __reassemble_comp_words_by_ref _comp__reassemble_words
 _comp_deprecate_func __get_cword_at_cursor_by_ref _comp__get_cword_at_cursor
 _comp_deprecate_func _get_comp_words_by_ref _comp_get_words
-_comp_deprecate_func _quote_readline_by_ref _comp_quote_compgen
 
 # Backwards compatibility for compat completions that use have().
 # @deprecated should no longer be used; generally not needed with dynamically
@@ -33,6 +32,19 @@ quote()
 {
     local quoted=${1//\'/\'\\\'\'}
     printf "'%s'" "$quoted"
+}
+
+# This function is the same as `_comp_quote_compgen`, but receives the second
+# argument specifying the variable name to store the result.
+# @param $1  Argument to quote
+# @param $2  Name of variable to return result to
+# @deprecated Use `_comp_quote_compgen "$1"` instead.  Note that
+# `_comp_quote_compgen` stores the result in a fixed variable `ret`.
+_quote_readline_by_ref()
+{
+    [[ $2 == ret ]] || local ret
+    _comp_quote_compgen "$1"
+    [[ $2 == ret ]] || printf -v "$2" %s "$ret"
 }
 
 # This function shell-dequotes the argument

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -34,6 +34,14 @@ quote()
     printf "'%s'" "$quoted"
 }
 
+# @deprecated Use `_comp_quote_compgen`
+quote_readline()
+{
+    local ret
+    _comp_quote_compgen "$1"
+    printf %s "$ret"
+} # quote_readline()
+
 # This function is the same as `_comp_quote_compgen`, but receives the second
 # argument specifying the variable name to store the result.
 # @param $1  Argument to quote

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST = \
 	test_unit_pids.py \
 	test_unit_pnames.py \
 	test_unit_quote.py \
-	test_unit_quote_readline.py \
+	test_unit_quote_compgen.py \
 	test_unit_split.py \
 	test_unit_tilde.py \
 	test_unit_unlocal.py \

--- a/test/t/unit/test_unit_quote_compgen.py
+++ b/test/t/unit/test_unit_quote_compgen.py
@@ -6,7 +6,7 @@ from conftest import assert_bash_exec, assert_complete, bash_env_saved
 
 
 @pytest.mark.bashcomp(cmd=None, temp_cwd=True)
-class TestUnitQuoteReadline:
+class TestUnitQuoteCompgen:
     def test_exec(self, bash):
         assert_bash_exec(bash, "quote_readline '' >/dev/null")
 
@@ -36,9 +36,9 @@ class TestUnitQuoteReadline:
         Reported at https://github.com/scop/bash-completion/pull/492
 
         Arbitrary commands could be unintendedly executed by
-        _quote_readline_by_ref.  In the following example, the command
-        "touch 1.txt" would be unintendedly created before the fix.  The file
-        "1.txt" should not be created by completion on the following line:
+        _comp_quote_compgen.  In the following example, the command "touch
+        1.txt" would be unintendedly created before the fix.  The file "1.txt"
+        should not be created by completion on the following line:
 
           $ echo '$(touch file.txt)[TAB]
 
@@ -97,10 +97,10 @@ class TestUnitQuoteReadline:
         Ref [2] https://github.com/scop/bash-completion/pull/526
 
         The escape sequences in the local variable of "value" in
-        "_quote_readline_by_ref" needs to be unescaped by passing it to printf
-        as the format string.  This causes a problem in the following case
-        [where the spaces after "alpha\" is a TAB character inserted in the
-        command string by "C-v TAB"]:
+        "_comp_quote_compgen" needs to be unescaped by passing it to printf as
+        the format string.  This causes a problem in the following case [where
+        the spaces after "alpha\" is a TAB character inserted in the command
+        string by "C-v TAB"]:
 
           $ echo alpha\   b[TAB]
 


### PR DESCRIPTION
- Also, `quote_readline` is deprecated.
- `_comp_quote_compgen` always stores the result in `ret` (as in the second paragraph in [§ General API conventions](https://github.com/scop/bash-completion/blob/master/doc/api-and-naming.md#general-api-conventions)).

After this is merged, I'll submit the refactoring mentioned in https://github.com/scop/bash-completion/pull/909#issuecomment-1488328631.