### PR TITLE
[WIP] Array utilities

### DIFF
--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -150,3 +150,57 @@ _comp_xfunc_ARRAY_filter()
 
     [[ ! $_unset ]]
 }
+
+_bashcomp_uniq()
+{
+    local -n _bashcomp_uniq_array_=$1
+    local -A tmp
+    local -i i
+    for i in ${!_bashcomp_uniq_array_[*]}; do
+        ((tmp["${_bashcomp_uniq_array_[i]}"]++ > 0)) &&
+            unset '_bashcomp_uniq_array_[i]'
+    done
+}
+
+_bashcomp_last_index()
+{
+    local -n _bashcomp_last_index_array_=$1 _bashcomp_last_index_ret_=$2
+    local -i i
+    for i in ${!_bashcomp_last_index_array_[*]}; do :; done
+    _bashcomp_last_index_ret_=$i
+}
+
+_bashcomp_compact()
+{
+    local -n _bashcomp_compact_array_=$1
+    local i j=0
+
+    for i in ${!_bashcomp_compact_array_[*]}; do
+        if ((i > j)); then
+            _bashcomp_compact_array_[j]="${_bashcomp_compact_array_[i]}"
+            unset "_bashcomp_compact_array_[i]"
+        fi
+        ((j++))
+    done
+}
+
+_bashcomp_index_of()
+{
+    # TODO getopts -> -r gets rightmost (last) index
+    # TODO getopts: -R uses regex instead of glob
+    local -n _bashcomp_index_of_array_=$1
+    local pattern=$2
+    local -n _bashcomp_index_of_ret_=$3
+
+    local -i i
+    for i in ${!_bashcomp_index_of_array_[*]}; do
+        # shellcheck disable=SC2053
+        if [[ ${_bashcomp_index_of_array_[i]} == $pattern ]]; then
+            _bashcomp_index_of_ret_=$i
+            return 0
+        fi
+    done
+
+    _bashcomp_index_of_ret_=-1
+    return 1
+}

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -224,25 +224,97 @@ _comp_compact()
     _comp_compact__array=("${_comp_compact__array[@]}")
 }
 
+# @version bash-4.3
+_comp_xfunc_ARRAY_reverse()
+{
+    _comp_compact "$1"
+    local -n _comp_reverse__arr=$1
+    local _comp_reverse__i=0
+    local _comp_reverse__j=$((${#_comp_reverse__arr[@]} - 1))
+    local _comp_reverse__tmp
+    while ((_comp_reverse__i < _comp_reverse__j)); do
+        _comp_reverse__tmp=${_comp_reverse__arr[_comp_reverse__i]}
+        _comp_reverse__arr[_comp_reverse__i]=${_comp_reverse__arr[_comp_reverse__j]}
+        _comp_reverse__arr[_comp_reverse__j]=$_comp_reverse__tmp
+        ((_comp_reverse__i++, _comp_reverse__j--))
+    done
+}
+
+# usage: _comp_index_of [-EFGpxmxrl] array pattern
 # Find the index of a matching element
+# Options:
+#
+#   -EFGe  Select the type of the pattern.  The default is -F.
+#   -psmx  Select the anchoring option.
+#   -r     Revert the condition.
+#     See _comp_xfunc_ARRAY_filter for the details of these options.
+#
+#   -l     Get the last index of matching elements.
+#
 # @var[out] ret
 # @version bash-4.3
 _comp_index_of()
 {
-    # TODO getopts -> -r gets rightmost (last) index
-    # TODO getopts: -R uses regex instead of glob
-    local -n _comp_index_of__array=$1
-    local _comp_compact__pattern=$2
-
-    local -i _comp_index_of__i
-    for _comp_index_of__i in "${!_comp_index_of__array[@]}"; do
-        # shellcheck disable=SC2053
-        if [[ ${_comp_index_of__array[_comp_index_of__i]} == $_comp_compact__pattern ]]; then
-            ret=$_comp_index_of__i
-            return 0
-        fi
+    local _old_nocasematch=""
+    if shopt -q nocasematch; then
+        _old_nocasematch=set
+        shopt -u nocasematch
+    fi
+    local _flags="" _pattype=F _anchoring=""
+    local OPTIND=1 OPTARG="" OPTERR=0 _opt=""
+    while getopts 'EFGepsmxrl' _opt "$@"; do
+        case $_opt in
+            [EFGe]) _pattype=$_opt ;;
+            [psmx]) _anchoring=$_opt ;;
+            [rl]) _flags+=$_opt ;;
+            *)
+                printf 'bash_completion: %s: %s\n' "$FUNCNAME" 'usage error' >&2
+                printf 'usage: %s %s\n' "$FUNCNAME" "[-EFGepsmxrl] ARRAY_NAME CONDITION" >&2
+                return 2
+                ;;
+        esac
     done
