### PR TITLE
chore(gitlint): ignore fixup and squash commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,8 +1,6 @@
 [general]
 ignore = body-is-missing
-ignore-fixup-commits = false
 ignore-revert-commits = false
-ignore-squash-commits = false
 ignore-stdin = true
 contrib = contrib-title-conventional-commits
 regex-style-search = true


### PR DESCRIPTION
Per rationale at
https://jorisroovers.com/gitlint/#merge-fixup-squash-and-revert-commits

> ... these are temporary commits that will be squashed into a
> different commit, ...