### PR TITLE
fix(_minimal): fall back to defaults instead of `_filedir`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2487,10 +2487,9 @@ unset -f _install_xspec
 # Minimal completion to use as fallback in _completion_loader.
 _minimal()
 {
-    local cur prev words cword split comp_args
-    _comp_initialize -s -- "$@" || return
-    $split && return
-    _filedir
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+    compopt -o bashdefault -o default
 }
 # Complete the empty string to allow completion of '>', '>>', and '<' on < 4.3
 # https://lists.gnu.org/archive/html/bug-bash/2012-01/msg00045.html


### PR DESCRIPTION
We don't actually know if filenames are wanted here, so there's no reason to insist filename completions specifically. Besides, the bash and readline defaults handle the basic filename completions at least as well as we do. They additionally make wildcard completions work.

Remove no longer needed long option splitting, as it is no longer needed after this change.

Closes https://github.com/scop/bash-completion/issues/444