+    shift "$((OPTIND - 1))"
+    if (($# != 2)); then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "unexpected number of arguments: $#" >&2
+        printf 'usage: %s %s\n' "$FUNCNAME" "[-EFGepsmxrl] ARRAY_NAME CONDITION" >&2
+        [[ $_old_nocasematch ]] && shopt -s nocasematch
+        return 2
+    elif [[ $1 != [a-zA-Z_]*([a-zA-Z_0-9]) ]]; then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "invalid array name '$1'." >&2
+        [[ $_old_nocasematch ]] && shopt -s nocasematch
+        return 2
+    elif [[ $1 == @(_*|OPTIND|OPTARG|OPTERR) ]]; then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "array name '$1' is reserved for internal uses" >&2
+        [[ $_old_nocasematch ]] && shopt -s nocasematch
+        return 2
+    fi
+    [[ $_old_nocasematch ]] && shopt -s nocasematch
 
     ret=-1
+
+    local -n _array=$1
+    if ((${#_array[@]})); then
+        local _predicate
+        _comp_xfunc_ARRAY__init_predicate "$2" "$_pattype" "$_anchoring" "$_flags"
+
+        local -a _indices=("${!_array[@]}")
+        [[ $_flags == *l* ]] && _comp_xfunc_ARRAY_reverse _indices
+
+        local -i _i
+        for _i in "${_indices[@]}"; do
+            _comp_xfunc_ARRAY__predicate "${_array[_i]}"
+            case $? in
+                0)
+                    ret=$_i
+                    return 0
+                    ;;
+                1) continue ;;
+                27) return 27 ;;
+                *) return 2 ;;
+            esac
+        done
+    fi
+
     return 1
 }

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -151,56 +151,56 @@ _comp_xfunc_ARRAY_filter()
     [[ ! $_unset ]]
 }
 
-_bashcomp_uniq()
+_comp_uniq()
 {
-    local -n _bashcomp_uniq_array_=$1
+    local -n _comp_uniq__array=$1
     local -A tmp
     local -i i
-    for i in ${!_bashcomp_uniq_array_[*]}; do
-        ((tmp["${_bashcomp_uniq_array_[i]}"]++ > 0)) &&
-            unset '_bashcomp_uniq_array_[i]'
+    for i in ${!_comp_uniq__array[*]}; do
+        ((tmp["${_comp_uniq__array[i]}"]++ > 0)) &&
+            unset '_comp_uniq__array[i]'
     done
 }
 
-_bashcomp_last_index()
+_comp_last_index()
 {
-    local -n _bashcomp_last_index_array_=$1 _bashcomp_last_index_ret_=$2
+    local -n _comp_last_index__array=$1 _comp_last_index__ret=$2
     local -i i
-    for i in ${!_bashcomp_last_index_array_[*]}; do :; done
-    _bashcomp_last_index_ret_=$i
+    for i in ${!_comp_last_index__array[*]}; do :; done
+    _comp_last_index__ret=$i
 }
 
-_bashcomp_compact()
+_comp_compact()
 {
-    local -n _bashcomp_compact_array_=$1
+    local -n _comp_compact__array=$1
     local i j=0
 
-    for i in ${!_bashcomp_compact_array_[*]}; do
+    for i in ${!_comp_compact__array[*]}; do
         if ((i > j)); then
-            _bashcomp_compact_array_[j]="${_bashcomp_compact_array_[i]}"
-            unset "_bashcomp_compact_array_[i]"
+            _comp_compact__array[j]="${_comp_compact__array[i]}"
+            unset "_comp_compact__array[i]"
         fi
         ((j++))
     done
 }
 
