### PR TITLE
fix(bash_completion): use `_comp_split` and new `_comp_compgen` for safer splitting

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1082,8 +1082,6 @@ __parse_options()
     fi
     [[ $option ]] || return 1
 
-    local IFS=$' \t\n' # affects parsing of the regexps below...
-
     # Expand --[no]foo to --foo and --nofoo etc
     if [[ $option =~ (\[((no|dont)-?)\]). ]]; then
         option2=${option/"${BASH_REMATCH[1]}"/}

--- a/bash_completion
+++ b/bash_completion
@@ -432,9 +432,14 @@ _comp_compgen()
     elif [[ $1 == @(*[^_a-zA-Z0-9]*|[0-9]*|''|_*|IFS|OPTIND|OPTARG|OPTERR) ]]; then
         printf '%s\n' "bash_completion: $FUNCNAME: invalid array name \`$1'." >&2
         return 2
-    elif [[ ${*:2} == *\$[0-9]* || ${*:2} == *\$\{[0-9]* ]]; then
+    elif
+        local _nopt=$(($# - 1))
+        [[ ${*:$#-1:1} == -- ]] && ((_nopt -= 2)) # exclude "-- CUR" from check
+        [[ ${*:2:_nopt} == *\$[0-9]* || ${*:2:_nopt} == *\$\{[0-9]* ]]
+    then
         # Note: extglob *\$?(\{)[0-9]* can be extremely slow when the string
-        # "${*:2}" becomes longer, so we test \$[0-9] and \$\{[0-9] separately.
+        # "${*:2:_nopt}" becomes longer, so we test \$[0-9] and \$\{[0-9]
+        # separately.
         printf '%s\n' "bash_completion: $FUNCNAME: positional parameter \$1, \$2, ... do not work inside this function." >&2
         return 2
     fi

--- a/bash_completion
+++ b/bash_completion
@@ -324,24 +324,27 @@ _comp_expand_glob()
 # state of `IFS` and the shell option `noglob`.  A naive splitting by
 # `arr=(...)` suffers from unexpected IFS and pathname expansions, so one
 # should prefer this function to such naive splitting.
-# @param $1 array_name  The array name
-#   The array name should not start with an underscores "_", which is
-#   internally used.  The array name should not be either "IFS" or
-#   "OPT{IND,ARG,ERR}".
-# @param $2 text        The string to split
 # OPTIONS
 #   -a      Append to the array
 #   -F sep  Set a set of separator characters (used as IFS).  The default
 #           separator is $' \t\n'
 #   -l      The same as -F $'\n'
+# @param $1 array_name  The array name
+#   The array name should not start with an underscores "_", which is
+#   internally used.  The array name should not be either "IFS" or
+#   "OPT{IND,ARG,ERR}".
+# @param $2 text        The string to split
+# @return 2 when the usage is wrong, 0 when one or more completions are
+#   generated, or 1 when the execution succeeds but no candidates are
+#   generated.
 _comp_split()
 {
-    local _assign='=' IFS=$' \t\n'
+    local _append=false IFS=$' \t\n'
 
     local OPTIND=1 OPTARG="" OPTERR=0 _opt
     while getopts ':alF:' _opt "$@"; do
         case $_opt in
-            a) _assign='+=' ;;
+            a) _append=true ;;
             l) IFS=$'\n' ;;
             F) IFS=$OPTARG ;;
             *)
@@ -363,10 +366,19 @@ _comp_split()
     local _original_opts=$SHELLOPTS
     set -o noglob
 
-    eval "$1$_assign(\$2)"
+    local _old_size _new_size
+    if "$_append"; then
+        eval "$1+=()" # in case $1 is unset
+        eval "_old_size=\${#$1[@]}"
+        eval "$1+=(\$2)"
+    else
+        _old_size=0
+        eval "$1=(\$2)"
+    fi
+    eval "_new_size=\${#$1[@]}"
 
     [[ :$_original_opts: == *:noglob:* ]] || set +o noglob
-    return 0
+    ((_new_size > _old_size))
 }
 
 # Check if the argument looks like a path.
@@ -2507,8 +2519,8 @@ __load_completion()
     # 1) From BASH_COMPLETION_USER_DIR (e.g. ~/.local/share/bash-completion):
     # User installed completions.
     if [[ ${BASH_COMPLETION_USER_DIR-} ]]; then
-        _comp_split -F : paths "$BASH_COMPLETION_USER_DIR"
-        dirs+=("${paths[@]/%//completions}")
+        _comp_split -F : paths "$BASH_COMPLETION_USER_DIR" &&
+            dirs+=("${paths[@]/%//completions}")
     else
         dirs=("${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions")
     fi
@@ -2536,8 +2548,8 @@ __load_completion()
 
     # 4) From XDG_DATA_DIRS or system dirs (e.g. /usr/share, /usr/local/share):
     # Completions in the system data dirs.
-    _comp_split -F : paths "${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-    dirs+=("${paths[@]/%//bash-completion/completions}")
+    _comp_split -F : paths "${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" &&
+        dirs+=("${paths[@]/%//bash-completion/completions}")
 
     local backslash=
     if [[ $cmd == \\* ]]; then

--- a/bash_completion
+++ b/bash_completion
@@ -381,6 +381,79 @@ _comp_split()
     ((_new_size > _old_size))
 }
 
+# Call `compgen` with the specified arguments and store the results in the
+# specified array.
+# Usage: _comp_compgen [-al] [-F sep] ARRAY args... [-- cur]
+# This function essentially performs ARRAY=($(compgen args...)) but properly
+# handles shell options, IFS, etc. using _comp_split.  This function is
+# equivalent to `_comp_split [-a] -F sep ARRAY "$(compgen args...)"`, but this
+# pattern is frequent in the codebase and is good to separate out as a function
+# for the possible future implementation change.
+# OPTIONS
+#   -a      Append to the array
+#   -F sep  Set a set of separator characters (used as IFS in evaluating
+#           `compgen').  The default separator is $' \t\n'.  Note that this is
+#           not the set of separators to delimit output of `compgen', but the
+#           separators in evaluating the expansions of `-W '...'`, etc.  The
+#           delimiter of the output of `compgen` is always a newline.
+#   -l      The same as -F $'\n'
+# @param $1 array_name  The array name
+#   The array name should not start with an underscores "_", which is
+#   internally used.  The array name should not be either "IFS" or
+#   "OPT{IND,ARG,ERR}".
+# @param $2... args     The arguments that are passed to compgen
+#   Note: References to positional parameters $1, $2, ... (such as -W '$1')
+#   will not work as expected because these reference the arguments of
+#   `_comp_compgen' instead of those of the caller function.  When there are
+#   needs to reference them, save the arguments to an array and reference the
+#   array instead.
+_comp_compgen()
+{
+    local _append=false IFS=$' \t\n'
+    local -a _split_options=(-l)
+
+    local OPTIND=1 OPTARG="" OPTERR=0 _opt
+    while getopts ':alF:' _opt "$@"; do
+        case $_opt in
+            a) _append=true _split_options+=(-a) ;;
+            l) IFS=$'\n' ;;
+            F) IFS=$OPTARG ;;
+            *)
+                echo "bash_completion: $FUNCNAME: usage error" >&2
+                return 2
+                ;;
+        esac
+    done
+    shift "$((OPTIND - 1))"
+    if (($# < 2)); then
+        printf '%s\n' "bash_completion: $FUNCNAME: unexpected number of arguments." >&2
+        printf '%s\n' "usage: $FUNCNAME [-al] [-F SEP] ARRAY_NAME ARGS... [-- CUR]" >&2
+        return 2
+    elif [[ $1 == @(*[^_a-zA-Z0-9]*|[0-9]*|''|_*|IFS|OPTIND|OPTARG|OPTERR) ]]; then
+        printf '%s\n' "bash_completion: $FUNCNAME: invalid array name \`$1'." >&2
+        return 2
+    elif [[ ${*:2} == *\$[0-9]* || ${*:2} == *\$\{[0-9]* ]]; then
+        # Note: extglob *\$?(\{)[0-9]* can be extremely slow when the string
+        # "${*:2}" becomes longer, so we test \$[0-9] and \$\{[0-9] separately.
+        printf '%s\n' "bash_completion: $FUNCNAME: positional parameter \$1, \$2, ... do not work inside this function." >&2
+        return 2
+    fi
+
+    local _result
+    _result=$(compgen "${@:2}") || {
+        local _status=$?
+        if "$_append"; then
+            # make sure existence of variable
+            eval -- "$1+=()"
+        else
+            eval -- "$1=()"
+        fi
+        return "$_status"
+    }
+
+    _comp_split "${_split_options[@]}" "$1" "$_result"
+}
+
 # Check if the argument looks like a path.
 # @param $1 thing to check
 # @return True (0) if it does, False (> 0) otherwise

--- a/bash_completion
+++ b/bash_completion
@@ -743,20 +743,13 @@ _comp_quote_compgen()
 #
 _filedir()
 {
-    local IFS=$'\n'
-
     _tilde "${cur-}" || return
 
     local -a toks
-    local reset arg=${1-}
+    local arg=${1-}
 
     if [[ $arg == -d ]]; then
-        reset=$(shopt -po noglob)
-        set -o noglob
-        toks=($(compgen -d -- "${cur-}"))
-        IFS=' '
-        $reset
-        IFS=$'\n'
+        _comp_compgen toks -d -- "${cur-}"
     else
         local ret
         _comp_quote_compgen "${cur-}"
@@ -777,23 +770,12 @@ _filedir()
             ! ${plusdirs-} ]] ||
             opts+=("${plusdirs[@]}")
 
-        reset=$(shopt -po noglob)
-        set -o noglob
-        toks+=($(compgen "${opts[@]}" -- "$quoted"))
-        IFS=' '
-        $reset
-        IFS=$'\n'
+        _comp_compgen toks "${opts[@]}" -- "$quoted"
 
         # Try without filter if it failed to produce anything and configured to
         [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} &&
-            $arg && ${#toks[@]} -lt 1 ]] && {
-            reset=$(shopt -po noglob)
-            set -o noglob
-            toks+=($(compgen -f ${plusdirs+"${plusdirs[@]}"} -- "$quoted"))
-            IFS=' '
-            $reset
-            IFS=$'\n'
-        }
+            $arg && ${#toks[@]} -lt 1 ]] &&
+            _comp_compgen -a toks -f ${plusdirs+"${plusdirs[@]}"} -- "$quoted"
     fi
 
     if ((${#toks[@]} != 0)); then
@@ -831,29 +813,25 @@ _variables()
         # Completing $var / ${var / ${!var / ${#var
         if [[ $cur == '${'* ]]; then
             local arrs vars
-            vars=($(compgen -A variable -P "${BASH_REMATCH[1]}" -S '}' -- "${BASH_REMATCH[3]}"))
-            arrs=($(compgen -A arrayvar -P "${BASH_REMATCH[1]}" -S '[' -- "${BASH_REMATCH[3]}"))
+            _comp_compgen vars -A variable -P "${BASH_REMATCH[1]}" -S '}' -- "${BASH_REMATCH[3]}"
+            _comp_compgen arrs -A arrayvar -P "${BASH_REMATCH[1]}" -S '[' -- "${BASH_REMATCH[3]}"
             if ((${#vars[@]} == 1 && ${#arrs[@]} != 0)); then
                 # Complete ${arr with ${array[ if there is only one match, and that match is an array variable
                 compopt -o nospace
-                COMPREPLY+=(${arrs[*]})
+                COMPREPLY+=("${arrs[@]}")
             else
                 # Complete ${var with ${variable}
-                COMPREPLY+=(${vars[*]})
+                COMPREPLY+=("${vars[@]}")
             fi
         else
             # Complete $var with $variable
-            COMPREPLY+=($(compgen -A variable -P '$' -- "${BASH_REMATCH[3]}"))
+            _comp_compgen -a COMPREPLY -A variable -P '$' -- "${BASH_REMATCH[3]}"
         fi
         return 0
     elif [[ $cur =~ ^(\$\{[#!]?)([A-Za-z0-9_]*)\[([^]]*)$ ]]; then
         # Complete ${array[i with ${array[idx]}
-        local reset=$(shopt -po noglob) IFS=$'\n'
-        set -o noglob
-        COMPREPLY+=($(compgen -W '$(printf %s\\n "${!'"${BASH_REMATCH[2]}"'[@]}")' \
-            -P "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[" -S ']}' -- "${BASH_REMATCH[3]}"))
-        IFS=$' \t\n'
-        $reset
+        _comp_compgen -a COMPREPLY -W '"${!'"${BASH_REMATCH[2]}"'[@]}"' \
+            -P "${BASH_REMATCH[1]}${BASH_REMATCH[2]}[" -S ']}' -- "${BASH_REMATCH[3]}"
         # Complete ${arr[@ and ${arr[*
         if [[ ${BASH_REMATCH[3]} == [@*] ]]; then
             COMPREPLY+=("${BASH_REMATCH[1]}${BASH_REMATCH[2]}[${BASH_REMATCH[3]}]}")
@@ -888,15 +866,14 @@ _comp_delimited()
         # We could construct a -X pattern to feed to compgen, but that'd
         # conflict with possibly already set -X in $@, as well as have
         # glob char escaping issues to deal with. Do removals by hand instead.
-        COMPREPLY=($(compgen "$@"))
+        _comp_compgen COMPREPLY "$@"
         local -a existing
-        local x i IFS=$delimiter
-        existing=($cur)
+        _comp_split -F "$delimiter" existing "$cur"
         # Do not remove the last from existing if it's not followed by the
         # delimiter so we get space appended.
         [[ ! $cur || $cur == *"$delimiter" ]] || unset -v "existing[${#existing[@]}-1]"
-        _comp_unlocal IFS
         if ((${#COMPREPLY[@]})); then
+            local x i
             for x in ${existing+"${existing[@]}"}; do
                 for i in "${!COMPREPLY[@]}"; do
                     if [[ $x == "${COMPREPLY[i]}" ]]; then
@@ -906,13 +883,13 @@ _comp_delimited()
                 done
             done
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "${cur##*"$delimiter"}"))
+                _comp_compgen COMPREPLY -W '"${COMPREPLY[@]}"' -- "${cur##*"$delimiter"}"
         fi
     else
-        COMPREPLY=($(compgen "$@" -- "${cur##*"$delimiter"}"))
+        _comp_compgen COMPREPLY "$@" -- "${cur##*"$delimiter"}"
     fi
 
-    ((${#COMPREPLY[@]} == 1)) && COMPREPLY=(${COMPREPLY/#/$prefix})
+    ((${#COMPREPLY[@]} == 1)) && COMPREPLY=("$prefix$COMPREPLY")
     [[ $delimiter != : ]] || __ltrim_colon_completions "$cur"
 }
 
@@ -958,7 +935,7 @@ _comp_variable_assignments()
             _terms
             ;;
         LANG | LC_*)
-            COMPREPLY=($(compgen -W '$(locale -a 2>/dev/null)' -- "$cur"))
+            _comp_compgen COMPREPLY -W '$(locale -a 2>/dev/null)' -- "$cur"
             ;;
         LANGUAGE)
             _comp_delimited : -W '$(locale -a 2>/dev/null)'
@@ -1080,28 +1057,27 @@ _comp_initialize()
 # @return True (0) if an option was found, False (> 0) otherwise
 __parse_options()
 {
-    local option option2 i IFS=$' \t\n,/|'
+    local option option2 i
 
     # Take first found long option, or first one (short) if not found.
     option=
-    local reset=$(shopt -po noglob)
-    set -o noglob
-    local -a array=($1)
-    $reset
-    for i in "${array[@]}"; do
-        case "$i" in
-            ---*) break ;;
-            --?*)
-                option=$i
-                break
-                ;;
-            -?*) [[ $option ]] || option=$i ;;
-            *) break ;;
-        esac
-    done
+    local -a array
+    if _comp_split -F $' \t\n,/|' array "$1"; then
+        for i in "${array[@]}"; do
+            case "$i" in
+                ---*) break ;;
+                --?*)
+                    option=$i
+                    break
+                    ;;
+                -?*) [[ $option ]] || option=$i ;;
+                *) break ;;
+            esac
+        done
+    fi
     [[ $option ]] || return 1
 
-    IFS=$' \t\n' # affects parsing of the regexps below...
+    local IFS=$' \t\n' # affects parsing of the regexps below...
 
     # Expand --[no]foo to --foo and --nofoo etc
     if [[ $option =~ (\[((no|dont)-?)\]). ]]; then
@@ -1213,8 +1189,9 @@ _parse_usage()
 # @param $1 prefix
 _signals()
 {
-    local -a sigs=($(compgen -P "${1-}" -A signal "SIG${cur#"${1-}"}"))
-    COMPREPLY+=("${sigs[@]/#${1-}SIG/${1-}}")
+    local -a sigs
+    _comp_compgen sigs -P "${1-}" -A signal "SIG${cur#"${1-}"}" &&
+        COMPREPLY+=("${sigs[@]/#${1-}SIG/${1-}}")
 }
 
 # This function completes on known mac addresses
@@ -1228,7 +1205,7 @@ _mac_addresses()
     # - ifconfig on Linux: HWaddr or ether
     # - ifconfig on FreeBSD: ether
     # - ip link: link/ether
-    COMPREPLY+=($(
+    _comp_split -a COMPREPLY "$(
         {
             LC_ALL=C ifconfig -a || ip -c=never link show || ip link show
         } 2>/dev/null | command sed -ne \
@@ -1236,21 +1213,23 @@ _mac_addresses()
             "s/.*[[:space:]]HWaddr[[:space:]]\{1,\}\($re\)[[:space:]]*$/\1/p" -ne \
             "s|.*[[:space:]]\(link/\)\{0,1\}ether[[:space:]]\{1,\}\($re\)[[:space:]].*|\2|p" -ne \
             "s|.*[[:space:]]\(link/\)\{0,1\}ether[[:space:]]\{1,\}\($re\)[[:space:]]*$|\2|p"
-    ))
+    )"
 
     # ARP cache
-    COMPREPLY+=($({
-        arp -an || ip -c=never neigh show || ip neigh show
-    } 2>/dev/null | command sed -ne \
-        "s/.*[[:space:]]\($re\)[[:space:]].*/\1/p" -ne \
-        "s/.*[[:space:]]\($re\)[[:space:]]*$/\1/p"))
+    _comp_split -a COMPREPLY "$(
+        {
+            arp -an || ip -c=never neigh show || ip neigh show
+        } 2>/dev/null | command sed -ne \
+            "s/.*[[:space:]]\($re\)[[:space:]].*/\1/p" -ne \
+            "s/.*[[:space:]]\($re\)[[:space:]]*$/\1/p"
+    )"
 
     # /etc/ethers
-    COMPREPLY+=($(command sed -ne \
-        "s/^[[:space:]]*\($re\)[[:space:]].*/\1/p" /etc/ethers 2>/dev/null))
+    _comp_split -a COMPREPLY "$(command sed -ne \
+        "s/^[[:space:]]*\($re\)[[:space:]].*/\1/p" /etc/ethers 2>/dev/null)"
 
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+        _comp_compgen COMPREPLY -W '"${COMPREPLY[@]}"' -- "$cur"
     __ltrim_colon_completions "$cur"
 }
 
@@ -1263,28 +1242,28 @@ _configured_interfaces()
         # Debian system
         _comp_expand_glob files '/etc/network/interfaces /etc/network/interfaces.d/*'
         ((${#files[@]})) || return 0
-        COMPREPLY=($(compgen -W "$(command sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p' \
+        _comp_compgen COMPREPLY -W "$(command sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p' \
             "${files[@]}" 2>/dev/null)" \
-            -- "$cur"))
+            -- "$cur"
     elif [[ -f /etc/SuSE-release ]]; then
         # SuSE system
         _comp_expand_glob files '/etc/sysconfig/network/ifcfg-*'
         ((${#files[@]})) || return 0
-        COMPREPLY=($(compgen -W "$(printf '%s\n' \
+        _comp_compgen COMPREPLY -W "$(printf '%s\n' \
             "${files[@]}" |
-            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
+            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"
     elif [[ -f /etc/pld-release ]]; then
         # PLD Linux
-        COMPREPLY=($(compgen -W "$(command ls -B \
+        _comp_compgen COMPREPLY -W "$(command ls -B \
             /etc/sysconfig/interfaces |
-            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
+            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"
     else
         # Assume Red Hat
         _comp_expand_glob files '/etc/sysconfig/network-scripts/ifcfg-*'
         ((${#files[@]})) || return 0
-        COMPREPLY=($(compgen -W "$(printf '%s\n' \
+        _comp_compgen COMPREPLY -W "$(printf '%s\n' \
             "${files[@]}" |
-            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"))
+            command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')" -- "$cur"
     fi
 }
 
@@ -1307,14 +1286,14 @@ _ip_addresses()
     } 2>/dev/null |
         command sed -e 's/[[:space:]]addr:/ /' -ne \
             "s|.*inet${n}[[:space:]]\{1,\}\([^[:space:]/]*\).*|\1|p")
-    COMPREPLY+=($(compgen -W "$addrs" -- "${cur-}"))
+    _comp_compgen -a COMPREPLY -W "$addrs" -- "${cur-}"
 }
 
 # This function completes on available kernels
 #
 _kernel_versions()
 {
-    COMPREPLY=($(compgen -W '$(command ls /lib/modules)' -- "$cur"))
+    _comp_compgen COMPREPLY -W '$(command ls /lib/modules)' -- "$cur"
 }
 
 # This function completes on all available network interfaces
@@ -1324,8 +1303,7 @@ _kernel_versions()
 _available_interfaces()
 {
     local PATH=$PATH:/sbin
-
-    COMPREPLY=($({
+    local generated=$({
         if [[ ${1-} == -w ]]; then
             iwconfig
         elif [[ ${1-} == -a ]]; then
@@ -1334,10 +1312,9 @@ _available_interfaces()
             ifconfig -a || ip -c=never link show || ip link show
         fi
     } 2>/dev/null | awk \
-        '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }'))
-
-    ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]/%[[:punct:]]/}"' -- "$cur"))
+        '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }')
+    _comp_split -l COMPREPLY "$generated" &&
+        _comp_compgen COMPREPLY -W '"${COMPREPLY[@]/%[[:punct:]]/}"' -- "$cur"
 }
 
 # Echo number of CPUs, falling back to 1 on failure.
@@ -1355,15 +1332,15 @@ _ncpus()
 #          put in COMPREPLY and no further processing is necessary.
 _tilde()
 {
-    local result=0
     if [[ ${1-} == \~* && $1 != */* ]]; then
         # Try generate ~username completions
-        COMPREPLY=($(compgen -P '~' -u -- "${1#\~}"))
-        result=${#COMPREPLY[@]}
-        # 2>/dev/null for direct invocation, e.g. in the _tilde unit test
-        ((result > 0)) && compopt -o filenames 2>/dev/null
+        if _comp_compgen COMPREPLY -P '~' -u -- "${1#\~}"; then
+            # 2>/dev/null for direct invocation, e.g. in the _tilde unit test
+            compopt -o filenames 2>/dev/null
+            return 1
+        fi
     fi
-    return $((result > 0 ? 1 : 0))
+    return 0
 }
 
 # Expand variable starting with tilde (~)
@@ -1421,45 +1398,41 @@ if [[ $OSTYPE == *@(solaris|aix)* ]]; then
     # This function completes on process IDs.
     _pids()
     {
-        COMPREPLY=($(
-            compgen -W '$(command ps -efo pid | command sed 1d)' -- "$cur"
-        ))
+        _comp_compgen COMPREPLY -W '$(command ps -efo pid | command sed 1d)' -- "$cur"
     }
 
     _pgids()
     {
-        COMPREPLY=($(
-            compgen -W '$(command ps -efo pgid | command sed 1d)' -- "$cur"
-        ))
+        _comp_compgen COMPREPLY -W '$(command ps -efo pgid | command sed 1d)' -- "$cur"
     }
     _pnames()
     {
-        COMPREPLY=($(compgen -X '<defunct>' -W '$(command ps -efo comm | \
-            command sed -e 1d -e "s:.*/::" -e "s/^-//" | sort -u)' -- "$cur"))
+        _comp_compgen COMPREPLY -X '<defunct>' -W '$(command ps -efo comm | \
+            command sed -e 1d -e "s:.*/::" -e "s/^-//" | sort -u)' -- "$cur"
     }
 else
     _pids()
     {
-        COMPREPLY=($(compgen -W '$(command ps ax -o pid=)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(command ps ax -o pid=)' -- "$cur"
     }
     _pgids()
     {
-        COMPREPLY=($(compgen -W '$(command ps ax -o pgid=)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(command ps ax -o pgid=)' -- "$cur"
     }
     # @param $1 if -s, don't try to avoid truncated command names
     _pnames()
     {
         local -a procs=()
         if [[ ${1-} == -s ]]; then
-            procs=($(command ps ax -o comm | command sed -e 1d))
+            _comp_split procs "$(command ps ax -o comm | command sed -e 1d)"
         else
-            local line i=-1 IFS=$'\n'
             # Some versions of ps don't support "command", but do "comm", e.g.
             # some busybox ones. Fall back
-            local -a psout=($({
+            local -a psout
+            _comp_split -l psout "$({
                 command ps ax -o command= || command ps ax -o comm=
-            } 2>/dev/null))
-            _comp_unlocal IFS
+            } 2>/dev/null)"
+            local line i=-1
             for line in "${psout[@]}"; do
                 if ((i == -1)); then
                     # First line, see if it has COMMAND column header. For
@@ -1476,24 +1449,24 @@ else
                     #
                     line=${line:i}   # take command starting from found index
                     line=${line%% *} # trim arguments
-                    procs+=($line)
+                    [[ $line ]] && procs+=("$line")
                 fi
             done
             if ((i == -1)); then
                 # Regular command= parsing
                 for line in "${psout[@]}"; do
                     if [[ $line =~ ^[[(](.+)[])]$ ]]; then
-                        procs+=(${BASH_REMATCH[1]})
+                        procs+=("${BASH_REMATCH[1]}")
                     else
                         line=${line%% *}      # trim arguments
                         line=${line##@(*/|-)} # trim leading path and -
-                        procs+=($line)
+                        [[ $line ]] && procs+=("$line")
                     fi
                 done
             fi
         fi
         ((${#procs[@]})) &&
-            COMPREPLY=($(compgen -X "<defunct>" -W '"${procs[@]}"' -- "$cur"))
+            _comp_compgen COMPREPLY -X "<defunct>" -W '"${procs[@]}"' -- "$cur"
     }
 fi
 
@@ -1502,12 +1475,12 @@ fi
 _uids()
 {
     if type getent &>/dev/null; then
-        COMPREPLY=($(compgen -W '$(getent passwd | cut -d: -f3)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(getent passwd | cut -d: -f3)' -- "$cur"
     elif type perl &>/dev/null; then
-        COMPREPLY=($(compgen -W '$(perl -e '"'"'while (($uid) = (getpwent)[2]) { print $uid . "\n" }'"'"')' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(perl -e '"'"'while (($uid) = (getpwent)[2]) { print $uid . "\n" }'"'"')' -- "$cur"
     else
         # make do with /etc/passwd
-        COMPREPLY=($(compgen -W '$(cut -d: -f3 /etc/passwd)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(cut -d: -f3 /etc/passwd)' -- "$cur"
     fi
 }
 
@@ -1516,12 +1489,12 @@ _uids()
 _gids()
 {
     if type getent &>/dev/null; then
-        COMPREPLY=($(compgen -W '$(getent group | cut -d: -f3)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(getent group | cut -d: -f3)' -- "$cur"
     elif type perl &>/dev/null; then
-        COMPREPLY=($(compgen -W '$(perl -e '"'"'while (($gid) = (getgrent)[2]) { print $gid . "\n" }'"'"')' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(perl -e '"'"'while (($gid) = (getgrent)[2]) { print $gid . "\n" }'"'"')' -- "$cur"
     else
         # make do with /etc/group
-        COMPREPLY=($(compgen -W '$(cut -d: -f3 /etc/group)' -- "$cur"))
+        _comp_compgen COMPREPLY -W '$(cut -d: -f3 /etc/group)' -- "$cur"
     fi
 }
 
@@ -1538,8 +1511,7 @@ _xinetd_services()
         local -a svcs
         _comp_expand_glob svcs '$xinetddir/!($_comp_backup_glob)'
         if ((${#svcs[@]})); then
-            local IFS=$'\n'
-            COMPREPLY+=($(compgen -W '"${svcs[@]#$xinetddir/}"' -- "${cur-}"))
+            _comp_compgen COMPREPLY -W '"${svcs[@]#$xinetddir/}"' -- "${cur-}"
         fi
     fi
 }
@@ -1553,19 +1525,19 @@ _services()
 
     _comp_expand_glob COMPREPLY '${sysvdirs[0]}/!($_comp_backup_glob|functions|README)'
 
-    local IFS=$'\n'
-    COMPREPLY+=($({
+    local generated=$({
         systemctl list-units --full --all ||
             systemctl list-unit-files
     } 2>/dev/null |
-        awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }'))
+        awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }')
+    _comp_split -la COMPREPLY "$generated"
 
     if [[ -x /sbin/upstart-udev-bridge ]]; then
-        COMPREPLY+=($(initctl list 2>/dev/null | cut -d' ' -f1))
+        _comp_split -la COMPREPLY "$(initctl list 2>/dev/null | cut -d' ' -f1)"
     fi
 
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]#${sysvdirs[0]}/}"' -- "$cur"))
+        _comp_compgen COMPREPLY -W '"${COMPREPLY[@]#${sysvdirs[0]}/}"' -- "$cur"
 }
 
 # This completes on a list of all available service scripts for the
@@ -1584,11 +1556,11 @@ _service()
         _services
         [[ -e /etc/mandrake-release ]] && _xinetd_services
     else
-        local IFS=$'\n' sysvdirs
+        local sysvdirs
         _comp_sysvdirs
-        COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
+        _comp_compgen -l COMPREPLY -W '$(command sed -e "y/|/ /" \
             -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
-            ${sysvdirs[0]}/${prev##*/} 2>/dev/null` start stop' -- "$cur"))
+            ${sysvdirs[0]}/${prev##*/} 2>/dev/null) start stop' -- "$cur"
     fi
 } &&
     complete -F _service service
@@ -1612,17 +1584,17 @@ _modules()
 {
     local modpath
     modpath=/lib/modules/$1
-    COMPREPLY=($(compgen -W "$(command ls -RL "$modpath" 2>/dev/null |
+    _comp_compgen COMPREPLY -W "$(command ls -RL "$modpath" 2>/dev/null |
         command sed -ne 's/^\(.*\)\.k\{0,1\}o\(\.[gx]z\)\{0,1\}$/\1/p' \
-            -e 's/^\(.*\)\.ko\.zst$/\1/p')" -- "$cur"))
+            -e 's/^\(.*\)\.ko\.zst$/\1/p')" -- "$cur"
 }
 
 # This function completes on installed modules
 #
 _installed_modules()
 {
-    COMPREPLY=($(compgen -W "$(PATH="$PATH:/sbin" lsmod |
-        awk '{if (NR != 1) print $1}')" -- "$1"))
+    _comp_compgen COMPREPLY -W "$(PATH="$PATH:/sbin" lsmod |
+        awk '{if (NR != 1) print $1}')" -- "$1"
 }
 
 # This function completes on user or user:group format; as for chown and cpio.
@@ -1648,11 +1620,10 @@ _usergroup()
         if [[ ${1-} == -u ]]; then
             _allowed_groups "$mycur"
         else
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -g -- "$mycur"))
+            _comp_compgen COMPREPLY -g -- "$mycur"
         fi
         ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -P "$prefix" -W '"${COMPREPLY[@]}"'))
+            COMPREPLY=("${COMPREPLY[@]/#/$prefix}")
     elif [[ $cur == *:* ]]; then
         # Completing group after 'user:gr<TAB>'.
         # Reply with a list of unprefixed groups since readline with split on :
@@ -1661,8 +1632,7 @@ _usergroup()
         if [[ ${1-} == -u ]]; then
             _allowed_groups "$mycur"
         else
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -g -- "$mycur"))
+            _comp_compgen COMPREPLY -g -- "$mycur"
         fi
     else
         # Completing a partial 'usernam<TAB>'.
@@ -1673,8 +1643,7 @@ _usergroup()
         if [[ ${1-} == -u ]]; then
             _allowed_users "$cur"
         else
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen COMPREPLY -u -- "$cur"
         fi
     fi
 }
@@ -1682,32 +1651,28 @@ _usergroup()
 _allowed_users()
 {
     if _complete_as_root; then
-        local IFS=$'\n'
-        COMPREPLY=($(compgen -u -- "${1:-$cur}"))
+        _comp_compgen COMPREPLY -u -- "${1:-$cur}"
     else
-        local IFS=$'\n '
-        COMPREPLY=($(compgen -W \
-            "$(id -un 2>/dev/null || whoami 2>/dev/null)" -- "${1:-$cur}"))
+        _comp_compgen COMPREPLY -W \
+            "$(id -un 2>/dev/null || whoami 2>/dev/null)" -- "${1:-$cur}"
     fi
 }
 
 _allowed_groups()
 {
     if _complete_as_root; then
-        local IFS=$'\n'
-        COMPREPLY=($(compgen -g -- "$1"))
+        _comp_compgen COMPREPLY -g -- "$1"
     else
-        local IFS=$'\n '
-        COMPREPLY=($(compgen -W \
-            "$(id -Gn 2>/dev/null || groups 2>/dev/null)" -- "$1"))
+        _comp_compgen COMPREPLY -W \
+            "$(id -Gn 2>/dev/null || groups 2>/dev/null)" -- "$1"
     fi
 }
 
 _comp_selinux_users()
 {
-    COMPREPLY+=($(compgen -W '$(
+    _comp_compgen -a COMPREPLY -W '$(
         semanage user -nl 2>/dev/null | awk "{ print \$1 }"
-    )' -- "$cur"))
+    )' -- "$cur"
 }
 
 # This function completes on valid shells
@@ -1717,7 +1682,7 @@ _shells()
 {
     local shell rest
     while read -r shell rest; do
-        [[ $shell == /* && $shell == "$cur"* ]] && COMPREPLY+=($shell)
+        [[ $shell == /* && $shell == "$cur"* ]] && COMPREPLY+=("$shell")
     done 2>/dev/null <"${1-}"/etc/shells
 }
 
@@ -1741,7 +1706,7 @@ _fstypes()
              $([[ -d /etc/fs ]] && command ls /etc/fs)"
     fi
 
-    [[ $fss ]] && COMPREPLY+=($(compgen -W "$fss" -- "$cur"))
+    [[ $fss ]] && _comp_compgen -a COMPREPLY -W "$fss" -- "$cur"
 }
 
 # Get real command.
@@ -1815,34 +1780,34 @@ _count_args()
 #
 _pci_ids()
 {
-    COMPREPLY+=($(compgen -W \
-        "$(PATH="$PATH:/sbin" lspci -n | awk '{print $3}')" -- "$cur"))
+    _comp_compgen -a COMPREPLY -W \
+        "$(PATH="$PATH:/sbin" lspci -n | awk '{print $3}')" -- "$cur"
 }
 
 # This function completes on USB IDs
 #
 _usb_ids()
 {
-    COMPREPLY+=($(compgen -W \
-        "$(PATH="$PATH:/sbin" lsusb | awk '{print $6}')" -- "$cur"))
+    _comp_compgen -a COMPREPLY -W \
+        "$(PATH="$PATH:/sbin" lsusb | awk '{print $6}')" -- "$cur"
 }
 
 # CD device names
 _cd_devices()
 {
-    COMPREPLY+=($(compgen -f -d -X "!*/?([amrs])cd*" -- "${cur:-/dev/}"))
+    _comp_compgen -a COMPREPLY -f -d -X "!*/?([amrs])cd*" -- "${cur:-/dev/}"
 }
 
 # DVD device names
 _dvd_devices()
 {
-    COMPREPLY+=($(compgen -f -d -X "!*/?(r)dvd*" -- "${cur:-/dev/}"))
+    _comp_compgen -a COMPREPLY -f -d -X "!*/?(r)dvd*" -- "${cur:-/dev/}"
 }
 
 # TERM environment variable values
 _terms()
 {
-    COMPREPLY+=($(compgen -W "$({
+    _comp_compgen -a COMPREPLY -W "$({
         command sed -ne 's/^\([^[:space:]#|]\{2,\}\)|.*/\1/p' /etc/termcap
         {
             toe -a || toe
@@ -1851,7 +1816,7 @@ _terms()
         ((${#dirs[@]})) &&
             find "${dirs[@]}" -type f -maxdepth 1 |
             awk -F/ '{ print $NF }'
-    } 2>/dev/null)" -- "$cur"))
+    } 2>/dev/null)" -- "$cur"
 }
 
 _bashcomp_try_faketty()
@@ -1881,7 +1846,7 @@ _user_at_host()
     if [[ $cur == *@* ]]; then
         _known_hosts_real "$cur"
     else
-        COMPREPLY=($(compgen -u -S @ -- "$cur"))
+        _comp_compgen COMPREPLY -u -S @ -- "$cur"
         compopt -o nospace
     fi
 }
@@ -1913,12 +1878,9 @@ _included_ssh_config_files()
     local configfile i files f
     configfile=$1
 
-    local IFS=$' \t\n' reset=$(shopt -po noglob)
-    set -o noglob
-    local included=($(command sed -ne 's/^[[:blank:]]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][[:blank:]]\(.*\)$/\1/p' "${configfile}"))
-    $reset
+    local -a included
+    _comp_split included "$(command sed -ne 's/^[[:blank:]]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][[:blank:]]\(.*\)$/\1/p' "${configfile}")" || return
 
-    [[ ${included-} ]] || return
     for i in "${included[@]}"; do
         # Check the origin of $configfile to complete relative included paths on included
         # files according to ssh_config(5):
@@ -2029,13 +1991,11 @@ _known_hosts_real()
 
     # Known hosts files from configs
     if ((${#config[@]} > 0)); then
-        IFS=$'\n'
         # expand paths (if present) to global and user known hosts files
         # TODO(?): try to make known hosts files with more than one consecutive
         #          spaces in their name work (watch out for ~ expansion
         #          breakage! Alioth#311595)
-        tmpkh=($(awk 'sub("^[ \t]*([Gg][Ll][Oo][Bb][Aa][Ll]|[Uu][Ss][Ee][Rr])[Kk][Nn][Oo][Ww][Nn][Hh][Oo][Ss][Tt][Ss][Ff][Ii][Ll][Ee][ \t=]+", "") { print $0 }' "${config[@]}" | sort -u))
-        IFS=$' \t\n'
+        _comp_split -l tmpkh "$(awk 'sub("^[ \t]*([Gg][Ll][Oo][Bb][Aa][Ll]|[Uu][Ss][Ee][Rr])[Kk][Nn][Oo][Ww][Nn][Hh][Oo][Ss][Tt][Ss][Ff][Ii][Ll][Ee][ \t=]+", "") { print $0 }' "${config[@]}" | sort -u)"
     fi
     if ((${#tmpkh[@]} != 0)); then
         local j
@@ -2082,22 +2042,24 @@ _known_hosts_real()
                     # Ignore leading @foo (markers)
                     [[ $1 == @* ]] && shift
                     # Split entry on commas
-                    IFS=,
-                    for host in $1; do
-                        # Skip hosts containing wildcards
-                        [[ $host == *[*?]* ]] && continue
-                        # Remove leading [
-                        host=${host#[}
-                        # Remove trailing ] + optional :port
-                        host=${host%]?(:+([0-9]))}
-                        # Add host to candidates
-                        COMPREPLY+=($host)
-                    done
-                    IFS=$' \t\n'
+                    local -a hosts
+                    if _comp_split -F , hosts "$1"; then
+                        for host in "${hosts[@]}"; do
+                            # Skip hosts containing wildcards
+                            [[ $host == *[*?]* ]] && continue
+                            # Remove leading [
+                            host=${host#[}
+                            # Remove trailing ] + optional :port
+                            host=${host%]?(:+([0-9]))}
+                            # Add host to candidates
+                            [[ $host ]] &&
+                                COMPREPLY+=("$host")
+                        done
+                    fi
                 done <"$i"
             done
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen COMPREPLY -W '"${COMPREPLY[@]}"' -- "$cur"
         fi
         if ((${#khd[@]} > 0)); then
             # Needs to look for files called
@@ -2108,7 +2070,7 @@ _known_hosts_real()
                 if [[ $i == *key_22_$cur*.pub && -r $i ]]; then
                     host=${i/#*key_22_/}
                     host=${host/%.pub/}
-                    COMPREPLY+=($host)
+                    [[ $host ]] && COMPREPLY+=("$host")
                 fi
             done
         fi
@@ -2123,10 +2085,10 @@ _known_hosts_real()
 
     # append any available aliases from ssh config files
     if [[ ${#config[@]} -gt 0 && $aliases ]]; then
-        local -a hosts=($(command sed -ne 's/^[[:blank:]]*[Hh][Oo][Ss][Tt][[:blank:]=]\{1,\}\(.*\)$/\1/p' "${config[@]}"))
-        if ((${#hosts[@]} != 0)); then
-            COMPREPLY+=($(compgen -P "$prefix" \
-                -S "$suffix" -W '"${hosts[@]%%[*?%]*}"' -X '@(\!*|)' -- "$cur"))
+        local -a hosts
+        if _comp_split hosts "$(command sed -ne 's/^[[:blank:]]*[Hh][Oo][Ss][Tt][[:blank:]=]\{1,\}\(.*\)$/\1/p' "${config[@]}")"; then
+            _comp_compgen -a COMPREPLY -P "$prefix" \
+                -S "$suffix" -W '"${hosts[@]%%[*?%]*}"' -X '@(\!*|)' -- "$cur"
         fi
     fi
 
@@ -2135,24 +2097,22 @@ _known_hosts_real()
         type avahi-browse &>/dev/null; then
         # Some old versions of avahi-browse reportedly didn't have -k
         # (even if mentioned in the manpage); those we do not support any more.
-        COMPREPLY+=($(compgen -P "$prefix" -S "$suffix" -W \
-            "$(avahi-browse -cprak 2>/dev/null | awk -F';' \
-                '/^=/ && $5 ~ /^_(ssh|workstation)\._tcp$/ { print $7 }' |
-                sort -u)" -- "$cur"))
+        local generated=$(avahi-browse -cprak 2>/dev/null | awk -F';' \
+            '/^=/ && $5 ~ /^_(ssh|workstation)\._tcp$/ { print $7 }' |
+            sort -u)
+        _comp_compgen -a COMPREPLY -P "$prefix" -S "$suffix" -W '$generated' -- "$cur"
     fi
 
     # Add hosts reported by ruptime.
     if type ruptime &>/dev/null; then
-        COMPREPLY+=($(compgen -W \
-            "$(ruptime 2>/dev/null | awk '!/^ruptime:/ { print $1 }')" \
-            -- "$cur"))
+        local generated=$(ruptime 2>/dev/null | awk '!/^ruptime:/ { print $1 }')
+        _comp_compgen -a COMPREPLY -W '$generated' -- "$cur"
     fi
 
     # Add results of normal hostname completion, unless
     # `BASH_COMPLETION_KNOWN_HOSTS_WITH_HOSTFILE' is set to an empty value.
     if [[ ${BASH_COMPLETION_KNOWN_HOSTS_WITH_HOSTFILE-${COMP_KNOWN_HOSTS_WITH_HOSTFILE-1}} ]]; then
-        COMPREPLY+=(
-            $(compgen -A hostname -P "$prefix" -S "$suffix" -- "$cur"))
+        _comp_compgen -a COMPREPLY -A hostname -P "$prefix" -S "$suffix" -- "$cur"
     fi
 
     $reset
@@ -2186,7 +2146,8 @@ _cd()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help help "$1")' -- "$cur"))
+        local cmd=$1
+        _comp_compgen COMPREPLY -W '$(_parse_help help "$cmd")' -- "$cur"
         compopt +o nospace
         return
     fi
@@ -2271,7 +2232,7 @@ _comp_command_offset()
     if ((COMP_CWORD == 0)); then
         local IFS=$'\n'
         compopt -o filenames
-        COMPREPLY=($(compgen -d -c -- "$cur"))
+        _comp_compgen COMPREPLY -d -c -- "$cur"
     else
         local ret
         _comp_dequote "${COMP_WORDS[0]}" || ret=${COMP_WORDS[0]}
@@ -2341,9 +2302,7 @@ _comp_command_offset()
             else
                 cspec=${cspec#complete}
                 cspec=${cspec%%@("$compcmd"|"'${compcmd//\'/\'\\\'\'}'")}
-                local result=$(eval compgen "$cspec" -- '$cur')
-                local IFS=$'\n'
-                COMPREPLY=($result)
+                eval "_comp_compgen COMPREPLY $cspec -- \"\$cur\""
             fi
             break
         done
@@ -2421,11 +2380,11 @@ _longopt()
     $split && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(LC_ALL=C $1 --help 2>&1 |
+        _comp_compgen COMPREPLY -W "$(LC_ALL=C $1 --help 2>&1 |
             while read -r line; do
                 [[ $line =~ --[A-Za-z0-9]+([-_][A-Za-z0-9]+)*=? ]] &&
                     printf '%s\n' "${BASH_REMATCH[0]}"
-            done)" -- "$cur"))
+            done)" -- "$cur"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ $1 == *@(rmdir|chroot) ]]; then
         _filedir -d
@@ -2455,16 +2414,9 @@ _filedir_xspec()
     _comp_quote_compgen "$cur"
     local quoted=$ret
 
-    local IFS=$'\n' xspec=${_xspecs[${1##*/}]} tmp
+    local xspec=${_xspecs[${1##*/}]} tmp
     local -a toks
-
-    toks=($(
-        compgen -d -- "$quoted" | {
-            while read -r tmp; do
-                printf '%s\n' "$tmp"
-            done
-        }
-    ))
+    _comp_compgen toks -d -- "$quoted"
 
     # Munge xspec to contain uppercase version too
     # https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00036.html
@@ -2477,24 +2429,12 @@ _filedir_xspec()
     fi
     xspec="$matchop($xspec|${xspec^^})"
 
-    toks+=($(
-        eval compgen -f -X "'!$xspec'" -- '$quoted' | {
-            while read -r tmp; do
-                [[ $tmp ]] && printf '%s\n' "$tmp"
-            done
-        }
-    ))
+    _comp_compgen -a toks -f -X "@(|!($xspec))" -- "$quoted"
 
     # Try without filter if it failed to produce anything and configured to
     [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} &&
-        ${#toks[@]} -lt 1 ]] && {
-        local reset=$(shopt -po noglob)
-        set -o noglob
-        toks+=($(compgen -f -- "$quoted"))
-        IFS=' '
-        $reset
-        IFS=$'\n'
-    }
+        ${#toks[@]} -lt 1 ]] &&
+        _comp_compgen -a toks -f -- "$quoted"
 
     if ((${#toks[@]} != 0)); then
         compopt -o filenames

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -1,5 +1,6 @@
 EXTRA_DIST = \
 	test_unit_command_offset.py \
+	test_unit_compgen.py \
 	test_unit_count_args.py \
 	test_unit_deprecate_func.py \
 	test_unit_dequote.py \

--- a/test/t/unit/test_unit_compgen.py
+++ b/test/t/unit/test_unit_compgen.py
@@ -1,0 +1,85 @@
+import pytest
+
+from conftest import assert_bash_exec, bash_env_saved
+
+
+@pytest.mark.bashcomp(cmd=None)
+class TestUtilCompgen:
+    @pytest.fixture
+    def functions(self, bash):
+        assert_bash_exec(
+            bash,
+            "_comp__test_dump() { ((${#arr[@]})) && printf '<%s>' \"${arr[@]}\"; echo; }",
+        )
+        assert_bash_exec(
+            bash,
+            '_comp__test_words() { local -a arr=(00) input; input=("${@:1:$#-1}"); _comp_compgen arr -W \'${input[@]+"${input[@]}"}\' -- "${@:$#}"; _comp__test_dump; }',
+        )
+        assert_bash_exec(
+            bash,
+            '_comp__test_words_ifs() { local -a arr=(00); local input=$2; _comp_compgen -F "$1" arr -W \'$input\' -- "${@:$#}"; _comp__test_dump; }',
+        )
+
+    def test_1_basic(self, bash, functions):
+        output = assert_bash_exec(
+            bash, "_comp__test_words 12 34 56 ''", want_output=True
+        )
+        assert output.strip() == "<12><34><56>"
+
+    def test_2_space(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            "_comp__test_words $'a b' $'c d\\t' '  e  ' $'\\tf\\t' ''",
+            want_output=True,
+        )
+        assert output.strip() == "<a b><c d\t><  e  ><\tf\t>"
+
+    def test_2_IFS(self, bash, functions):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.write_variable("IFS", "34")
+            output = assert_bash_exec(
+                bash, "_comp__test_words 12 34 56 ''", want_output=True
+            )
+            assert output.strip() == "<12><34><56>"
+
+    def test_3_glob(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            "_comp__test_words '*' '[a-z]*' '[a][b][c]' ''",
+            want_output=True,
+        )
+        assert output.strip() == "<*><[a-z]*><[a][b][c]>"
+
+    def test_3_failglob(self, bash, functions):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("failglob", True)
+            output = assert_bash_exec(
+                bash,
+                "_comp__test_words '*' '[a-z]*' '[a][b][c]' ''",
+                want_output=True,
+            )
+            assert output.strip() == "<*><[a-z]*><[a][b][c]>"
+
+    def test_3_nullglob(self, bash, functions):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("nullglob", True)
+            output = assert_bash_exec(
+                bash,
+                "_comp__test_words '*' '[a-z]*' '[a][b][c]' ''",
+                want_output=True,
+            )
+            assert output.strip() == "<*><[a-z]*><[a][b][c]>"
+
+    def test_4_empty(self, bash, functions):
+        output = assert_bash_exec(
+            bash, "_comp__test_words ''", want_output=True
+        )
+        assert output.strip() == ""
+
+    def test_5_option_F(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            "_comp__test_words_ifs '25' ' 123 456 555 ' ''",
+            want_output=True,
+        )
+        assert output.strip() == "< 1><3 4><6 >< >"


### PR DESCRIPTION
Now we have a utility function `_comp_split` to safely split strings (including the output of the `compgen` builtin and other commands) without being affected by pathname expansions, unexpected word splitting, etc. I would like to switch from the repeated `local IFS=... reset=$(shopt -po noglob); set -o noglob; ...; IFS=$' \t\n'; $reset` to `_comp_split`.

- b46b71e7 I modified `_comp_split` to return whether nonzero elements are produced in the exit status. This is because `((${#arr[@]}))` is tested in many cases after splitting strings.
- f8a8f9f6 Also, there are many cases of `_comp_split -l arr "$(compgen ARGS)"`, so it is useful to define a function `_comp_compgen arr ARGS` (in particular to reduce nested quoting and command substitutions).
- bf37c0d91cd1bd933b152174a75d9a9580976ebd and a765cc58c9dec40e5618ce2f85400c48f30ca2f8 are independent fixes of the problems I noticed in testing `_comp_compgen`, etc.
- d015b5c1e03d5ac590abdc9e7fbd517901fb1849 is the main rewrite for the switching

The changes suggested in this PR are actually the ones that I mentioned in the following PRs before.

- https://github.com/scop/bash-completion/pull/887#issuecomment-1442170763
- https://github.com/scop/bash-completion/pull/909#issuecomment-1488328631

The changes to `completions/*` are left for later PRs.

