### PR TITLE
fix: quote boolean command names such as `if "$boolean_variable"; then`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -868,7 +868,7 @@ _comp_delimited()
     fi
     [[ $cur == *$delimiter* ]] && prefix=${cur%"$delimiter"*}$delimiter
 
-    if $deduplicate; then
+    if "$deduplicate"; then
         # We could construct a -X pattern to feed to compgen, but that'd
         # conflict with possibly already set -X in $@, as well as have
         # glob char escaping issues to deal with. Do removals by hand instead.

--- a/bash_completion
+++ b/bash_completion
@@ -1930,7 +1930,7 @@ _included_ssh_config_files()
 _known_hosts_real()
 {
     local configfile="" flag prefix=""
-    local cur suffix="" aliases="" i host ipv4="" ipv6=""
+    local cur suffix="" aliases="" i host ipv4=false ipv6=false
     local -a kh tmpkh=() khd=() config=()
 
     # TODO remove trailing %foo from entries
@@ -1948,8 +1948,8 @@ _known_hosts_real()
                 configfile=$OPTARG
                 ;;
             p) prefix=$OPTARG ;;
-            4) ipv4=1 ;;
-            6) ipv6=1 ;;
+            4) ipv4=true ;;
+            6) ipv6=true ;;
             *)
                 echo "bash_completion: $FUNCNAME: usage error" >&2
                 return 1