-_bashcomp_index_of()
+_comp_index_of()
 {
     # TODO getopts -> -r gets rightmost (last) index
     # TODO getopts: -R uses regex instead of glob
-    local -n _bashcomp_index_of_array_=$1
+    local -n _comp_index_of__array=$1
     local pattern=$2
-    local -n _bashcomp_index_of_ret_=$3
+    local -n _comp_index_of__ret=$3
 
     local -i i
-    for i in ${!_bashcomp_index_of_array_[*]}; do
+    for i in ${!_comp_index_of__array[*]}; do
         # shellcheck disable=SC2053
-        if [[ ${_bashcomp_index_of_array_[i]} == $pattern ]]; then
-            _bashcomp_index_of_ret_=$i
+        if [[ ${_comp_index_of__array[i]} == $pattern ]]; then
+            _comp_index_of__ret=$i
             return 0
         fi
     done
 
-    _bashcomp_index_of_ret_=-1
+    _comp_index_of__ret=-1
     return 1
 }

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -208,13 +208,13 @@ _comp_uniq()
 }
 
 # Obtain the largest index
-# @var[out] ret
+# @var[out] REPLY
 # @version bash-4.3
 _comp_last_index()
 {
     local -n _comp_last_index__array=$1
     local -a _comp_last_index__indices=("${!_comp_last_index__array[@]}")
-    ret=${_comp_last_index__indices[*]: -1}
+    REPLY=${_comp_last_index__indices[*]: -1}
 }
 
 # @version bash-4.3
@@ -251,7 +251,7 @@ _comp_xfunc_ARRAY_reverse()
 #
 #   -l     Get the last index of matching elements.
 #
