### PR TITLE
fix: quote `$split` of `$split && return` for custom IFS

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2372,7 +2372,7 @@ _complete_as_root()
 
 _longopt()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "${prev,,}" in
@@ -2403,7 +2403,7 @@ _longopt()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _comp_compgen COMPREPLY -W "$(LC_ALL=C $1 --help 2>&1 |

--- a/bash_completion
+++ b/bash_completion
@@ -983,21 +983,21 @@ _comp_variable_assignments()
 #                     argument $2 is the string before the cursor in the
 #                     current word.  The third argument $3 is the previous
 #                     word.
-# @var[out] cur       Reconstructed current word
-# @var[out] prev      Reconstructed previous word
-# @var[out] words     Reconstructed words
-# @var[out] cword     Current word index in `words`
-# @var[out] comp_args Original arguments specified to the completion function
-#                     are saved in this array, if the arguments $1...$3 is
-#                     specified.
-# @var[out,opt] split When "-s" is specified, `true/false` is set depending on
-#                     whether the split happened.
+# @var[out] cur           Reconstructed current word
+# @var[out] prev          Reconstructed previous word
+# @var[out] words         Reconstructed words
+# @var[out] cword         Current word index in `words`
+# @var[out] comp_args     Original arguments specified to the completion function
+#                         are saved in this array, if the arguments $1...$3 is
+#                         specified.
+# @var[out,opt] was_split When "-s" is specified, `"set"/""` is set depending
+#                         on whether the split happened.
 # @return  True (0) if completion needs further processing,
 #          False (> 0) no further processing is necessary.
 #
 _comp_initialize()
 {
-    local exclude="" outx errx inx
+    local exclude="" opt_split="" outx errx inx
 
     local flag OPTIND=1 OPTARG="" OPTERR=0
     while getopts "n:e:o:i:s" flag "$@"; do
@@ -1007,7 +1007,8 @@ _comp_initialize()
             o) outx=$OPTARG ;;
             i) inx=$OPTARG ;;
             s)
-                split=false
+                opt_split="set"
+                was_split=""
                 exclude+="="
                 ;;
             *)
@@ -1065,7 +1066,7 @@ _comp_initialize()
     ((cword <= 0)) && return 1
     prev=${words[cword - 1]}
 
-    [[ ${split-} ]] && _split_longopt && split=true
+    [[ $opt_split ]] && _split_longopt && was_split="set"
 
     return 0
 }

--- a/completions/2to3
+++ b/completions/2to3
@@ -2,7 +2,7 @@
 
 _2to3()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -24,7 +24,7 @@ _2to3()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/_mock
+++ b/completions/_mock
@@ -5,7 +5,7 @@
 
 _comp_cmd_mock()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local plugins='tmpfs root_cache yum_cache bind_mount ccache'
@@ -55,7 +55,7 @@ _comp_cmd_mock()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/_repomanage
+++ b/completions/_repomanage
@@ -5,12 +5,12 @@
 
 _comp_cmd_repomanage()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     [[ $prev == -@([hk]|-help|-keep) ]] && return
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/_rtcwake
+++ b/completions/_rtcwake
@@ -5,7 +5,7 @@
 
 _comp_cmd_rtcwake()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -24,7 +24,7 @@ _comp_cmd_rtcwake()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
 } &&

--- a/completions/_su
+++ b/completions/_su
@@ -10,7 +10,7 @@ fi
 
 _comp_cmd_su()
 { # linux-specific completion
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -26,7 +26,7 @@ _comp_cmd_su()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -5,7 +5,7 @@
 
 _comp_cmd_udevadm()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i udevcmd has_udevcmd=""
@@ -52,7 +52,7 @@ _comp_cmd_udevadm()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ ! $has_udevcmd ]]; then
         case $cur in

--- a/completions/_yum
+++ b/completions/_yum
@@ -39,7 +39,7 @@ _yum_plugins()
 
 _comp_cmd_yum()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local special="" i
@@ -136,7 +136,7 @@ _comp_cmd_yum()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/a2x
+++ b/completions/a2x
@@ -2,7 +2,7 @@
 
 _a2x()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[aDd]*)'
@@ -26,7 +26,7 @@ _a2x()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))

--- a/completions/aclocal
+++ b/completions/aclocal
@@ -2,7 +2,7 @@
 
 _aclocal()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -25,7 +25,7 @@ _aclocal()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/add_members
+++ b/completions/add_members
@@ -2,7 +2,7 @@
 
 _add_members()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -16,7 +16,7 @@ _add_members()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--regular-members-file --digest-members-file

--- a/completions/appdata-validate
+++ b/completions/appdata-validate
@@ -2,7 +2,7 @@
 
 _appdata_validate()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -17,7 +17,7 @@ _appdata_validate()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -2,7 +2,7 @@
 
 _comp_cmd_apt_mark()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local special="" i
@@ -49,7 +49,7 @@ _comp_cmd_apt_mark()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--file= --help --version --config-file

--- a/completions/arch
+++ b/completions/arch
@@ -5,7 +5,7 @@
 _comp_have_command mailmanctl &&
     _arch()
     {
-        local cur prev words cword split comp_args
+        local cur prev words cword was_split comp_args
         _comp_initialize -s -- "$@" || return
 
         case $prev in
@@ -19,7 +19,7 @@ _comp_have_command mailmanctl &&
                 ;;
         esac
 
-        $split && return
+        [[ $was_split ]] && return
 
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -9,7 +9,7 @@ _comp_deprecate_func _asciidoc_doctype _comp_xfunc_asciidoc_doctype
 
 _asciidoc()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[abfdo]*)'