@@ -2122,13 +2122,13 @@ _known_hosts_real()
     $reset
 
     if ((${#COMPREPLY[@]})); then
-        if [[ $ipv4 ]]; then
+        if "$ipv4"; then
             COMPREPLY=("${COMPREPLY[@]/*:*$suffix/}")
         fi
-        if [[ $ipv6 ]]; then
+        if "$ipv6"; then
             COMPREPLY=("${COMPREPLY[@]/+([0-9]).+([0-9]).+([0-9]).+([0-9])$suffix/}")
         fi
-        if [[ $ipv4 || $ipv6 ]]; then
+        if "$ipv4" || "$ipv6"; then
             for i in "${!COMPREPLY[@]}"; do
                 [[ ${COMPREPLY[i]} ]] || unset -v 'COMPREPLY[i]'
             done

--- a/completions/export
+++ b/completions/export
@@ -52,7 +52,7 @@ _comp_cmd_export()
                 return
             fi
             local suffix=""
-            if ! $remove && [[ $action != function ]]; then
+            if ! "$remove" && [[ $action != function ]]; then
                 suffix="="
                 compopt -o nospace
             fi

--- a/completions/find
+++ b/completions/find
@@ -71,7 +71,7 @@ _comp_cmd_find()
     done
 
     # handle case where first parameter is not a dash option
-    if ! $exprfound && [[ $cur != [-\(\),\!]* ]]; then
+    if ! "$exprfound" && [[ $cur != [-\(\),\!]* ]]; then
         _filedir -d
         return
     fi

--- a/completions/fio
+++ b/completions/fio
@@ -118,7 +118,7 @@ _comp_cmd_fio()
                     local line="" in_values=false
                     ret=()
                     for line in "${cmdhelp[@]}"; do
-                        if $in_values; then
+                        if "$in_values"; then
                             if [[ $line =~ ^[[:space:]]*:[[:space:]]*([^[:space:]]+) ]]; then
                                 ret+=("${BASH_REMATCH[1]}")
                             else

--- a/completions/jarsigner
+++ b/completions/jarsigner
@@ -40,7 +40,7 @@ _jarsigner()
         fi
     done
 
-    if ! $jar; then
+    if ! "$jar"; then
         if [[ $cur == -* ]]; then
             # Documented as "should not be used": -internalsf, -sectionsonly
             COMPREPLY=($(compgen -W '-keystore -storepass -storetype

--- a/completions/lzip
+++ b/completions/lzip
@@ -35,7 +35,7 @@ _lzip()
         return
     fi
 
-    if $decompress; then
+    if "$decompress"; then
         _filedir lz
         return
     fi

--- a/completions/make
+++ b/completions/make
@@ -111,7 +111,7 @@ _comp_make__truncate_non_unique_paths()
         for target in "${COMPREPLY[@]}"; do
             local path=${target%/}
             while [[ ! ${paths[$path]+set} ]] &&
-                paths[$path]=1 &&
+                paths[$path]=true &&
                 [[ $path == "$prefix"*/* ]]; do
                 path=${path%/*}
                 nchild[$path]=$((${nchild[$path]-0} + 1))

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -49,15 +49,15 @@ _mcrypt()
     elif [[ ${words[0]} == mdecrypt ]]; then
         _filedir nc
     else
-        local i decrypt=0
+        local i decrypt=false
         for ((i = 1; i < ${#words[@]} - 1; i++)); do
             if [[ ${words[i]} == -@(d|-decrypt) ]]; then
                 _filedir nc
-                decrypt=1
+                decrypt=true
                 break
             fi
         done
-        if ((decrypt == 0)); then
+        if ! "$decrypt"; then
             _filedir
         fi
     fi

--- a/completions/mutt
+++ b/completions/mutt
@@ -64,8 +64,8 @@ _comp_cmd_mutt__get_conffiles()
 # @var[ref] visited    Dictionary of config files already visited
 _comp_cmd_mutt__get_conffiles__visit()
 {
-    [[ -f $1 && ${visited[$1]-} != yes ]] || return 0
-    visited[$1]=yes
+    [[ -f $1 && ${visited[$1]-} != true ]] || return 0
+    visited[$1]=true
     conffiles+=("$1")
 
     local -a newconffiles=($(command sed -n 's|^source[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' "$1"))

--- a/completions/pack200
+++ b/completions/pack200
@@ -53,7 +53,7 @@ _pack200()
         esac
     done
 
-    if ! $pack; then
+    if ! "$pack"; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '--no-gzip --gzip --strip-debug
                 --no-keep-file-order --segment-limit= --effort= --deflate-hint=
@@ -65,7 +65,7 @@ _pack200()
         else
             _filedir 'pack?(.gz)'
         fi
-    elif ! $jar; then
+    elif ! "$jar"; then
         _filedir jar
     fi
 } &&

--- a/completions/postcat
+++ b/completions/postcat
@@ -17,11 +17,11 @@ _postcat()
         return
     fi
 
-    local idx qfile=0
+    local idx qfile=false
     for idx in "${words[@]}"; do
-        [[ $idx == -q ]] && qfile=1 && break
+        [[ $idx == -q ]] && qfile=true && break
     done
-    if ((qfile == 1)); then
+    if "$qfile"; then
         local len=${#cur} pval
         for pval in $(mailq 2>/dev/null |
             command sed -e '1d; $d; /^[^0-9A-Z]/d; /^$/d; s/[* !].*$//'); do

--- a/completions/pytest
+++ b/completions/pytest
@@ -112,7 +112,7 @@ _pytest()
             elif [[ $line =~ ^class[[:space:]] ]]; then
                 in_class=false
             fi
-            if $in_class && [[ $line =~ ^[[:space:]]+(async[[:space:]]+)?def[[:space:]]+(test_[A-Za-z0-9_]+) ]]; then
+            if "$in_class" && [[ $line =~ ^[[:space:]]+(async[[:space:]]+)?def[[:space:]]+(test_[A-Za-z0-9_]+) ]]; then
                 COMPREPLY+=(${BASH_REMATCH[2]})
             fi
         done 2>/dev/null <"$file"

--- a/completions/ssh
+++ b/completions/ssh
@@ -489,7 +489,7 @@ _comp_xfunc_ssh_scp_local_files()
     local files
     _comp_expand_glob files '"$cur"*'
     ((${#files[@]})) || return 0
-    if $dirsonly; then
+    if "$dirsonly"; then
         COMPREPLY+=($(command ls -aF1dL "${files[@]}" 2>/dev/null |
             command sed -e "s/$_comp_cmd_scp__path_esc/\\\\&/g" -e '/[^\/]$/d' \
                 -e "s/^/${1-}/"))

--- a/completions/strace
+++ b/completions/strace
@@ -40,7 +40,7 @@ _strace()
                             while read -r define syscall rest; do
                                 [[ $define == "#define" &&
                                     $syscall =~ ^__NR_(.+) ]] &&
-                                    syscalls[${BASH_REMATCH[1]}]=1
+                                    syscalls[${BASH_REMATCH[1]}]=true
                             done 2>/dev/null </usr/include/asm/unistd.h
                             if ((${#syscalls[@]} == 0)); then
                                 local unistd arch=$(command uname -m)
@@ -52,7 +52,7 @@ _strace()
                                 while read -r define syscall rest; do
                                     [[ $define == "#define" &&
                                         $syscall =~ ^__NR_(.+) ]] &&
-                                        syscalls[${BASH_REMATCH[1]}]=1
+                                        syscalls[${BASH_REMATCH[1]}]=true
                                 done 2>/dev/null <$unistd
                             fi
 

--- a/completions/svcadm
+++ b/completions/svcadm
@@ -24,12 +24,12 @@ _smf_complete_fmri()
 {
     local cur="$1" prefix="$2"
     local cur_prefix fmri fmri_list=""
-    local exact_mode="" pattern
+    local exact_mode=false pattern
 
     if [[ $cur == $prefix* ]]; then
         [[ $cur == "$prefix" ]] && cur+="/"
         pattern="$cur*"
-        exact_mode=1
+        exact_mode=true
     else
         pattern="$prefix*/$cur*"
     fi
@@ -38,7 +38,7 @@ _smf_complete_fmri()
 
     for fmri in $(svcs -H -o FMRI "$pattern" 2>/dev/null); do
         local fmri_part_list fmri_part
-        if [[ ! $exact_mode ]]; then
+        if ! "$exact_mode"; then
             fmri=${fmri#"$prefix/"}
 
             # we generate all possibles abbreviations for the FMRI

--- a/completions/tar
+++ b/completions/tar
@@ -171,16 +171,16 @@ __tar_parse_old_opt()
 
     # current word is the first word
     [[ $cword -eq 1 && $cur && ${cur:0:1} != '-' ]] &&
-        old_opt_progress=1
+        old_opt_progress=true
 
     # check that first argument does not begin with "-"
     first_word=${words[1]}
     [[ $first_word && ${first_word:0:1} != "-" ]] &&
-        old_opt_used=1
+        old_opt_used=true
 
     # parse the old option (if present) contents to allow later code expect
     # corresponding arguments
-    if ((old_opt_used == 1)); then
+    if "$old_opt_used"; then
         char=${first_word:0:1}
         while [[ $char ]]; do
             if __tar_is_argreq "$char"; then
@@ -195,13 +195,12 @@ __tar_parse_old_opt()
 # Make the analysis of whole command line.
 __tar_preparse_cmdline()
 {
-    local first_arg i modes="ctxurdA"
+    local first_arg=true i modes="ctxurdA"
 
     shift # progname
 
     __tar_parse_old_opt
 
-    first_arg=1
     for i in "$@"; do
         case "$i" in
             --delete | --test-label)
@@ -220,14 +219,14 @@ __tar_preparse_cmdline()
                 ;;
             *[$modes]*)
                 # Only the first arg may be "MODE" without leading dash
-                if ((first_arg == 1)); then
+                if "$first_arg"; then
                     tar_mode=${i//[^$modes]/}
                     tar_mode=${tar_mode:0:1}
                     tar_mode_arg=$i
                 fi
                 ;;
         esac
-        first_arg=0
+        first_arg=false
     done
 }
 
@@ -306,7 +305,7 @@ __tar_complete_mode()
 
     # The last short option requires argument, like '-cf<TAB>'.  Cut the
     # completion here to enforce argument processing.
-    if ((old_opt_progress == 0)) &&
+    if ! "$old_opt_progress" &&
         __tar_is_argreq "$(__tar_last_char "$cur")"; then
         COMPREPLY=("$cur") && return 0
     fi
@@ -383,7 +382,7 @@ __tar_adjust_PREV_from_old_option()
     # deal with old style arguments here
     # $ tar cfTC # expects this sequence of arguments:
     # $ tar cfTC ARCHIVE_FILE PATTERNS_FILE CHANGE_DIR
-    if ((old_opt_used == 1 && cword > 1 && cword < ${#old_opt_parsed[@]} + 2)); then
+    if "$old_opt_used" && ((cword > 1 && cword < ${#old_opt_parsed[@]} + 2)); then
         # make e.g. 'C' option from 'cffCT'
         prev="-${old_opt_parsed[cword - 2]}"
     fi
@@ -488,8 +487,8 @@ _gtar()
     local long_opts short_opts basic_tar=false \
         long_arg_none="" long_arg_opt="" long_arg_req="" \
         short_arg_none="" short_arg_opt="" short_arg_req="" \
-        tar_mode tar_mode_arg old_opt_progress=0 \
-        old_opt_used=0 old_opt_parsed=()
+        tar_mode tar_mode_arg old_opt_progress=false \
+        old_opt_used=false old_opt_parsed=()
 
     # Main mode, e.g. -x or -c (extract/creation)
     local tar_mode=none
@@ -678,8 +677,8 @@ _posix_tar()
     local long_opts short_opts basic_tar=true \
         long_arg_none="" long_arg_opt long_arg_req="" \
         short_arg_none short_arg_opt short_arg_req \
-        tar_mode tar_mode_arg old_opt_progress=0 \
-        old_opt_used=1 old_opt_parsed=()
+        tar_mode tar_mode_arg old_opt_progress=false \
+        old_opt_used=true old_opt_parsed=()
 
     # Main mode, e.g. -x or -c (extract/creation)
     local tar_mode=none

--- a/completions/tar
+++ b/completions/tar
@@ -276,7 +276,7 @@ __tar_complete_mode()
         filler i
 
     short_modes="ctx"
-    [[ ! $basic_tar ]] && short_modes="ctxurdA"
+    ! "$basic_tar" && short_modes="ctxurdA"
 
     # Remove prefix when needed
     rawopt=${cur#-}
@@ -289,7 +289,7 @@ __tar_complete_mode()
 
         # when user passed something like 'tar cf' do not put the '-' before
         filler=
-        if [[ ! $cur && ! $basic_tar ]]; then
+        if [[ ! $cur ]] && ! "$basic_tar"; then
             filler=-
         fi
 
@@ -357,14 +357,14 @@ __tar_try_mode()
     case "$cur" in
         --*)
             # posix tar does not support long opts
-            [[ $basic_tar ]] && return 0
+            "$basic_tar" && return 0
             __gtar_complete_lopts
             return $?
             ;;
 
         -*)
             # posix tar does not support short options
-            [[ $basic_tar ]] && return 0
+            "$basic_tar" && return 0
 
             __tar_complete_mode && return 0
             ;;
@@ -485,7 +485,7 @@ __tar_detect_ext()
 
 _gtar()
 {
-    local long_opts short_opts basic_tar="" \
+    local long_opts short_opts basic_tar=false \
         long_arg_none="" long_arg_opt="" long_arg_req="" \
         short_arg_none="" short_arg_opt="" short_arg_req="" \
         tar_mode tar_mode_arg old_opt_progress=0 \
@@ -675,7 +675,7 @@ __tar_posix_prev_handle()
 
 _posix_tar()
 {
-    local long_opts short_opts basic_tar="" \
+    local long_opts short_opts basic_tar=true \
         long_arg_none="" long_arg_opt long_arg_req="" \
         short_arg_none short_arg_opt short_arg_req \
         tar_mode tar_mode_arg old_opt_progress=0 \
@@ -691,7 +691,6 @@ _posix_tar()
 
     _comp_initialize -s -- "$@" || return
 
-    basic_tar=yes
     tar_mode=none
 
     # relatively compatible modes are {c,t,x}

--- a/completions/timeout
+++ b/completions/timeout
@@ -8,7 +8,7 @@ _timeout()
     local noargopts='!(-*|*[ks]*)'
     for ((i = 1; i <= COMP_CWORD; i++)); do
         if [[ ${COMP_WORDS[i]} != -* && ${COMP_WORDS[i - 1]} != = ]]; then
-            if $found; then
+            if "$found"; then
                 _comp_command_offset $i
                 return
             fi

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -33,7 +33,7 @@ _unpack200()
         esac
     done
 
-    if ! $pack; then
+    if ! "$pack"; then
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '--deflate-hint= --remove-pack-file
                 --verbose --quiet --log-file= --help --version' -- "$cur"))
@@ -41,7 +41,7 @@ _unpack200()
         else
             _filedir 'pack?(.gz)'
         fi
-    elif ! $jar; then
+    elif ! "$jar"; then
         _filedir jar
     fi
 } &&

--- a/completions/upgradepkg
+++ b/completions/upgradepkg
@@ -14,12 +14,12 @@ _upgradepkg()
     if [[ $cur == ?*%* ]]; then
         prev="${cur%%?(\\)%*}"
         cur="${cur#*%}"
-        local nofiles="" IFS=$'\n'
+        local nofiles=false IFS=$'\n'
         compopt -o filenames
         COMPREPLY=($(compgen -P "$prev%" -f -X "!*.@(t[bgxl]z)" -- "$cur"))
-        [[ ${COMPREPLY-} ]] || nofiles=1
+        [[ ${COMPREPLY-} ]] || nofiles=true
         COMPREPLY+=($(compgen -P "$prev%" -S '/' -d -- "$cur"))
-        [[ $nofiles ]] && compopt -o nospace
+        "$nofiles" && compopt -o nospace
         return
     fi
 

--- a/completions/wodim
+++ b/completions/wodim
@@ -66,15 +66,15 @@ _cdrecord()
         -isosize -pad -nopad -shorttrack -noshorttrack -preemp -nopreemp
         -copy -nocopy -scms "isrc=" "index=" "padsize=" "pregap=" "tsize=")
     # look if previous was either a file or a track option
-    track_mode=0
+    track_mode=false
     if ((cword > 1)); then
         if [[ -f $prev ]]; then
-            track_mode=1
+            track_mode=true
         else
             local opt
             for opt in "${track_options[@]}"; do
                 if [[ $opt == "$prev" ]]; then
-                    track_mode=1
+                    track_mode=true
                     break
                 fi
             done
@@ -86,7 +86,7 @@ _cdrecord()
     # track options are always available
     COMPREPLY+=($(compgen -W '"${track_options[@]}"' -- "$cur"))
     # general options are no more available after file or track option
-    if ((track_mode == 0)); then
+    if ! "$track_mode"; then
         COMPREPLY+=($(compgen -W '"${generic_options[@]}"' -- "$cur"))
     fi
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace


### PR DESCRIPTION
I have created this branch after https://github.com/scop/bash-completion/pull/891#issuecomment-1445250871 but left it for about one month. Now there was a related discussion in https://github.com/scop/bash-completion/pull/910#discussion_r1155867722, so I decided to submit it here.

**edit**: This branch also includes other fixes: 7b6fb48894c79a3c7c57e9a7f5cb14bf7b2ff198, e731fc4d846423e330f199f786f8c054f0e01b99, 7971f50f569a2e2af7133b9f3459f00a89c22895