-# @var[out] ret
+# @var[out] REPLY
 # @version bash-4.3
 _comp_index_of()
 {
@@ -291,7 +291,7 @@ _comp_index_of()
     fi
     [[ $_old_nocasematch ]] && shopt -s nocasematch
 
-    ret=-1
+    REPLY=-1
 
     local -n _array=$1
     if ((${#_array[@]})); then
@@ -306,7 +306,7 @@ _comp_index_of()
             _comp_xfunc_ARRAY__predicate "${_array[_i]}"
             case $? in
                 0)
-                    ret=$_i
+                    REPLY=$_i
                     return 0
                     ;;
                 1) continue ;;

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -156,7 +156,7 @@ _comp_uniq()
     local -n _comp_uniq__array=$1
     local -A tmp
     local -i i
-    for i in ${!_comp_uniq__array[*]}; do
+    for i in "${!_comp_uniq__array[@]}"; do
         ((tmp["${_comp_uniq__array[i]}"]++ > 0)) &&
             unset '_comp_uniq__array[i]'
     done
@@ -166,7 +166,7 @@ _comp_last_index()
 {
     local -n _comp_last_index__array=$1 _comp_last_index__ret=$2
     local -i i
-    for i in ${!_comp_last_index__array[*]}; do :; done
+    for i in "${!_comp_last_index__array[@]}"; do :; done
     _comp_last_index__ret=$i
 }
 
@@ -175,7 +175,7 @@ _comp_compact()
     local -n _comp_compact__array=$1
     local i j=0
 
-    for i in ${!_comp_compact__array[*]}; do
+    for i in "${!_comp_compact__array[@]}"; do
         if ((i > j)); then
             _comp_compact__array[j]="${_comp_compact__array[i]}"
             unset "_comp_compact__array[i]"
@@ -193,7 +193,7 @@ _comp_index_of()
     local -n _comp_index_of__ret=$3
 
     local -i i
-    for i in ${!_comp_index_of__array[*]}; do
+    for i in "${!_comp_index_of__array[@]}"; do
         # shellcheck disable=SC2053
         if [[ ${_comp_index_of__array[i]} == $pattern ]]; then
             _comp_index_of__ret=$i

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -166,9 +166,8 @@ _comp_uniq()
 _comp_last_index()
 {
     local -n _comp_last_index__array=$1 _comp_last_index__ret=$2
-    local -i _comp_last_index__i
-    for _comp_last_index__i in "${!_comp_last_index__array[@]}"; do :; done
-    _comp_last_index__ret=$_comp_last_index__i
+    local -a _comp_last_index__indices=("${!_comp_last_index__array[@]}")
+    _comp_last_index__ret=${_comp_last_index__indices[*]: -1}
 }
 
 _comp_compact()

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -154,33 +154,33 @@ _comp_xfunc_ARRAY_filter()
 _comp_uniq()
 {
     local -n _comp_uniq__array=$1
-    local -A tmp
-    local -i i
-    for i in "${!_comp_uniq__array[@]}"; do
-        ((tmp["${_comp_uniq__array[i]}"]++ > 0)) &&
-            unset '_comp_uniq__array[i]'
+    local -A _comp_uniq__tmp
+    local -i _comp_uniq__i
+    for _comp_uniq__i in "${!_comp_uniq__array[@]}"; do
+        ((_comp_uniq__tmp["${_comp_uniq__array[_comp_uniq__i]}"]++ > 0)) &&
+            unset '_comp_uniq__array[_comp_uniq__i]'
     done
 }
 
 _comp_last_index()
 {
     local -n _comp_last_index__array=$1 _comp_last_index__ret=$2
-    local -i i
-    for i in "${!_comp_last_index__array[@]}"; do :; done
-    _comp_last_index__ret=$i
+    local -i _comp_last_index__i
+    for _comp_last_index__i in "${!_comp_last_index__array[@]}"; do :; done
+    _comp_last_index__ret=$_comp_last_index__i
 }
 
 _comp_compact()
 {
     local -n _comp_compact__array=$1
-    local i j=0
+    local _comp_compact__i _comp_compact__j=0
 
-    for i in "${!_comp_compact__array[@]}"; do
-        if ((i > j)); then
-            _comp_compact__array[j]="${_comp_compact__array[i]}"
-            unset "_comp_compact__array[i]"
+    for _comp_compact__i in "${!_comp_compact__array[@]}"; do
+        if ((_comp_compact__i > _comp_compact__j)); then
+            _comp_compact__array[_comp_compact__j]="${_comp_compact__array[_comp_compact__i]}"
+            unset "_comp_compact__array[_comp_compact__i]"
         fi
-        ((j++))
+        ((_comp_compact__j++))
     done
 }
 
@@ -189,14 +189,14 @@ _comp_index_of()
     # TODO getopts -> -r gets rightmost (last) index
     # TODO getopts: -R uses regex instead of glob
     local -n _comp_index_of__array=$1
-    local pattern=$2
+    local _comp_compact__pattern=$2
     local -n _comp_index_of__ret=$3
 
-    local -i i
-    for i in "${!_comp_index_of__array[@]}"; do
+    local -i _comp_index_of__i
+    for _comp_index_of__i in "${!_comp_index_of__array[@]}"; do
         # shellcheck disable=SC2053
-        if [[ ${_comp_index_of__array[i]} == $pattern ]]; then
-            _comp_index_of__ret=$i
+        if [[ ${_comp_index_of__array[_comp_index_of__i]} == $_comp_compact__pattern ]]; then
+            _comp_index_of__ret=$_comp_index_of__i
             return 0
         fi
     done

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -154,11 +154,12 @@ _comp_xfunc_ARRAY_filter()
 _comp_uniq()
 {
     local -n _comp_uniq__array=$1
-    local -A _comp_uniq__tmp
+    local -A _comp_uniq__tmp=()
     local -i _comp_uniq__i
     for _comp_uniq__i in "${!_comp_uniq__array[@]}"; do
-        ((_comp_uniq__tmp["${_comp_uniq__array[_comp_uniq__i]}"]++ > 0)) &&
+        [[ ${_comp_uniq__tmp[${_comp_uniq__array[_comp_uniq__i]}]-} ]] &&
             unset -v '_comp_uniq__array[_comp_uniq__i]'
+        _comp_uniq__tmp[${_comp_uniq__array[_comp_uniq__i]}]=set
     done
 }
 

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -158,7 +158,7 @@ _comp_uniq()
     local -i _comp_uniq__i
     for _comp_uniq__i in "${!_comp_uniq__array[@]}"; do
         ((_comp_uniq__tmp["${_comp_uniq__array[_comp_uniq__i]}"]++ > 0)) &&
-            unset '_comp_uniq__array[_comp_uniq__i]'
+            unset -v '_comp_uniq__array[_comp_uniq__i]'
     done
 }
 
@@ -178,7 +178,7 @@ _comp_compact()
     for _comp_compact__i in "${!_comp_compact__array[@]}"; do
         if ((_comp_compact__i > _comp_compact__j)); then
             _comp_compact__array[_comp_compact__j]="${_comp_compact__array[_comp_compact__i]}"
-            unset "_comp_compact__array[_comp_compact__i]"
+            unset -v '_comp_compact__array[_comp_compact__i]'
         fi
         ((_comp_compact__j++))
     done

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -151,6 +151,7 @@ _comp_xfunc_ARRAY_filter()
     [[ ! $_unset ]]
 }
 
