### PR TITLE
fix(_comp_delimited): prepend prefix to all compreply args

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -895,6 +895,13 @@ _comp_delimited()
         _comp_compgen COMPREPLY "$@" -- "${cur##*"$delimiter"}"
     fi
 
+    # It would seem that in some specific cases we could avoid adding the
+    # prefix to all completions, thereby making the list of suggestions
+    # cleaner, and only adding it when there's exactly one completion.
+    # The cases where this opportunity has been observed involve having
+    # `show-all-if-ambiguous` on, but even that has cases where it fails
+    # and the last separator including everything before it is lost.
+    # https://github.com/scop/bash-completion/pull/913#issuecomment-1490140309
     local i
     for i in "${!COMPREPLY[@]}"; do
         COMPREPLY[i]="$prefix${COMPREPLY[i]}"

--- a/bash_completion
+++ b/bash_completion
@@ -895,7 +895,10 @@ _comp_delimited()
         _comp_compgen COMPREPLY "$@" -- "${cur##*"$delimiter"}"
     fi
 
-    ((${#COMPREPLY[@]})) && COMPREPLY=("${COMPREPLY[@]/#/"$prefix"}")
+    local i
+    for i in "${!COMPREPLY[@]}"; do
+        COMPREPLY[i]="$prefix${COMPREPLY[i]}"
+    done
 
     [[ $delimiter != : ]] || __ltrim_colon_completions "$cur"
 }

--- a/bash_completion
+++ b/bash_completion
@@ -895,7 +895,8 @@ _comp_delimited()
         _comp_compgen COMPREPLY "$@" -- "${cur##*"$delimiter"}"
     fi
 
-    ((${#COMPREPLY[@]} == 1)) && COMPREPLY=("$prefix$COMPREPLY")
+    ((${#COMPREPLY[@]})) && COMPREPLY=("${COMPREPLY[@]/#/"$prefix"}")
+
     [[ $delimiter != : ]] || __ltrim_colon_completions "$cur"
 }
 

--- a/test/t/test_pgrep.py
+++ b/test/t/test_pgrep.py
@@ -31,4 +31,3 @@ class TestPgrep:
     )
     def test_nslist_after_comma(self, completion):
         assert completion
-        assert not any("," in x for x in completion)

--- a/test/t/test_ssh_keygen.py
+++ b/test/t/test_ssh_keygen.py
@@ -27,13 +27,11 @@ class TestSshKeygen:
     @pytest.mark.complete("ssh-keygen -s foo_key -n foo,")
     def test_usernames_for_n(self, completion):
         assert completion
-        assert not any("," in x for x in completion)
         # TODO check that these are usernames
 
     @pytest.mark.complete("ssh-keygen -s foo_key -h -n foo,")
     def test_host_for_h_n(self, completion):
         assert completion
-        assert not any("," in x for x in completion)
         # TODO check that these are hostnames
 
     @pytest.mark.complete("ssh-keygen -Y foo -n ")

--- a/test/t/test_tox.py
+++ b/test/t/test_tox.py
@@ -12,7 +12,7 @@ class TestTox:
 
     @pytest.mark.complete("tox -e foo,", cwd="tox")
     def test_3(self, completion):
-        assert all(x in completion for x in "py37 ALL".split())
+        assert all("foo," + x in completion for x in "py37 ALL".split())
 
     @pytest.mark.complete("tox -e foo -- ", cwd="tox")
     def test_default_after_dashdash(self, completion):

--- a/test/t/test_tshark.py
+++ b/test/t/test_tshark.py
@@ -14,7 +14,7 @@ class TestTshark:
     @pytest.mark.complete("tshark -O foo,htt", require_cmd=True)
     def test_3(self, completion):
         # p: one completion only; http: e.g. http and http2
-        assert completion == "p" or "http" in completion
+        assert completion == "p" or "foo,http" in completion
 
     @pytest.mark.complete("tshark -o tcp", require_cmd=True)
     def test_4(self, completion):

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -2,6 +2,7 @@ EXTRA_DIST = \
 	test_unit_command_offset.py \
 	test_unit_compgen.py \
 	test_unit_count_args.py \
+	test_unit_delimited.py \
 	test_unit_deprecate_func.py \
 	test_unit_dequote.py \
 	test_unit_expand.py \

--- a/test/t/unit/test_unit_delimited.py
+++ b/test/t/unit/test_unit_delimited.py
@@ -1,0 +1,42 @@
+import pytest
+
+from conftest import assert_bash_exec
+
+
+@pytest.mark.bashcomp(cmd=None)
+class TestUnitDelimited:
+    @pytest.fixture(scope="class")
+    def functions(self, request, bash):
+        assert_bash_exec(
+            bash,
+            "_comp_cmd_test_delim() {"
+            "  local cur prev words cword comp_args;"
+            "  _comp_get_words cur;"
+            "  _comp_delimited , -W 'alpha beta bravo';"
+            "};"
+            "complete -F _comp_cmd_test_delim test_delim",
+        )
+
+    @pytest.mark.complete("test_delim --opt=a")
+    def test_1(self, functions, completion):
+        assert completion == ["lpha"]
+
+    @pytest.mark.complete("test_delim --opt=b")
+    def test_2(self, functions, completion):
+        assert completion == ["beta", "bravo"]
+
+    @pytest.mark.complete("test_delim --opt=alpha,b")
+    def test_3(self, functions, completion):
+        assert completion == ["alpha,beta", "alpha,bravo"]
+
+    @pytest.mark.complete("test_delim --opt=alpha,be")
+    def test_4(self, functions, completion):
+        assert completion == ["ta"]
+
+    @pytest.mark.complete("test_delim --opt=beta,a")
+    def test_5(self, functions, completion):
+        assert completion == ["lpha"]
+
+    @pytest.mark.complete("test_delim --opt=c")
+    def test_6(self, functions, completion):
+        assert not completion


### PR DESCRIPTION
Fixes #552.

Previously prefix was only prepended if COMPREPLY only contained one argument - this commit fixes it so prefix is prepended to all arguments.

The problem existed since 4138714c, in the very first version of `_comp_delimited` function. I'm not sure why the original only prepended the prefix back when there was only one completion, so I'm worried I'm missing something.