@@ -40,7 +40,7 @@ _asciidoc()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help manpage")' \

--- a/completions/aspell
+++ b/completions/aspell
@@ -18,7 +18,7 @@ _aspell_dictionary()
 
 _aspell()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -59,7 +59,7 @@ _aspell()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--conf= --conf-dir= --data-dir= --dict-dir=

--- a/completions/autoconf
+++ b/completions/autoconf
@@ -2,7 +2,7 @@
 
 _autoconf()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -25,7 +25,7 @@ _autoconf()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/automake
+++ b/completions/automake
@@ -2,7 +2,7 @@
 
 _automake()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -21,7 +21,7 @@ _automake()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/autoreconf
+++ b/completions/autoreconf
@@ -2,7 +2,7 @@
 
 _autoreconf()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case "$prev" in
@@ -22,7 +22,7 @@ _autoreconf()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/autoscan
+++ b/completions/autoscan
@@ -2,7 +2,7 @@
 
 _autoscan()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[BI]*)'
@@ -17,7 +17,7 @@ _autoscan()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/avahi-browse
+++ b/completions/avahi-browse
@@ -2,7 +2,7 @@
 
 _comp_cmd_avahi_browse()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[D]*)'
@@ -16,7 +16,7 @@ _comp_cmd_avahi_browse()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/bts
+++ b/completions/bts
@@ -19,7 +19,7 @@ _src_packages_with_prefix()
 
 _bts()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -90,7 +90,7 @@ _bts()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '--offline --online --no-offline
         --no-action --cache --no-cache --cache-mode --cache-delay --mbox

--- a/completions/carton
+++ b/completions/carton
@@ -15,7 +15,7 @@ _carton_command_help()
 
 _carton()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i command="" has_command=""
@@ -64,7 +64,7 @@ _carton()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         [[ $command == @(help|usage) ]] || COMPREPLY=(--help)

--- a/completions/ccache
+++ b/completions/ccache
@@ -2,7 +2,7 @@
 
 _ccache()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i
@@ -30,7 +30,7 @@ _ccache()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/ccze
+++ b/completions/ccze
@@ -2,7 +2,7 @@
 
 _ccze()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[acFmop]*)'
@@ -36,7 +36,7 @@ _ccze()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/chage
+++ b/completions/chage
@@ -2,7 +2,7 @@
 
 _chage()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[dEImMWR]*)'
@@ -18,7 +18,7 @@ _chage()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/change_pw
+++ b/completions/change_pw
@@ -2,7 +2,7 @@
 
 _change_pw()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _change_pw()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--all --domain --listname --password --quiet

--- a/completions/checksec
+++ b/completions/checksec
@@ -2,7 +2,7 @@
 
 _checksec()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -41,7 +41,7 @@ _checksec()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/chgrp
+++ b/completions/chgrp
@@ -2,7 +2,7 @@
 
 _chgrp()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     cur=${cur//\\\\/}
@@ -12,7 +12,7 @@ _chgrp()
         return
     fi
 
-    $split && return
+    [[ $was_split ]] && return
 
     # options completion
     if [[ $cur == -* ]]; then

--- a/completions/chkconfig
+++ b/completions/chkconfig
@@ -2,7 +2,7 @@
 
 _chkconfig()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -17,7 +17,7 @@ _chkconfig()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--list --add --del --override --level' \

--- a/completions/chmod
+++ b/completions/chmod
@@ -2,7 +2,7 @@
 
 _chmod()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -15,7 +15,7 @@ _chmod()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     # Adapted from coreutils 8.28 chmod man page
     local modearg="-@(@(+([rwxXst])|[ugo])|+([0-7]))"

--- a/completions/chown
+++ b/completions/chown
@@ -2,7 +2,7 @@
 
 _chown()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     # Don't treat user:group as separate words.
     _comp_initialize -s -n : -- "$@" || return
 
@@ -17,7 +17,7 @@ _chown()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # Complete -options

--- a/completions/chpasswd
+++ b/completions/chpasswd
@@ -2,7 +2,7 @@
 
 _chpasswd()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[csR]*)'
@@ -22,7 +22,7 @@ _chpasswd()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -2,7 +2,7 @@
 
 _chromium_browser()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     case $prev in
@@ -34,7 +34,7 @@ _chromium_browser()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/clone_member
+++ b/completions/clone_member
@@ -2,7 +2,7 @@
 
 _clone_member()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _clone_member()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--listname --remove --admin --quiet

--- a/completions/config_list
+++ b/completions/config_list
@@ -2,7 +2,7 @@
 
 _config_list()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _config_list()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--inputfile --outputfile --checkonly

--- a/completions/configure
+++ b/completions/configure
@@ -2,7 +2,7 @@
 
 _configure()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -20,7 +20,7 @@ _configure()
             ;;
     esac
 
-    if $split || [[ $cur != -* ]]; then
+    if [[ $was_split || $cur != -* ]]; then
         _filedir
         return
     fi