+# @version bash-4.3
 _comp_uniq()
 {
     local -n _comp_uniq__array=$1
@@ -163,36 +164,42 @@ _comp_uniq()
     done
 }
 
+# Obtain the largest index
+# @var[out] ret
+# @version bash-4.3
 _comp_last_index()
 {
-    local -n _comp_last_index__array=$1 _comp_last_index__ret=$2
+    local -n _comp_last_index__array=$1
     local -a _comp_last_index__indices=("${!_comp_last_index__array[@]}")
-    _comp_last_index__ret=${_comp_last_index__indices[*]: -1}
+    ret=${_comp_last_index__indices[*]: -1}
 }
 
+# @version bash-4.3
 _comp_compact()
 {
     local -n _comp_compact__array=$1
     _comp_compact__array=("${_comp_compact__array[@]}")
 }
 
+# Find the index of a matching element
+# @var[out] ret
+# @version bash-4.3
 _comp_index_of()
 {
     # TODO getopts -> -r gets rightmost (last) index
     # TODO getopts: -R uses regex instead of glob
     local -n _comp_index_of__array=$1
     local _comp_compact__pattern=$2
-    local -n _comp_index_of__ret=$3
 
     local -i _comp_index_of__i
     for _comp_index_of__i in "${!_comp_index_of__array[@]}"; do
         # shellcheck disable=SC2053
         if [[ ${_comp_index_of__array[_comp_index_of__i]} == $_comp_compact__pattern ]]; then
-            _comp_index_of__ret=$_comp_index_of__i
+            ret=$_comp_index_of__i
             return 0
         fi
     done
 
-    _comp_index_of__ret=-1
+    ret=-1
     return 1
 }

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -173,15 +173,7 @@ _comp_last_index()
 _comp_compact()
 {
     local -n _comp_compact__array=$1
-    local _comp_compact__i _comp_compact__j=0
-
-    for _comp_compact__i in "${!_comp_compact__array[@]}"; do
-        if ((_comp_compact__i > _comp_compact__j)); then
-            _comp_compact__array[_comp_compact__j]="${_comp_compact__array[_comp_compact__i]}"
-            unset -v '_comp_compact__array[_comp_compact__i]'
-        fi
-        ((_comp_compact__j++))
-    done
+    _comp_compact__array=("${_comp_compact__array[@]}")
 }
 
 _comp_index_of()

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -1,0 +1,152 @@
+# Utility xfunc functions for array manipulations
+
+# Filter the array elements with the specified condition.
+# @param $1 Array name (that is not "value", "_*" or other internal variable
+#   names)
+# @param $2 When any of the options `-EFG' is specified, the second argument is
+#   used as a pattern string whose meaning is determined by the option `-EFG'.
+#   Otherwise, the second argument specifies the command that tests the array
+#   element.  The command is supposed to exit with:
+#
+#     status 0 .... when the element should be preserved
+#     status 1 .... when the element should be removed
+#     status 2 .... when the usage of the predicate is wrong
+#     status 27 ... when the loop should be canceled.  All the remaining
+#                   elements will be preserved regardless of the presence of
+#                   option `-r'.
+#
+#   The other exit statuses are reserved and cancel the array filtering with an
+#   error message, and the function returns with the exit status 2.  If this is
+#   an existing command name, the command is called with the value of the array
+#   element being specified as the first command argument.  Otherwise, this
+#   shall be a shell command that tests the array-element value stored in the
+#   environment variable "value".
+#
+# Options:
+#
+#     The following options specify the type of the pattern.  When multiple
+#     options are supplied, the last-specified one overwrite the previous
+#     option.
+#
+#     -E          $2 is interpreted as a POSIX extended regular expression.
+#                 The default anchoring is `-m` (see below).
+#     -F          $2 is interpreted as a fixed string.  The default anchoring
+#                 is `-m` (see below).
+#     -G          $2 is interpreted as a glob pattern.  The default anchoring
+#                 is `-x` (see below).
+#
+#     Combined with any of -EFG, the following options specify the anchoring
+#     type of the pattern matching.  When multiple options are supplied, the
+#     last-specified one overwrites the previous option.
+#
+#     -p          performs the prefix matching.
+#     -s          performs the suffix matching.
+#     -m          performs the middle matching.
+#     -x          performs the exact matching.
+#
+#     -r          Revert the condition, i.e., remove elements that satisfy
+#                 the original condition.
+#     -C          Array compaction is not performed.
+#
+# @return 2 with a wrong usage, 1 when any elements are removed, 0 when the set
+#   of array elements are unchanged. [ Note: the compaction will be performed
+#   (without the option -C) even when the set of array elements are
+#   unchanged. ]
+_comp_xfunc_ARRAY_filter()
+{
+    local _flags="" _pattype="" _anchoring=""
+    local OPTIND=1 OPTARG="" OPTERR=0 _opt=""
+    while getopts 'EFGpsmxrC' _opt "$@"; do
+        case $_opt in
+            [EFG]) _pattype=$_opt ;;
+            [psmx]) _anchoring=$_opt ;;
+            [rC]) _flags=$_opt$_flags ;;
+            *)
+                printf 'bash_completion: %s: %s\n' "$FUNCNAME" 'usage error' >&2
+                printf 'usage: %s %s\n' "$FUNCNAME" "[-EFGpsmxrC] ARRAY_NAME CONDITION" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    shift "$((OPTIND - 1))"
+    if (($# != 2)); then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "unexpected number of arguments: $#" >&2
+        printf 'usage: %s %s\n' "$FUNCNAME" "[-EFGpsmxrC] ARRAY_NAME CONDITION" >&2
+        return 2
+    elif [[ $1 != [a-zA-Z_]*([a-zA-Z_0-9]) ]]; then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "invalid array name '$1'." >&2
+        return 2
+    elif [[ $1 == @(_*|OPTIND|OPTARG|OPTERR) ]]; then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "array name '$1' is reserved for internal uses" >&2
+        return 2
+    elif [[ ! $_pattype && $1 == value ]]; then
+        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "array name '$1' cannot be used for the predicate" >&2
+        return 2
+    fi
+    # When the array is empty:
+    eval "((\${#$1[@]}))" || return 0
+
+    local _predicate='' _pattern=$2
+    case $_pattype in
+        E)
+            case $_anchoring in
+                p) _predicate='[[ $_value =~ ^($_pattern) ]]' ;;
+                s) _predicate='[[ $_value =~ ($_pattern)$ ]]' ;;
+                x) _predicate='[[ $_value =~ ^($_pattern)$ ]]' ;;
+                *) _predicate='[[ $_value =~ $_pattern ]]' ;;
+            esac
+            ;;
+        F)
+            case $_anchoring in
+                p) _predicate='[[ $_value == "$_pattern"* ]]' ;;
+                s) _predicate='[[ $_value == *"$_pattern" ]]' ;;
+                x) _predicate='[[ $_value == "$_pattern" ]]' ;;
+                *) _predicate='[[ $_value == *"$_pattern"* ]]' ;;
+            esac
+            ;;
+        G)
+            case $_anchoring in
+                p) _predicate='[[ $_value == $_pattern* ]]' ;;
+                s) _predicate='[[ $_value == *$_pattern ]]' ;;
+                m) _predicate='[[ $_value == *$_pattern* ]]' ;;
+                *) _predicate='[[ $_value == $_pattern ]]' ;;
+            esac
+            ;;
+        *)
+            if type -t "$2" &>/dev/null; then
+                _predicate="$2 \"\$_value\""
+            else
+                _predicate="local -x value=\$_value; $2"
+            fi
+            ;;
+    esac
+
+    local _unset="" _expected_status=0
+    [[ $_flags == *r* ]] && _expected_status=1
+
+    local _indices _index _value
+    eval "_indices=(\"\${!$1[@]}\")"
+    for _index in "${_indices[@]}"; do
+        eval "_value=\${$1[\$_index]}; $_predicate"
+        case $? in
+            "$_expected_status") continue ;;
+            [01])
+                unset -v "$1[\$_index]"
+                _unset=set
+                ;;
+            27) break ;;
+            *)
+                printf 'bash_completion: %s: %s\n' "$FUNCNAME" \
+                    "filter condition broken '${_pattype:+-$_pattype }$2'" >&2
+                return 2
+                ;;
+        esac
+    done
+
+    # Compaction of the sparse array
+    [[ $_flags == *C* ]] ||
+        eval "((\${#$1[@]})) && $1=(\"\${$1[@]}\")"
+
+    [[ ! $_unset ]]
+}

