### PR TITLE
refactor(cd): move to `completions/`, rename `_cd` -> `_comp_cmd_cd`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2163,65 +2163,6 @@ _known_hosts_real()
 complete -F _known_hosts traceroute traceroute6 \
     fping fping6 telnet rsh rlogin ftp dig drill mtr ssh-installkeys showmount
 
-# This meta-cd function observes the CDPATH variable, so that cd additionally
-# completes on directories under those specified in CDPATH.
-#
-_cd()
-{
-    local cur prev words cword comp_args
-    _comp_initialize -- "$@" || return
-
-    if [[ $cur == -* ]]; then
-        local cmd=$1
-        _comp_compgen COMPREPLY -W '$(_parse_help help "$cmd")' -- "$cur"
-        compopt +o nospace
-        return
-    fi
-
-    local IFS=$'\n' i j k
-
-    compopt -o filenames
-
-    # Use standard dir completion if no CDPATH or parameter starts with /,
-    # ./ or ../
-    if [[ ! ${CDPATH-} || $cur == ?(.)?(.)/* ]]; then
-        _filedir -d
-        return
-    fi
-
-    local mark_dirs="" mark_symdirs=""
-    _comp_readline_variable_on mark-directories && mark_dirs=y
-    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=y
-
-    # we have a CDPATH, so loop on its contents
-    for i in ${CDPATH//:/$'\n'}; do
-        # create an array of matched subdirs
-        k=${#COMPREPLY[@]}
-        for j in $(compgen -d -- "$i/$cur"); do
-            if [[ ($mark_symdirs && -L $j || $mark_dirs && ! -L $j) && ! -d ${j#"$i/"} ]]; then
-                j+="/"
-            fi
-            COMPREPLY[k++]=${j#"$i/"}
-        done
-    done
-
-    _filedir -d
-
-    if ((${#COMPREPLY[@]} == 1)); then
-        i=${COMPREPLY[0]}
-        if [[ $i == "$cur" && $i != "*/" ]]; then
-            COMPREPLY[0]="${i}/"
-        fi
-    fi
-
-    return
-}
-if shopt -q cdable_vars; then
-    complete -v -F _cd -o nospace cd pushd
-else
-    complete -F _cd -o nospace cd pushd
-fi
-
 # A meta-command completion function for commands like sudo(8), which need to
 # first complete on a command, then complete according to that command's own
 # completion definition.

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -235,4 +235,11 @@ _init_completion()
 # shellcheck disable=SC2154  # defined in the main "bash_completion"
 _backup_glob=$_comp_backup_glob
 
+# @deprecated use `_comp_cmd_cd` instead.
+_cd()
+{
+    declare -F _comp_cmd_cd &>/dev/null || __load_completion cd
+    _comp_cmd_cd "$@"
+}
+
 # ex: filetype=sh

--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -169,6 +169,7 @@
 /puppetmasterd
 /puppetqd
 /puppetrun
+/pushd
 /pvchange
 /pvcreate
 /pvdisplay

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -43,6 +43,7 @@ bashcomp_DATA = 2to3 \
 		carton \
 		ccache \
 		ccze \
+		cd \
 		cfagent \
 		cfrun \
 		chage \
@@ -701,6 +702,7 @@ CLEANFILES = \
 	puppetmasterd \
 	puppetqd \
 	puppetrun \
+	pushd \
 	pvchange \
 	pvcreate \
 	pvdisplay \
@@ -852,6 +854,8 @@ symlinks: $(DATA)
 		ncal
 	$(ss) cardctl \
 		pccardctl
+	$(ss) cd \
+		pushd
 	$(ss) chromium-browser \
 		chrome chromium google-chrome google-chrome-stable
 	$(ss) complete \

--- a/completions/cd
+++ b/completions/cd
@@ -1,0 +1,57 @@
+# cd(1) completion                                         -*- shell-script -*-
+
+# This meta-cd function observes the CDPATH variable, so that `cd`
+# additionally completes on directories under those specified in CDPATH.
+_comp_cmd_cd()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    if [[ $cur == -* ]]; then
+        local cmd=$1
+        _comp_compgen COMPREPLY -W '$(_parse_help help "$cmd")' -- "$cur"
+        compopt +o nospace
+        return
+    fi
+
+    local IFS=$'\n' i j k
+
+    compopt -o filenames
+
+    # Use standard dir completion if no CDPATH or parameter starts with /,
+    # ./ or ../
+    if [[ ! ${CDPATH-} || $cur == ?(.)?(.)/* ]]; then
+        _filedir -d
+        return
+    fi
+
+    local mark_dirs="" mark_symdirs=""
+    _comp_readline_variable_on mark-directories && mark_dirs=y
+    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=y
+
+    # we have a CDPATH, so loop on its contents
+    for i in ${CDPATH//:/$'\n'}; do
+        # create an array of matched subdirs
+        k=${#COMPREPLY[@]}
+        for j in $(compgen -d -- "$i/$cur"); do
+            if [[ ($mark_symdirs && -L $j || $mark_dirs && ! -L $j) && ! -d ${j#"$i/"} ]]; then
+                j+="/"
+            fi
+            COMPREPLY[k++]=${j#"$i/"}
+        done
+    done
+
+    _filedir -d
+
+    if ((${#COMPREPLY[@]} == 1)); then
+        i=${COMPREPLY[0]}
+        if [[ $i == "$cur" && $i != "*/" ]]; then
+            COMPREPLY[0]="${i}/"
+        fi
+    fi
+}
+if shopt -q cdable_vars; then
+    complete -v -F _comp_cmd_cd -o nospace cd pushd
+else
+    complete -F _comp_cmd_cd -o nospace cd pushd
+fi


### PR DESCRIPTION
Not sure why this was left embedded in `bash_completion`.