--- a/completions/cpio
+++ b/completions/cpio
@@ -2,7 +2,7 @@
 
 _cpio()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     # --name value style option
@@ -29,7 +29,7 @@ _cpio()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if ((cword == 1)); then
         COMPREPLY=($(compgen -W '-o --create -i --extract -p --pass-through

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -2,7 +2,7 @@
 
 _cppcheck()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -17,16 +17,16 @@ _cppcheck()
             ;;
         --enable)
             # split comma-separated list
-            split=false
+            local split=""
             if [[ $cur == ?*,* ]]; then
                 prev="${cur%,*}"
                 cur="${cur##*,}"
-                split=true
+                split="set"
             fi
             COMPREPLY=($(compgen -W 'all warning style performance
                 portability information unusedFunction missingInclude' \
                 -- "$cur"))
-            $split && COMPREPLY=(${COMPREPLY[@]/#/"$prev,"})
+            [[ $split ]] && COMPREPLY=(${COMPREPLY[@]/#/"$prev,"})
             return
             ;;
         --error-exitcode)
@@ -62,7 +62,7 @@ _cppcheck()
             return
             ;;
         -rp | --relative-paths)
-            if $split; then # -rp without argument is allowed
+            if [[ $was_split ]]; then # -rp without argument is allowed
                 _filedir -d
                 return
             fi
@@ -77,7 +77,7 @@ _cppcheck()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -13,7 +13,7 @@ _cryptsetup_device()
 
 _cryptsetup()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[cslSbopitTdM]*)'
@@ -33,7 +33,7 @@ _cryptsetup()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local arg
     _get_first_arg

--- a/completions/deja-dup
+++ b/completions/deja-dup
@@ -2,7 +2,7 @@
 
 _comp_cmd_deja_dup()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -19,7 +19,7 @@ _comp_cmd_deja_dup()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -37,7 +37,7 @@ _comp_deprecate_func _comp_dpkg_purgeable_packages _comp_xfunc_dpkg_purgeable_pa
 #
 _comp_cmd_dpkg()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i=$cword
@@ -113,7 +113,7 @@ _comp_cmd_dpkg()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     for i in ${!COMPREPLY[*]}; do

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -2,7 +2,7 @@
 
 _comp_cmd_ebtables()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local table chain='s/^Bridge chain: \([^ ,]\{1,\}\).*$/\1/p' \

--- a/completions/eog
+++ b/completions/eog
@@ -2,7 +2,7 @@
 
 _comp_cmd_eog()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -11,7 +11,7 @@ _comp_cmd_eog()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/evince
+++ b/completions/evince
@@ -2,7 +2,7 @@
 
 _comp_cmd_evince()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[pil]*)'
@@ -19,7 +19,7 @@ _comp_cmd_evince()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/faillog
+++ b/completions/faillog
@@ -2,7 +2,7 @@
 
 _comp_cmd_faillog()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[lmtu]*)'
@@ -17,7 +17,7 @@ _comp_cmd_faillog()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/feh
+++ b/completions/feh
@@ -2,7 +2,7 @@
 
 _comp_cmd_feh()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[foO|KCjeM@TSRHWEyJabgLD~^]*)'
@@ -102,7 +102,7 @@ _comp_cmd_feh()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # Some versions of feh just output "See 'man feh'" for --help :(

--- a/completions/file-roller
+++ b/completions/file-roller
@@ -2,7 +2,7 @@
 
 _comp_cmd_file_roller()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local exts='@(7z?(.001)|ace|alz|ar|arj|[bglx]z|bz2|tb?(z)2|cab|cb[rz]|iso?(9660)|Z|t[abglx]z|cpio|deb|rar|?(g)tar|gem|lh[az]|lz[4h]|?(t)lrz|lzma|lzo|wim|swm|rpm|sit|zoo|?(t)zst)'
@@ -28,7 +28,7 @@ _comp_cmd_file_roller()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/find_member
+++ b/completions/find_member
@@ -2,7 +2,7 @@
 
 _comp_cmd_find_member()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _comp_cmd_find_member()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--listname --exclude --owners --help' \

--- a/completions/fio
+++ b/completions/fio
@@ -9,7 +9,7 @@ _comp_cmd_fio__engines()
 
 _comp_cmd_fio()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local ret
@@ -137,7 +137,7 @@ _comp_cmd_fio()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/firefox
+++ b/completions/firefox
@@ -2,7 +2,7 @@
 
 _comp_cmd_firefox()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     [[ $cur == -MOZ_LOG*=* ]] && prev=${cur%%=*} cur=${cur#*=}
@@ -38,7 +38,7 @@ _comp_cmd_firefox()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/flake8
+++ b/completions/flake8
@@ -2,7 +2,7 @@
 
 _comp_cmd_flake8()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[j]*)'
@@ -29,7 +29,7 @@ _comp_cmd_flake8()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/getent
+++ b/completions/getent
@@ -2,7 +2,7 @@
 
 _comp_cmd_getent()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[s]*)'
@@ -64,7 +64,7 @@ _comp_cmd_getent()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/gnome-mplayer
+++ b/completions/gnome-mplayer
@@ -2,7 +2,7 @@
 
 _comp_cmd_gnome_mplayer()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -23,7 +23,7 @@ _comp_cmd_gnome_mplayer()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/gnome-screenshot