--- a/completions-core/ARRAY.bash
+++ b/completions-core/ARRAY.bash
@@ -1,5 +1,87 @@
 # Utility xfunc functions for array manipulations
 
+# usage: _comp_xfunc_ARRAY__init_predicate pattern pattype [anchoring flags]
+# @param $1      pattern   Pattern
+# @param $2      pattype   /[EFG]/ or empty
+# @param[opt] $3 anchoring /[psmx]/ or empty
+# @param[opt] $4 flags     /r/ or empty
+#   See _comp_xfunc_ARRAY_filter for details of pattern, pattype,
+#   anchoring, and flags.
+#
+# @var[out] _predicate[0] command
+# @var[out] _predicate[1] pattern
+# @var[out] _predicate[2] type
+# @var[out] _predicate[3] revert
+_comp_xfunc_ARRAY__init_predicate()
+{
+    _predicate[0]=false
+    _predicate[1]=$1
+    _predicate[2]=$2
+    _predicate[3]=""
+
+    local old_nocasematch=""
+    if shopt -q nocasematch; then
+        old_nocasematch=set
+        shopt -u nocasematch
+    fi
+
+    local _pattype=$2 _anchoring=${3-} flags=${4-}
+    case $_pattype in
+        E)
+            case $_anchoring in
+                p) _predicate[0]='[[ $_value =~ ^(${_predicate[1]}) ]]' ;;
+                s) _predicate[0]='[[ $_value =~ (${_predicate[1]})$ ]]' ;;
+                x) _predicate[0]='[[ $_value =~ ^(${_predicate[1]})$ ]]' ;;
+                *) _predicate[0]='[[ $_value =~ ${_predicate[1]} ]]' ;;
+            esac
+            ;;
+        F)
+            case $_anchoring in
+                p) _predicate[0]='[[ $_value == "${_predicate[1]}"* ]]' ;;
+                s) _predicate[0]='[[ $_value == *"${_predicate[1]}" ]]' ;;
+                x) _predicate[0]='[[ $_value == "${_predicate[1]}" ]]' ;;
+                *) _predicate[0]='[[ $_value == *"${_predicate[1]}"* ]]' ;;
+            esac
+            ;;
+        G)
+            case $_anchoring in
+                p) _predicate[0]='[[ $_value == ${_predicate[1]}* ]]' ;;
+                s) _predicate[0]='[[ $_value == *${_predicate[1]} ]]' ;;
+                m) _predicate[0]='[[ $_value == *${_predicate[1]}* ]]' ;;
+                *) _predicate[0]='[[ $_value == ${_predicate[1]} ]]' ;;
+            esac
+            ;;
+        *)
+            if type -t "$2" &>/dev/null; then
+                _predicate[0]="$2 \"\$_value\""
+            else
+                _predicate[0]="local -x value=\$_value; $2"
+            fi
+            ;;
+    esac
+
+    [[ $_flags == *r* ]] && _predicate[3]=set
+    [[ $old_nocasematch ]] && shopt -s nocasematch
+}
+
+_comp_xfunc_ARRAY__predicate()
+{
+    local _value=$1
+    eval "${_predicate[0]}"
+
+    local _ext=$?
+    case $_ext in
+        [01]) [[ ${_predicate[3]} ]] && _ext=$((1 - _ext)) ;;
+        27) ;;
+        *)
+            printf 'bash_completion: %s: %s\n' "$FUNCNAME" \
+                "filter condition broken '${_predicate[2]:+-${_predicate[2]} }$2'" >&2
+            return 2
+            ;;
+    esac
+    return "$_ext"
+}
+
 # Filter the array elements with the specified condition.
 # @param $1 Array name (that is not "value", "_*" or other internal variable
 #   names)
@@ -80,67 +162,28 @@ _comp_xfunc_ARRAY_filter()
     elif [[ $1 == @(_*|OPTIND|OPTARG|OPTERR) ]]; then
         printf 'bash_completion: %s: %s\n' "$FUNCNAME" "array name '$1' is reserved for internal uses" >&2
         return 2
-    elif [[ ! $_pattype && $1 == value ]]; then
-        printf 'bash_completion: %s: %s\n' "$FUNCNAME" "array name '$1' cannot be used for the predicate" >&2
-        return 2
     fi
     # When the array is empty:
     eval "((\${#$1[@]}))" || return 0
 
-    local _predicate='' _pattern=$2
-    case $_pattype in
-        E)
-            case $_anchoring in
-                p) _predicate='[[ $_value =~ ^($_pattern) ]]' ;;
-                s) _predicate='[[ $_value =~ ($_pattern)$ ]]' ;;
-                x) _predicate='[[ $_value =~ ^($_pattern)$ ]]' ;;
-                *) _predicate='[[ $_value =~ $_pattern ]]' ;;
-            esac
-            ;;
-        F)
-            case $_anchoring in
-                p) _predicate='[[ $_value == "$_pattern"* ]]' ;;
-                s) _predicate='[[ $_value == *"$_pattern" ]]' ;;
-                x) _predicate='[[ $_value == "$_pattern" ]]' ;;
-                *) _predicate='[[ $_value == *"$_pattern"* ]]' ;;
-            esac
-            ;;
-        G)
-            case $_anchoring in
-                p) _predicate='[[ $_value == $_pattern* ]]' ;;
-                s) _predicate='[[ $_value == *$_pattern ]]' ;;
-                m) _predicate='[[ $_value == *$_pattern* ]]' ;;
-                *) _predicate='[[ $_value == $_pattern ]]' ;;
-            esac
-            ;;
-        *)
-            if type -t "$2" &>/dev/null; then
-                _predicate="$2 \"\$_value\""
-            else
-                _predicate="local -x value=\$_value; $2"
-            fi
-            ;;
-    esac
+    local _predicate
+    _comp_xfunc_ARRAY__init_predicate "$2" "$_pattype" "$_anchoring" "$_flags"
 