+++ b/completions/gnome-screenshot
@@ -2,7 +2,7 @@
 
 _comp_cmd_gnome_screenshot()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[def]*)'
@@ -21,7 +21,7 @@ _comp_cmd_gnome_screenshot()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -2,7 +2,7 @@
 
 _comp_cmd_gphoto2()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     case $prev in
@@ -42,7 +42,7 @@ _comp_cmd_gphoto2()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/gprof
+++ b/completions/gprof
@@ -2,7 +2,7 @@
 
 _comp_cmd_gprof()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $cur in
@@ -41,7 +41,7 @@ _comp_cmd_gprof()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))

--- a/completions/groupadd
+++ b/completions/groupadd
@@ -2,7 +2,7 @@
 
 _comp_cmd_groupadd()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     # TODO: if -o/--non-unique is given, could complete on existing gids
@@ -16,7 +16,7 @@ _comp_cmd_groupadd()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/groupmod
+++ b/completions/groupmod
@@ -2,7 +2,7 @@
 
 _comp_cmd_groupmod()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     # TODO: if -o/--non-unique is given, could complete on existing gids
@@ -16,7 +16,7 @@ _comp_cmd_groupmod()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/gssdp-discover
+++ b/completions/gssdp-discover
@@ -2,7 +2,7 @@
 
 _comp_cmd_gssdp_discover()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -29,7 +29,7 @@ _bluetooth_packet_types()
 
 _hcitool()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -47,7 +47,7 @@ _hcitool()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local arg
     _get_first_arg
@@ -109,7 +109,7 @@ _hcitool()
 
 _sdptool()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -119,7 +119,7 @@ _sdptool()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local arg
     _get_first_arg

--- a/completions/hddtemp
+++ b/completions/hddtemp
@@ -2,7 +2,7 @@
 
 _hddtemp()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[flupsS]*)'
@@ -25,7 +25,7 @@ _hddtemp()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1") --help' -- "$cur"))

--- a/completions/htop
+++ b/completions/htop
@@ -2,7 +2,7 @@
 
 _htop()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[sud]*)'
@@ -22,7 +22,7 @@ _htop()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))

--- a/completions/iconv
+++ b/completions/iconv
@@ -10,7 +10,7 @@ _comp_deprecate_func _iconv_charsets _comp_xfunc_iconv_charsets
 
 _iconv()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[fto]*)'
@@ -30,7 +30,7 @@ _iconv()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/idn
+++ b/completions/idn
@@ -2,7 +2,7 @@
 
 _idn()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[p]*)'
@@ -18,7 +18,7 @@ _idn()
             ;;
     esac
 
-    if ! $split && [[ $cur == -* ]]; then
+    if [[ ! $was_split && $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi

--- a/completions/ifstat
+++ b/completions/ifstat
@@ -2,7 +2,7 @@
 
 _ifstat()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[idstx]*)'
@@ -56,7 +56,7 @@ _ifstat()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/info
+++ b/completions/info
@@ -2,7 +2,7 @@
 
 _info()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     # default completion if parameter looks like a path
@@ -33,7 +33,7 @@ _info()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/inject
+++ b/completions/inject
@@ -2,7 +2,7 @@
 
 _inject()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _inject()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--listname --queue --help' -- "$cur"))

--- a/completions/interdiff
+++ b/completions/interdiff
@@ -2,7 +2,7 @@
 
 _interdiff()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[Upd]*)'
@@ -13,7 +13,7 @@ _interdiff()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/iperf
+++ b/completions/iperf
@@ -2,7 +2,7 @@
 
 _iperf()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local noargopts='!(-*|*[ilpwMXbntLPTZCkOSAfIoFBcxy]*)'
@@ -66,7 +66,7 @@ _iperf()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     # Filter mode specific options
     local i filter=cat

--- a/completions/iptables
+++ b/completions/iptables
@@ -2,7 +2,7 @@
 
 _iptables()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local table chain='s/^Chain \([^ ]\{1,\}\).*$/\1/p'

--- a/completions/ipv6calc
+++ b/completions/ipv6calc
@@ -2,7 +2,7 @@
 
 _ipv6calc()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[dIOA]*)'
@@ -27,7 +27,7 @@ _ipv6calc()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$("$1" -h 2>&1 |

--- a/completions/iscsiadm
+++ b/completions/iscsiadm
@@ -2,7 +2,7 @@
 
 _iscsiadm()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[motLU]*)'
@@ -27,7 +27,7 @@ _iscsiadm()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local options
     if ((cword > 1)); then

--- a/completions/jpegoptim
+++ b/completions/jpegoptim
@@ -2,7 +2,7 @@
 
 _jpegoptim()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[dmTS]*)'
@@ -25,7 +25,7 @@ _jpegoptim()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/jshint
+++ b/completions/jshint
@@ -2,7 +2,7 @@
 
 _jshint()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -23,7 +23,7 @@ _jshint()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/kcov
+++ b/completions/kcov
@@ -2,7 +2,7 @@
 
 _comp_cmd_kcov()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     case "$prev" in
@@ -49,7 +49,7 @@ _comp_cmd_kcov()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))

--- a/completions/killall
+++ b/completions/killall
@@ -4,7 +4,7 @@
 
 _comp_cmd_killall()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[Zoysu]*)'