-    local _unset="" _expected_status=0
-    [[ $_flags == *r* ]] && _expected_status=1
+    local _unset=""
 
-    local _indices _index _value
+    local _indices _index _ref
     eval "_indices=(\"\${!$1[@]}\")"
     for _index in "${_indices[@]}"; do
-        eval "_value=\${$1[\$_index]}; $_predicate"
+        _ref="$1[\$_index]"
+        _comp_xfunc_ARRAY__predicate "${!_ref}"
         case $? in
-            "$_expected_status") continue ;;
-            [01])
-                unset -v "$1[\$_index]"
+            0) continue ;;
+            1)
+                unset -v "$_ref"
                 _unset=set
                 ;;
             27) break ;;
-            *)
-                printf 'bash_completion: %s: %s\n' "$FUNCNAME" \
-                    "filter condition broken '${_pattype:+-$_pattype }$2'" >&2
-                return 2
-                ;;
+            *) return 2 ;;
         esac
     done
 


### PR DESCRIPTION
I decided to move code stubs for array utilities in #739 and #950 to here.

> I guess this could end up as an invalid regex if `_parse_help` lets any strings through to `main_cmd` that make it so. The previous implementation had the same issue though, so not a regression. Leaving up to you to decide whether to address or merge as is.
> 
> Some array utilities would be nice to help with cases like this. I have this ages old unfinished patch for the main `bash_completion` in my stash, probably broken in the first place and uses namerefs so requires bash >= 4.3, but to illustrate what I was thinking back $then
> 
> ```diff
> +_bashcomp_uniq()
> [...]
> +_bashcomp_last_index() {
> [...]
> +_bashcomp_compact() {
> [...]
> +_bashcomp_index_of() {
> [...]
> ```

_Originally posted by @scop in https://github.com/scop/bash-completion/pull/950#discussion_r1183001067_

> * [bc6f87d](https://github.com/scop/bash-completion/commit/bc6f87d7f27a9df0f5b9662f44316f0426ec02fb) This implements a function `_comp_array_filter`. I'm not sure whether Ville would finally find it reasonable to include the function in bash-completion, but I tried to make the interface minimal (one function `_comp_array_filter`) yet make the function versatile as @calestyo would be likely to request. In any way, this function can be used for the array manipulations of general cases.

_Originally posted by @akinomyoga in https://github.com/scop/bash-completion/pull/739#issue-1201728747_