@@ -23,7 +23,7 @@ _comp_cmd_killall()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/koji
+++ b/completions/koji
@@ -34,7 +34,7 @@ _comp_cmd_koji__target()
 
 _comp_cmd_koji()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local commandix command="" has_command=""
@@ -106,7 +106,7 @@ _comp_cmd_koji()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $has_command ]]; then
         if [[ $cur == -* ]]; then

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -21,7 +21,7 @@ _comp_cmd_ktutil__heimdal_encodings()
 
 _comp_cmd_ktutil()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local command commands i options
@@ -49,7 +49,7 @@ _comp_cmd_ktutil()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     commands='add change copy get list remove rename purge srvconvert
         srv2keytab srvcreate key2srvtab'

--- a/completions/lastlog
+++ b/completions/lastlog
@@ -2,7 +2,7 @@
 
 _comp_cmd_lastlog()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[btu]*)'
@@ -17,7 +17,7 @@ _comp_cmd_lastlog()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace

--- a/completions/list_members
+++ b/completions/list_members
@@ -2,7 +2,7 @@
 
 _comp_cmd_list_members()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -21,7 +21,7 @@ _comp_cmd_list_members()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--output --regular --digest --nomail

--- a/completions/locale-gen
+++ b/completions/locale-gen
@@ -2,7 +2,7 @@
 
 _comp_cmd_locale_gen()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -15,7 +15,7 @@ _comp_cmd_locale_gen()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/lsscsi
+++ b/completions/lsscsi
@@ -2,7 +2,7 @@
 
 _comp_cmd_lsscsi()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[y]*)'
@@ -17,7 +17,7 @@ _comp_cmd_lsscsi()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/luseradd
+++ b/completions/luseradd
@@ -2,7 +2,7 @@
 
 _comp_cmd_luseradd()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[culPpdksg]*)'
@@ -27,7 +27,7 @@ _comp_cmd_luseradd()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/lzip
+++ b/completions/lzip
@@ -2,7 +2,7 @@
 
 _comp_cmd_lzip()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local decompress=""
@@ -27,7 +27,7 @@ _comp_cmd_lzip()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1") {-1..-9}' -- "$cur"))

--- a/completions/lzma
+++ b/completions/lzma
@@ -3,10 +3,10 @@
 
 _comp_cmd_lzma()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1") -{1..9}' -- "$cur"))

--- a/completions/make
+++ b/completions/make
@@ -139,7 +139,7 @@ _comp_make__truncate_non_unique_paths()
 
 _make()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local makef makef_dir=("-C" ".") i
@@ -169,7 +169,7 @@ _make()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/man
+++ b/completions/man
@@ -2,7 +2,7 @@
 
 _man()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local comprsuffix=".@([glx]z|bz2|lzma|Z|zst)"
@@ -43,7 +43,7 @@ _man()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/mc
+++ b/completions/mc
@@ -2,7 +2,7 @@
 
 _mc()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[evlPCD]*)'
@@ -17,7 +17,7 @@ _mc()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))

--- a/completions/mdadm
+++ b/completions/mdadm
@@ -71,7 +71,7 @@ _mdadm_update_flag()
 
 _mdadm()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[cblpaU]*)'
@@ -99,7 +99,7 @@ _mdadm()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local options='--help --help-options --version --verbose --quiet --brief
         --force --config= --scan --metadata= --homehost='

--- a/completions/mii-diag
+++ b/completions/mii-diag
@@ -2,7 +2,7 @@
 
 _mii_diag()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -13,7 +13,7 @@ _mii_diag()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/mii-tool
+++ b/completions/mii-tool
@@ -2,7 +2,7 @@
 
 _mii_tool()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[FA]*)'
@@ -20,7 +20,7 @@ _mii_tool()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/minicom
+++ b/completions/minicom
@@ -2,7 +2,7 @@
 
 _minicom()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[acSCp]*)'
@@ -25,7 +25,7 @@ _minicom()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/mkinitrd
+++ b/completions/mkinitrd
@@ -2,7 +2,7 @@
 
 _mkinitrd()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -20,7 +20,7 @@ _mkinitrd()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--version --help -v -f --preload \

--- a/completions/mktemp
+++ b/completions/mktemp
@@ -2,7 +2,7 @@
 
 _mktemp()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[p]*)'
@@ -17,7 +17,7 @@ _mktemp()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         local opts=$(_parse_help "$1")

--- a/completions/modinfo
+++ b/completions/modinfo
@@ -2,7 +2,7 @@
 
 _modinfo()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[Fkb]*)'
@@ -25,7 +25,7 @@ _modinfo()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -2,7 +2,7 @@
 
 _modprobe()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[CdtS]*)'
@@ -25,7 +25,7 @@ _modprobe()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/monodevelop
+++ b/completions/monodevelop
@@ -2,10 +2,10 @@
 
 _monodevelop()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))

--- a/completions/mypy
+++ b/completions/mypy
@@ -2,7 +2,7 @@
 
 _mypy()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     [[ $cword -gt 2 && ${words[cword - 2]} == --shadow-file ]] &&
@@ -46,7 +46,7 @@ _mypy()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/mysql
+++ b/completions/mysql
@@ -15,7 +15,7 @@ _comp_deprecate_func _mysql_character_sets _comp_xfunc_mysql_character_sets
 
 _mysql()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[uDhSPeI]*)'
@@ -74,7 +74,7 @@ _mysql()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     case $cur in
         --*)

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -2,7 +2,7 @@
 
 _mysqladmin()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[uhScPOiw]*)'
@@ -49,7 +49,7 @@ _mysqladmin()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
 

--- a/completions/newlist
+++ b/completions/newlist
@@ -2,7 +2,7 @@
 
 _newlist()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -11,7 +11,7 @@ _newlist()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/newusers
+++ b/completions/newusers
@@ -2,7 +2,7 @@
 
 _newusers()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -15,7 +15,7 @@ _newusers()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/nmap
+++ b/completions/nmap
@@ -2,7 +2,7 @@
 
 _nmap()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -24,7 +24,7 @@ _nmap()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # strip everything following a :, inclusive

--- a/completions/nproc
+++ b/completions/nproc
@@ -2,7 +2,7 @@
 
 _nproc()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -11,7 +11,7 @@ _nproc()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/oggdec
+++ b/completions/oggdec
@@ -2,7 +2,7 @@
 
 _oggdec()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[beso]*)'
@@ -25,7 +25,7 @@ _oggdec()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pack200
+++ b/completions/pack200
@@ -2,7 +2,7 @@
 
 _pack200()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -42,7 +42,7 @@ _pack200()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     # Check if a pack or a jar was already given.
     local i pack="" jar=""

--- a/completions/patch
+++ b/completions/patch
@@ -2,7 +2,7 @@
 
 _patch()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[pDBYzgFiorVd]*)'
@@ -48,7 +48,7 @@ _patch()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pkg-config
+++ b/completions/pkg-config
@@ -2,7 +2,7 @@
 
 _pkg_config()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -29,7 +29,7 @@ _pkg_config()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pngfix
+++ b/completions/pngfix
@@ -2,7 +2,7 @@
 
 _pngfix()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -21,7 +21,7 @@ _pngfix()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/prelink
+++ b/completions/prelink
@@ -2,7 +2,7 @@
 
 _prelink()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -27,7 +27,7 @@ _prelink()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/protoc
+++ b/completions/protoc
@@ -2,7 +2,7 @@
 
 _protoc()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -30,7 +30,7 @@ _protoc()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     case $cur in
         -o*)

--- a/completions/psql
+++ b/completions/psql
@@ -20,7 +20,7 @@ _pg_users()
 #
 _createdb()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[hUOpDET]*)'
@@ -40,7 +40,7 @@ _createdb()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -55,7 +55,7 @@ _createdb()
 #
 _createuser()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[pchU]*)'
@@ -74,7 +74,7 @@ _createuser()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -87,7 +87,7 @@ _createuser()
 #
 _dropdb()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[hU]*)'
@@ -106,7 +106,7 @@ _dropdb()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -121,7 +121,7 @@ _dropdb()
 #
 _dropuser()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[phU]*)'
@@ -140,7 +140,7 @@ _dropuser()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -155,7 +155,7 @@ _dropuser()
 #
 _psql()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[hUdofLcFpPRTv]*)'
@@ -184,7 +184,7 @@ _psql()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # return list of available options

--- a/completions/pwgen
+++ b/completions/pwgen
@@ -2,7 +2,7 @@
 
 _pwgen()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[NH]*)'
@@ -17,7 +17,7 @@ _pwgen()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pycodestyle
+++ b/completions/pycodestyle
@@ -2,7 +2,7 @@
 
 _pycodestyle()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -19,7 +19,7 @@ _pycodestyle()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pydocstyle
+++ b/completions/pydocstyle
@@ -2,7 +2,7 @@
 
 _pydocstyle()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -20,7 +20,7 @@ _pydocstyle()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pylint
+++ b/completions/pylint
@@ -21,7 +21,7 @@ _comp_cmd_pylint_message_ids()
 
 _pylint()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local python=python
@@ -100,7 +100,7 @@ _pylint()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W \

--- a/completions/pytest
+++ b/completions/pytest
@@ -10,7 +10,7 @@ _pytest_option_choice_args()
 
 _pytest()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local noargopts='!(-*|*[kmorpcWn]*)'
@@ -93,7 +93,7 @@ _pytest()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/pyvenv
+++ b/completions/pyvenv
@@ -2,7 +2,7 @@
 
 _pyvenv()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -11,7 +11,7 @@ _pyvenv()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _longopt "$@"

--- a/completions/qrunner
+++ b/completions/qrunner
@@ -2,10 +2,10 @@
 
 _qrunner()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--runner --once --list --verbose --subproc

--- a/completions/querybts
+++ b/completions/querybts
@@ -2,7 +2,7 @@
 
 _querybts()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[Bu]*)'
@@ -24,7 +24,7 @@ _querybts()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/quota
+++ b/completions/quota
@@ -39,7 +39,7 @@ _filesystems()
 
 _quota()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -52,7 +52,7 @@ _quota()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _quota_parse_help "$1"
@@ -64,7 +64,7 @@ _quota()
 
 _setquota()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -81,7 +81,7 @@ _setquota()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _quota_parse_help "$1"
@@ -104,7 +104,7 @@ _setquota()
 
 _edquota()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -125,7 +125,7 @@ _edquota()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _quota_parse_help "$1"
@@ -137,7 +137,7 @@ _edquota()
 
 _quotacheck()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -150,7 +150,7 @@ _quotacheck()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _quota_parse_help "$1"
@@ -162,7 +162,7 @@ _quotacheck()
 
 _quotaon()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -179,7 +179,7 @@ _quotaon()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _quota_parse_help "$1"

--- a/completions/remove_members
+++ b/completions/remove_members
@@ -2,7 +2,7 @@
 
 _remove_members()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _remove_members()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--file --all --fromall --nouserack

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -2,7 +2,7 @@
 
 _reportbug()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[CefKHPsoiATjVuQtBS]*)'
@@ -57,7 +57,7 @@ _reportbug()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/ri
+++ b/completions/ri
@@ -35,7 +35,7 @@ _ri_get_methods()
 # needs at least Ruby 1.8.0 in order to use -W0
 _ri()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local noargopts='!(-*|*[wfd]*)'
@@ -58,7 +58,7 @@ _ri()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/rpm
+++ b/completions/rpm
@@ -47,7 +47,7 @@ _rpm_buildarchs()
 #
 _rpm()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     if ((cword == 1)); then
@@ -119,7 +119,7 @@ _rpm()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     # options common to all modes
     local -a opts=(
@@ -241,7 +241,7 @@ _rpm()
 
 _rpmbuild()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local rpm="${1%build*}"
@@ -278,7 +278,7 @@ _rpmbuild()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))

--- a/completions/rsync
+++ b/completions/rsync
@@ -2,7 +2,7 @@
 
 _rsync()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local noargopts='!(-*|*[Te]*)'
@@ -54,7 +54,7 @@ _rsync()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     _expand || return
 

--- a/completions/scrub
+++ b/completions/scrub
@@ -2,7 +2,7 @@
 
 _scrub()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[bsDpX]*)'
@@ -24,7 +24,7 @@ _scrub()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/secret-tool
+++ b/completions/secret-tool
@@ -2,10 +2,10 @@
 
 _secret_tool()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
-    $split && return
+    [[ $was_split ]] && return
 
     local -i i
     local mode="" has_mode="" word

--- a/completions/sha256sum
+++ b/completions/sha256sum
@@ -2,7 +2,7 @@
 
 _comp_cmd_sha256sum()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -11,7 +11,7 @@ _comp_cmd_sha256sum()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         _longopt "$@"

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -9,7 +9,7 @@ _shellcheck_optarg()
 
 _shellcheck()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[eifCsoPW]*)'
@@ -50,7 +50,7 @@ _shellcheck()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -5,7 +5,7 @@
 
 _sitecopy()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[dgrp]*)'

--- a/completions/slapt-src
+++ b/completions/slapt-src
@@ -2,7 +2,7 @@
 
 _slapt_src()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     case "$prev" in
@@ -16,7 +16,7 @@ _slapt_src()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -93,7 +93,7 @@ _smartctl_drivedb()
 
 _smartctl()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[qdTbrnsoSlvFPBt]*)'
@@ -152,7 +152,7 @@ _smartctl()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -41,7 +41,7 @@ _samba_signing()
 
 _smbclient()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[RtsAlDOTWdLSpMIbUniTcm]*)'
@@ -98,7 +98,7 @@ _smbclient()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -109,7 +109,7 @@ _smbclient()
 
 _smbget()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[ofdwupb]*)'
@@ -132,7 +132,7 @@ _smbget()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -143,7 +143,7 @@ _smbget()
 
 _smbcacls()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[AsldOWDMaSCGniU]*)'
@@ -179,7 +179,7 @@ _smbcacls()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -190,7 +190,7 @@ _smbcacls()
 
 _smbcquotas()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[sAldUuS]*)'
@@ -217,7 +217,7 @@ _smbcquotas()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
@@ -294,7 +294,7 @@ _smbtar()
 
 _smbtree()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[sAldSU]*)'
@@ -321,7 +321,7 @@ _smbtree()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/ss
+++ b/completions/ss
@@ -2,7 +2,7 @@
 
 _ss()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[fADF]*)'
@@ -27,7 +27,7 @@ _ss()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/strings
+++ b/completions/strings
@@ -2,7 +2,7 @@
 
 _strings()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[nstTe]*)'
@@ -33,7 +33,7 @@ _strings()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # macOS: ... [-t format] [-number] [-n number] ...

--- a/completions/sudo
+++ b/completions/sudo
@@ -2,7 +2,7 @@
 
 _sudo()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i mode=normal
@@ -42,7 +42,7 @@ _sudo()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/sync_members
+++ b/completions/sync_members
@@ -2,7 +2,7 @@
 
 _sync_members()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -16,7 +16,7 @@ _sync_members()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--no-change --welcome-msg --goodbye-msg

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -2,7 +2,7 @@
 
 _sysbench()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -100,7 +100,7 @@ _sysbench()
             return
             ;;
         --*)
-            $split && return
+            [[ $was_split ]] && return
             ;;
     esac
 

--- a/completions/tar
+++ b/completions/tar
@@ -502,7 +502,7 @@ _gtar()
         local PS4='$BASH_SOURCE:$LINENO: '
     fi
 
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
 
     _comp_initialize -s -- "$@" || return
 
@@ -602,7 +602,7 @@ _gtar()
                 # if there is some unknown option with '=', for example
                 # (literally) user does --nonexistent=<TAB>, we do not want
                 # continue also
-                $split && break
+                [[ $was_split ]] && break
 
                 # Most probably, when code goes here, the PREV variable contains
                 # some string from "$long_arg_none" and we want continue.
@@ -686,7 +686,7 @@ _posix_tar()
     # The mode argument, e.g. -cpf or -c
     local tar_mode_arg=
 
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
 
     _comp_initialize -s -- "$@" || return
 

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -2,7 +2,7 @@
 
 _tcpdump()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[rwFVimTzZBcCDEGMsWyjQ]*)'
@@ -53,7 +53,7 @@ _tcpdump()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))

--- a/completions/timeout
+++ b/completions/timeout
@@ -2,7 +2,7 @@
 
 _timeout()
 {
-    local cur prev words cword split comp_args i found=""
+    local cur prev words cword was_split comp_args i found=""
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[ks]*)'
@@ -29,7 +29,7 @@ _timeout()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(

--- a/completions/tree
+++ b/completions/tree
@@ -2,7 +2,7 @@
 
 _comp_cmd_tree()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[LPIHTo]*)'
@@ -25,7 +25,7 @@ _comp_cmd_tree()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/truncate
+++ b/completions/truncate
@@ -2,7 +2,7 @@
 
 _comp_cmd_truncate()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[sr]*)'
@@ -17,7 +17,7 @@ _comp_cmd_truncate()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -2,7 +2,7 @@
 
 _unpack200()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[Hl]*)'
@@ -22,7 +22,7 @@ _unpack200()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     # Check if a pack or a jar was already given.
     local word pack="" jar=""

--- a/completions/uscan
+++ b/completions/uscan
@@ -2,7 +2,7 @@
 
 _uscan()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -25,7 +25,7 @@ _uscan()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
 } &&

--- a/completions/useradd
+++ b/completions/useradd
@@ -2,7 +2,7 @@
 
 _useradd()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     # TODO: if -o/--non-unique is given, could complete on existing uids
@@ -49,7 +49,7 @@ _useradd()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     [[ $cur == -* ]] &&
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/usermod
+++ b/completions/usermod
@@ -2,7 +2,7 @@
 
 _usermod()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     # TODO: if -o/--non-unique is given, could complete on existing uids
@@ -49,7 +49,7 @@ _usermod()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         # TODO: -U/--unlock, -p/--password, -L/--lock mutually exclusive

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -2,7 +2,7 @@
 
 _valgrind()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local i
@@ -101,7 +101,7 @@ _valgrind()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help ${tool-}")' \

--- a/completions/watch
+++ b/completions/watch
@@ -4,7 +4,7 @@
 
 _watch()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local offset=0 i
@@ -44,7 +44,7 @@ _watch()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/wget
+++ b/completions/wget
@@ -2,7 +2,7 @@
 
 _wget()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[DPoaOitTwlQeBUARIX]*)'
@@ -166,7 +166,7 @@ _wget()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/wol
+++ b/completions/wol
@@ -2,7 +2,7 @@
 
 _wol()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -n : -- "$@" || return
 
     local noargopts='!(-*|*[pwhif]*)'
@@ -30,7 +30,7 @@ _wol()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/wvdial
+++ b/completions/wvdial
@@ -2,7 +2,7 @@
 
 _wvdial()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -12,7 +12,7 @@ _wvdial()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     local config i IFS=$'\n'
 

--- a/completions/xmms
+++ b/completions/xmms
@@ -2,7 +2,7 @@
 
 _xmms()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[SRA]*)'
@@ -17,7 +17,7 @@ _xmms()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -2,7 +2,7 @@
 
 _xvfb_run()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*[npsef]*)'
@@ -27,7 +27,7 @@ _xvfb_run()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/xz
+++ b/completions/xz
@@ -2,7 +2,7 @@
 
 _xz()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local xspec="*.@(xz|lzma|txz|tlz)"
@@ -38,7 +38,7 @@ _xz()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --long-help) {-1..-9}' \

--- a/completions/xzdec
+++ b/completions/xzdec
@@ -2,7 +2,7 @@
 
 _xzdec()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     local noargopts='!(-*|*M*)'
@@ -16,7 +16,7 @@ _xzdec()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))

--- a/completions/zopflipng
+++ b/completions/zopflipng
@@ -2,7 +2,7 @@
 
 _zopflipng()
 {
-    local cur prev words cword split comp_args
+    local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
     case $prev in
@@ -15,7 +15,7 @@ _zopflipng()
             ;;
     esac
 
-    $split && return
+    [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(_parse_help "$1" -h))

--- a/doc/styleguide.md
+++ b/doc/styleguide.md
@@ -78,7 +78,7 @@ appended after the equal sign. Calling `compopt -o nospace` makes sense
 in case completion actually occurs: when only one completion is
 available in `COMPREPLY`.
 
-## `$split && return`
+## `[[ $was_split ]] && return`
 
 Should be used in completions using the `-s` flag of `_comp_initialize`,
 or other similar cases where `_split_longopt` has been invoked, after


### PR DESCRIPTION
These are all the following simple changes but just applied to many files.

```diff
-    $split && return
+    "$split" && return
```

This was originally a part of #914, but I have separated it for easier review of non-trivial changes in #914.