### PR TITLE
refactor: `_parse_{help,usage}` => `_comp_compgen_help`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1190,10 +1190,52 @@ _comp_initialize()
     return 0
 }
 
-# Helper function for _parse_help and _parse_usage.
+# Helper function for _comp_compgen_help and _comp_compgen_usage.
+# Obtain the help output based on the arguments.
+# @param $@ args  Arguments specified to the caller.
+# @var[out] _lines
+# @return 2 if the usage is wrong, 1 if no output is obtained, or otherwise 0.
+_comp_compgen_help__get_help_lines()
+{
+    local -a help_cmd
+    case ${1-} in
+        -)
+            if (($# > 1)); then
+                printf 'bash_completion: %s -: extra arguments for -\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s -\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s -c cmd args...\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s [-- args...]\n' "${FUNCNAME[1]}" >&2
+                return 2
+            fi
+            help_cmd=(exec cat)
+            ;;
+        -c)
+            if (($# < 2)); then
+                printf 'bash_completion: %s -c: no command is specified\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s -\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s -c cmd args...\n' "${FUNCNAME[1]}" >&2
+                printf 'usage: %s [-- args...]\n' "${FUNCNAME[1]}" >&2
+                return 2
+            fi
+            help_cmd=("${@:2}")
+            ;;
+        --) shift 1 ;&
+        *)
+            local ret
+            _comp_dequote "${comp_args[0]-}" || ret=${comp_args[0]-}
+            help_cmd=("${ret:-false}" "$@")
+            ;;
+    esac
+
+    local ret
+    _comp_split -l ret "$(LC_ALL=C "${help_cmd[@]}" 2>&1)" &&
+        _lines=("${ret[@]}")
+}
+
+# Helper function for _comp_compgen_help and _comp_compgen_usage.
+# @var[in,out] _options Add options
 # @return True (0) if an option was found, False (> 0) otherwise
-# TODO: rename per API conventions, rework to use vars rather than outputting
-__parse_options()
+_comp_compgen_help__parse()
 {
     local option option2 i
 
@@ -1219,7 +1261,7 @@ __parse_options()
     if [[ $option =~ (\[((no|dont)-?)\]). ]]; then
         option2=${option/"${BASH_REMATCH[1]}"/}
         option2=${option2%%[<{().[]*}
-        printf '%s\n' "${option2/=*/=}"
+        _options+=("${option2/=*/=}")
         option=${option/"${BASH_REMATCH[1]}"/"${BASH_REMATCH[2]}"}
     fi
 
@@ -1227,100 +1269,81 @@ __parse_options()
     option=${option/=*/=}
     [[ $option ]] || return 1
 
-    printf '%s\n' "$option"
+    _options+=("$option")
 }
 
-# Parse GNU style help output of the given command.
-# @param $1  command; if "-", read from stdin and ignore rest of args
-# @param $2  command options (default: --help)
+# Parse GNU style help output of the given command and generate and store
+# completions in an array. The help output is produced in the way depending on
+# the usage:
+# usage: _comp_compgen_help -              # read from stdin
+# usage: _comp_compgen_help -c cmd args... # run "cmd args..."
+# usage: _comp_compgen_help [[--] args...] # run "${comp_args[0]} args..."
+# When no arguments are specified, `--help` is assumed.
 #
-# TODO: rename per API conventions, rework to use vars rather than outputting
-_parse_help()
+# @var[in] comp_args[0]
+_comp_compgen_help()
 {
-    local IFS=$' \t\n'
-    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe) reset_noglob=$(shopt -po noglob)
-    set +o monitor
-    shopt -s lastpipe
-    set -o noglob
+    (($#)) || set -- -- --help
 
-    local cmd=$1
-    local line rc=1
-    (
-        case $cmd in
-            -) exec cat ;;
-            *)
-                # shellcheck disable=SC2086
-                _comp_dequote "$cmd" && LC_ALL=C "$ret" ${2:---help} 2>&1
-                ;;
-        esac
-    ) |
-        while read -r line; do
+    local -a _lines
+    _comp_compgen_help__get_help_lines "$@" || return "$?"
 
-            [[ $line == *([[:blank:]])-* ]] || continue
-            # transform "-f FOO, --foo=FOO" to "-f , --foo=FOO" etc
-            while [[ $line =~ ((^|[^-])-[A-Za-z0-9?][[:space:]]+)\[?[A-Z0-9]+([,_-]+[A-Z0-9]+)?(\.\.+)?\]? ]]; do
-                line=${line/"${BASH_REMATCH[0]}"/"${BASH_REMATCH[1]}"}
-            done
-            __parse_options "${line// or /, }" && rc=0
-
+    local -a _options=()
+    local _line
+    for _line in "${_lines[@]}"; do
+        [[ $_line == *([[:blank:]])-* ]] || continue
+        # transform "-f FOO, --foo=FOO" to "-f , --foo=FOO" etc
+        while [[ $_line =~ ((^|[^-])-[A-Za-z0-9?][[:space:]]+)\[?[A-Z0-9]+([,_-]+[A-Z0-9]+)?(\.\.+)?\]? ]]; do
+            _line=${_line/"${BASH_REMATCH[0]}"/"${BASH_REMATCH[1]}"}
         done
+        _comp_compgen_help__parse "${_line// or /, }"
+    done
+    ((${#_options[@]})) || return 1
 
-    $reset_monitor
-    $reset_lastpipe
-    $reset_noglob
-    return $rc
+    _comp_compgen -- -W '"${_options[@]}"'
+    return 0
 }
 
-# Parse BSD style usage output (options in brackets) of the given command.
-# @param $1  command; if "-", read from stdin and ignore rest of args
-# @param $2  command options (default: --usage)
+# Parse BSD style usage output (options in brackets) of the given command. The
+# help output is produced in the way depending on the usage:
+# usage: _comp_compgen_usage -              # read from stdin
+# usage: _comp_compgen_usage -c cmd args... # run "cmd args..."
+# usage: _comp_compgen_usage [[--] args...] # run "${comp_args[0]} args..."
+# When no arguments are specified, `--usage` is assumed.
 #
-# TODO: rename per API conventions, rework to use vars rather than outputting
-_parse_usage()
+# @var[in] comp_args[0]
+_comp_compgen_usage()
 {
-    local IFS=$' \t\n'
-    local reset_monitor=$(shopt -po monitor) reset_lastpipe=$(shopt -p lastpipe) reset_noglob=$(shopt -po noglob)
-    set +o monitor
-    shopt -s lastpipe
-    set -o noglob
+    (($#)) || set -- -- --usage
 
-    local cmd=$1
-    local line match option i char rc=1
-    (
-        case $cmd in
-            -) exec cat ;;
-            *)
-                # shellcheck disable=SC2086
-                _comp_dequote "$cmd" && LC_ALL=C "$ret" ${2:---usage} 2>&1
-                ;;
-        esac
-    ) |
-        while read -r line; do
+    local -a _lines
+    _comp_compgen_help__get_help_lines "$@" || return "$?"
 
-            while [[ $line =~ \[[[:space:]]*(-[^]]+)[[:space:]]*\] ]]; do
-                match=${BASH_REMATCH[0]}
-                option=${BASH_REMATCH[1]}
-                case $option in
-                    -?(\[)+([a-zA-Z0-9?]))
-                        # Treat as bundled short options
-                        for ((i = 1; i < ${#option}; i++)); do
-                            char=${option:i:1}
-                            [[ $char != '[' ]] && printf '%s\n' -"$char" && rc=0
-                        done
-                        ;;
-                    *)
-                        __parse_options "$option" && rc=0
-                        ;;
-                esac
-                line=${line#*"$match"}
-            done
-
+    local -a _options=()
+    local _line _match _option _i _char
+    for _line in "${_lines[@]}"; do
+        while [[ $_line =~ \[[[:space:]]*(-[^]]+)[[:space:]]*\] ]]; do
+            _match=${BASH_REMATCH[0]}
+            _option=${BASH_REMATCH[1]}
+            case $_option in
+                -?(\[)+([a-zA-Z0-9?]))
+                    # Treat as bundled short options
+                    for ((_i = 1; _i < ${#_option}; _i++)); do
+                        _char=${_option:_i:1}
+                        [[ $_char != '[' ]] && _options+=("-$_char")
+                    done
+                    ;;
+                *)
+                    _comp_compgen_help__parse "$_option"
+                    ;;
+            esac
+            _line=${_line#*"$_match"}
         done
+    done
+    ((${#_options[@]})) || return 1
 
-    $reset_monitor
-    $reset_lastpipe
-    $reset_noglob
-    return $rc
+    _comp_compgen -- -W '"${_options[@]}"'
+    return 0
 }
 
 # This function completes on signal names (minus the SIG prefix)

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -276,4 +276,62 @@ _tilde()
     ! _comp_compgen -c "$1" tilde
 }
 
+# Helper function for _parse_help and _parse_usage.
+# @return True (0) if an option was found, False (> 0) otherwise
+# @deprecated Use _comp_compgen_help__parse
+__parse_options()
+{
+    local -a _options=()
+    _comp_compgen_help__parse "$1"
+    printf '%s\n' "${_options[@]}"
+}
+
+# Parse GNU style help output of the given command.
+# @param $1  command; if "-", read from stdin and ignore rest of args
+# @param $2  command options (default: --help)
+# @deprecated Use `_comp_compgen_help`.  `COMPREPLY=($(compgen -W
+#   '$(_parse_help "$1" ...)' -- "$cur"))` can be replaced with
+#   `_comp_compgen_help [-- ...]`.  Also, `var=($(_parse_help "$1" ...))` can
+#   be replaced with `_comp_compgen -Rv var help [-- ...]`.
+_parse_help()
+{
+    local -a args
+    if [[ $1 == - ]]; then
+        args=(-)
+    else
+        local ret opt IFS=$' \t\n'
+        _comp_dequote "$1"
+        _comp_split opt "${2:---help}"
+        args=(-c "$ret" ${opt[@]+"${opt[@]}"})
+    fi
+    local -a ret=()
+    _comp_compgen -Rv ret help "${args[@]}" || return 1
+    ((${#ret[@]})) && printf '%s\n' "${ret[@]}"
+    return 0
+}
+
+# Parse BSD style usage output (options in brackets) of the given command.
+# @param $1  command; if "-", read from stdin and ignore rest of args
+# @param $2  command options (default: --usage)
+# @deprecated Use `_comp_compgen_usage`.  `COMPREPLY=($(compgen -W
+#   '$(_parse_usage "$1" ...)' -- "$cur"))` can be replaced with
+#   `_comp_compgen_usage [-- ...]`. `var=($(_parse_usage "$1" ...))` can be
+#   replaced with `_comp_compgen -Rv var usage [-- ...]`.
+_parse_usage()
+{
+    local -a args
+    if [[ $1 == - ]]; then
+        args=(-)
+    else
+        local ret opt IFS=$' \t\n'
+        _comp_dequote "$1"
+        _comp_split opt "${2:---usage}"
+        args=(-c "$ret" ${opt[@]+"${opt[@]}"})
+    fi
+    local -a ret=()
+    _comp_compgen -Rv ret usage "${args[@]}" || return 1
+    ((${#ret[@]})) && printf '%s\n' "${ret[@]}"
+    return 0
+}
+
 # ex: filetype=sh

--- a/completions/2to3
+++ b/completions/2to3
@@ -27,7 +27,7 @@ _comp_cmd_2to3()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/_adb
+++ b/completions/_adb
@@ -37,7 +37,7 @@ _comp_cmd_adb()
     if [[ ! $has_cmd ]]; then
         local tmp=()
         if [[ ! $cur || $cur == -* ]]; then
-            tmp+=($(compgen -W '$(_parse_help "$1" help)' -- "$cur"))
+            _comp_compgen -av tmp help -- help
         fi
         if [[ ! $cur || $cur != -* ]]; then
             tmp+=($("$1" help 2>&1 | awk '$1 == "adb" { print $2 }'))

--- a/completions/_cal
+++ b/completions/_cal
@@ -24,9 +24,7 @@ _comp_cmd_cal()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/_chsh
+++ b/completions/_chsh
@@ -32,9 +32,7 @@ _comp_cmd_chsh()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
     else
         _allowed_users
     fi

--- a/completions/_dmesg
+++ b/completions/_dmesg
@@ -25,9 +25,7 @@ _comp_cmd_dmesg()
             ;;
     esac
 
-    COMPREPLY=($(
-        compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-    ))
+    _comp_compgen_help || _comp_compgen_usage
 } &&
     complete -F _comp_cmd_dmesg dmesg
 

--- a/completions/_eject
+++ b/completions/_eject
@@ -19,7 +19,7 @@ _comp_cmd_eject()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     elif [[ $prev == @(-d|--default) ]]; then
         return

--- a/completions/_hexdump
+++ b/completions/_hexdump
@@ -19,9 +19,7 @@ _comp_cmd_hexdump()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/_ionice
+++ b/completions/_ionice
@@ -51,7 +51,7 @@ _comp_cmd_ionice()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 } &&

--- a/completions/_mock
+++ b/completions/_mock
@@ -58,7 +58,7 @@ _comp_cmd_mock()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir '@(?(no)src.r|s)pm'

--- a/completions/_repomanage
+++ b/completions/_repomanage
@@ -13,7 +13,7 @@ _comp_cmd_repomanage()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir -d

--- a/completions/_reptyr
+++ b/completions/_reptyr
@@ -15,7 +15,7 @@ _comp_cmd_reptyr()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/_rtcwake
+++ b/completions/_rtcwake
@@ -26,7 +26,7 @@ _comp_cmd_rtcwake()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_rtcwake rtcwake
 

--- a/completions/_su
+++ b/completions/_su
@@ -29,7 +29,7 @@ _comp_cmd_su()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -67,8 +67,7 @@ _comp_cmd_udevadm()
     fi
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W \
-            '$(_parse_help "$1" "${udevcmd-} --help")' -- "$cur"))
+        _comp_compgen_help -- ${has_udevcmd:+"$udevcmd"} --help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/_yum
+++ b/completions/_yum
@@ -141,7 +141,7 @@ _comp_cmd_yum()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/a2x
+++ b/completions/a2x
@@ -29,7 +29,7 @@ _comp_cmd_a2x()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/a2x
+++ b/completions/a2x
@@ -29,7 +29,7 @@ _comp_cmd_a2x()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/aclocal
+++ b/completions/aclocal
@@ -27,7 +27,7 @@ _comp_cmd_aclocal()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_aclocal aclocal aclocal-1.1{0..6}

--- a/completions/acpi
+++ b/completions/acpi
@@ -17,7 +17,7 @@ _comp_cmd_acpi()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_acpi acpi
 

--- a/completions/alias
+++ b/completions/alias
@@ -19,7 +19,7 @@ _comp_cmd_alias()
     esac
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_usage help "-s $1"
+        _comp_compgen_usage -c help -s "$1"
         ((${#COMPREPLY[*]} != 1)) || compopt +o nospace
     fi
 } &&

--- a/completions/alias
+++ b/completions/alias
@@ -19,7 +19,7 @@ _comp_cmd_alias()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
+        _comp_compgen_usage help "-s $1"
         ((${#COMPREPLY[*]} != 1)) || compopt +o nospace
     fi
 } &&

--- a/completions/ant
+++ b/completions/ant
@@ -64,8 +64,7 @@ _comp_cmd_ant()
     elif [[ $cur == -* ]]; then
         # The </dev/null prevents "phing -" weirdness/getting just a literal
         # tab displayed on complete on CentOS 6 with phing 2.6.1.
-        COMPREPLY=(
-            $(compgen -W '$(_parse_help "$1" -h </dev/null)' -- "$cur"))
+        _comp_compgen_help -- -h </dev/null
     else
         # available targets completion
         # find which buildfile to use

--- a/completions/appdata-validate
+++ b/completions/appdata-validate
@@ -20,7 +20,7 @@ _comp_cmd_appdata_validate()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/arch
+++ b/completions/arch
@@ -22,7 +22,7 @@ _comp_have_command mailmanctl &&
         [[ $was_split ]] && return
 
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         else
             local args=$cword
             for ((i = 1; i < cword; i++)); do

--- a/completions/arp
+++ b/completions/arp
@@ -29,9 +29,7 @@ _comp_cmd_arp()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/arping
+++ b/completions/arping
@@ -20,7 +20,7 @@ _comp_cmd_arping()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 

--- a/completions/arpspoof
+++ b/completions/arpspoof
@@ -17,7 +17,7 @@ _comp_cmd_arpspoof()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -43,8 +43,7 @@ _comp_cmd_asciidoc()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help manpage")' \
-            -- "$cur"))
+        _comp_compgen_help -- --help manpage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/autoconf
+++ b/completions/autoconf
@@ -28,7 +28,7 @@ _comp_cmd_autoconf()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/automake
+++ b/completions/automake
@@ -24,7 +24,7 @@ _comp_cmd_automake()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/autoreconf
+++ b/completions/autoreconf
@@ -25,7 +25,7 @@ _comp_cmd_autoreconf()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/autoscan
+++ b/completions/autoscan
@@ -20,7 +20,7 @@ _comp_cmd_autoscan()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/avahi-browse
+++ b/completions/avahi-browse
@@ -19,7 +19,7 @@ _comp_cmd_avahi_browse()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} != *= ]] || compopt -o nospace
         return
     fi

--- a/completions/bind
+++ b/completions/bind
@@ -25,7 +25,7 @@ _comp_cmd_bind()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
+        _comp_compgen_usage help "-s $1"
         return
     fi
 

--- a/completions/bind
+++ b/completions/bind
@@ -25,7 +25,7 @@ _comp_cmd_bind()
     esac
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_usage help "-s $1"
+        _comp_compgen_usage -c help -s "$1"
         return
     fi
 

--- a/completions/ccache
+++ b/completions/ccache
@@ -32,7 +32,7 @@ _comp_cmd_ccache()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_ccache ccache

--- a/completions/ccze
+++ b/completions/ccze
@@ -38,7 +38,7 @@ _comp_cmd_ccze()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_ccze ccze

--- a/completions/cd
+++ b/completions/cd
@@ -8,8 +8,7 @@ _comp_cmd_cd()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        local cmd=$1
-        _comp_compgen -- -W '$(_parse_help help "$cmd")'
+        _comp_compgen_help -c help "$1"
         compopt +o nospace
         return
     fi

--- a/completions/cfagent
+++ b/completions/cfagent
@@ -13,7 +13,7 @@ _comp_cmd_cfagent()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_cfagent cfagent

--- a/completions/cfrun
+++ b/completions/cfrun
@@ -38,7 +38,7 @@ _comp_cmd_cfrun()
             fi
             ;;
         2)
-            COMPREPLY=($(compgen -W '$(_parse_help cfagent)' -- "$cur"))
+            _comp_compgen_help -c cfagent --help
             ;;
     esac
 } &&

--- a/completions/chage
+++ b/completions/chage
@@ -21,7 +21,7 @@ _comp_cmd_chage()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/checksec
+++ b/completions/checksec
@@ -44,7 +44,7 @@ _comp_cmd_checksec()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/chmod
+++ b/completions/chmod
@@ -22,9 +22,7 @@ _comp_cmd_chmod()
 
     # shellcheck disable=SC2053
     if [[ $cur == -* && $cur != $modearg ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/chpasswd
+++ b/completions/chpasswd
@@ -24,7 +24,7 @@ _comp_cmd_chpasswd()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_chpasswd chpasswd

--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -37,7 +37,7 @@ _comp_cmd_chromium_browser()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/chrpath
+++ b/completions/chrpath
@@ -18,7 +18,7 @@ _comp_cmd_chrpath()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/cksfv
+++ b/completions/cksfv
@@ -6,7 +6,7 @@ _comp_cmd_cksfv()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/configure
+++ b/completions/configure
@@ -34,7 +34,7 @@ _comp_cmd_configure()
             -- "$cur"))
         [[ ${COMPREPLY-} == *=* ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/convert
+++ b/completions/convert
@@ -135,7 +135,7 @@ _comp_cmd_convert()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+adjoin +append +compress +contrast +debug
             +dither +endian +gamma +label +map +mask +matte +negate +noise
@@ -154,7 +154,7 @@ _comp_cmd_mogrify()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
             +gamma +label +map +mask +matte +negate +page +raise' -- "$cur"))
@@ -172,7 +172,7 @@ _comp_cmd_display()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
             +gamma +label +map +matte +negate +page +raise +write' -- "$cur"))
@@ -190,7 +190,7 @@ _comp_cmd_animate()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug +dither +gamma +map +matte' \
             -- "$cur"))
@@ -208,7 +208,7 @@ _comp_cmd_identify()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
@@ -225,7 +225,7 @@ _comp_cmd_montage()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+adjoin +compress +debug +dither +endian
             +gamma +label +matte +page' -- "$cur"))
@@ -243,7 +243,7 @@ _comp_cmd_composite()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+compress +debug +dither +endian +label
             +matte +negate +page +write' -- "$cur"))
@@ -261,7 +261,7 @@ _comp_cmd_compare()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
@@ -278,7 +278,7 @@ _comp_cmd_conjure()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
@@ -295,7 +295,7 @@ _comp_cmd_import()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
@@ -312,7 +312,7 @@ _comp_cmd_stream()
     _comp_cmd_convert__common_options && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else

--- a/completions/cpan2dist
+++ b/completions/cpan2dist
@@ -20,7 +20,7 @@ _comp_cmd_cpan2dist()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         local cpandirs=("$HOME/.cpanplus/" "$HOME/.cpan/source/modules/")
         local dir packagelist=

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -80,7 +80,7 @@ _comp_cmd_cppcheck()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir '@([cht]pp|[cht]xx|cc|[ch]++|[ch])'

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -38,7 +38,7 @@ _comp_cmd_cryptsetup()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
             COMPREPLY=($(compgen -W 'open close resize status benchmark

--- a/completions/curl
+++ b/completions/curl
@@ -158,7 +158,7 @@ _comp_cmd_curl()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help all")' -- "$cur"))
+        _comp_compgen_help -- --help all
         [[ ${COMPREPLY-} ]] ||
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     fi

--- a/completions/cvs
+++ b/completions/cvs
@@ -29,7 +29,7 @@ _cvs_commands()
 
 _comp_cmd_cvs__command_options()
 {
-    COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help $2")' -- "$cur"))
+    _comp_compgen_help -- --help "$2"
 }
 
 _comp_cmd_cvs__kflags()

--- a/completions/cvsps
+++ b/completions/cvsps
@@ -48,7 +48,7 @@ _comp_cmd_cvsps()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
     else
         _comp_xfunc cvs roots
     fi

--- a/completions/deja-dup
+++ b/completions/deja-dup
@@ -22,7 +22,7 @@ _comp_cmd_deja_dup()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/desktop-file-validate
+++ b/completions/desktop-file-validate
@@ -12,7 +12,7 @@ _comp_cmd_desktop_file_validate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/dhclient
+++ b/completions/dhclient
@@ -24,7 +24,7 @@ _comp_cmd_dhclient()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _available_interfaces
     fi

--- a/completions/dict
+++ b/completions/dict
@@ -35,7 +35,7 @@ _comp_cmd_dict()
     done
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/dmypy
+++ b/completions/dmypy
@@ -32,7 +32,7 @@ _comp_cmd_dmypy()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/dnsspoof
+++ b/completions/dnsspoof
@@ -17,7 +17,7 @@ _comp_cmd_dnsspoof()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -115,7 +115,7 @@ _comp_cmd_dpkg()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     for i in ${!COMPREPLY[*]}; do
         # remove ones ending with a dash (known parse issue, hard to fix)
         [[ ${COMPREPLY[i]} != *- ]] || unset -v 'COMPREPLY[i]'

--- a/completions/dselect
+++ b/completions/dselect
@@ -17,7 +17,7 @@ _comp_cmd_dselect()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         COMPREPLY=($(compgen -W 'access update select install config remove
             quit' -- "$cur"))

--- a/completions/dumpe2fs
+++ b/completions/dumpe2fs
@@ -16,7 +16,7 @@ _comp_cmd_dumpe2fs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/e2freefrag
+++ b/completions/e2freefrag
@@ -12,7 +12,7 @@ _comp_cmd_e2freefrag()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" -h)' -- "$cur"))
+        _comp_compgen_usage -- -h
         return
     fi
 

--- a/completions/ecryptfs-migrate-home
+++ b/completions/ecryptfs-migrate-home
@@ -15,7 +15,7 @@ _comp_cmd_ecryptfs_migrate_home()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_ecryptfs_migrate_home ecryptfs-migrate-home
 

--- a/completions/eog
+++ b/completions/eog
@@ -14,7 +14,7 @@ _comp_cmd_eog()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/evince
+++ b/completions/evince
@@ -22,7 +22,7 @@ _comp_cmd_evince()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/faillog
+++ b/completions/faillog
@@ -20,7 +20,7 @@ _comp_cmd_faillog()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/feh
+++ b/completions/feh
@@ -106,7 +106,7 @@ _comp_cmd_feh()
 
     if [[ $cur == -* ]]; then
         # Some versions of feh just output "See 'man feh'" for --help :(
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/feh
+++ b/completions/feh
@@ -106,7 +106,7 @@ _comp_cmd_feh()
 
     if [[ $cur == -* ]]; then
         # Some versions of feh just output "See 'man feh'" for --help :(
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/file
+++ b/completions/file
@@ -23,7 +23,7 @@ _comp_cmd_file()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/file-roller
+++ b/completions/file-roller
@@ -31,7 +31,7 @@ _comp_cmd_file_roller()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/filefrag
+++ b/completions/filefrag
@@ -6,7 +6,7 @@ _comp_cmd_filefrag()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/filesnarf
+++ b/completions/filesnarf
@@ -13,7 +13,7 @@ _comp_cmd_snarf()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/firefox
+++ b/completions/firefox
@@ -41,7 +41,7 @@ _comp_cmd_firefox()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/flake8
+++ b/completions/flake8
@@ -32,7 +32,7 @@ _comp_cmd_flake8()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/freeciv
+++ b/completions/freeciv
@@ -32,7 +32,7 @@ _comp_cmd_freeciv()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 
 } &&

--- a/completions/freeciv-server
+++ b/completions/freeciv-server
@@ -13,7 +13,7 @@ _comp_cmd_civserver()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 
 } &&

--- a/completions/fusermount
+++ b/completions/fusermount
@@ -18,7 +18,7 @@ _comp_cmd_fusermount()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
     else
         _comp_compgen_filedir -d
     fi

--- a/completions/genisoimage
+++ b/completions/genisoimage
@@ -27,7 +27,7 @@ _comp_cmd_mkisofs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     else
         _comp_compgen_filedir
     fi

--- a/completions/geoiplookup
+++ b/completions/geoiplookup
@@ -20,7 +20,7 @@ _comp_cmd_geoiplookup()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" -h)' -- "$cur"))
+        _comp_compgen_usage -- -h
         return
     fi
 

--- a/completions/getent
+++ b/completions/getent
@@ -67,7 +67,7 @@ _comp_cmd_getent()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ ! $has_db ]]; then
         COMPREPLY=($(compgen -W 'passwd group hosts services protocols

--- a/completions/gkrellm
+++ b/completions/gkrellm
@@ -32,7 +32,7 @@ _comp_cmd_gkrellm()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_gkrellm gkrellm gkrellm2
 

--- a/completions/gnome-mplayer
+++ b/completions/gnome-mplayer
@@ -26,7 +26,7 @@ _comp_cmd_gnome_mplayer()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/gnome-screenshot
+++ b/completions/gnome-screenshot
@@ -24,7 +24,7 @@ _comp_cmd_gnome_screenshot()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/gpasswd
+++ b/completions/gpasswd
@@ -16,7 +16,7 @@ _comp_cmd_gpasswd()
 
     if [[ $cur == -* ]]; then
         # TODO: only -A and -M can be combined
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/gpgv
+++ b/completions/gpgv
@@ -23,7 +23,7 @@ _comp_cmd_gpgv()
     _count_args "" "--@(weak-digest|*-fd|keyring|homedir)"
 
     if [[ $cur == -* && $args -eq 1 ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -45,7 +45,7 @@ _comp_cmd_gphoto2()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 

--- a/completions/gprof
+++ b/completions/gprof
@@ -43,7 +43,7 @@ _comp_cmd_gprof()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/groupadd
+++ b/completions/groupadd
@@ -19,7 +19,7 @@ _comp_cmd_groupadd()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/groupdel
+++ b/completions/groupdel
@@ -16,7 +16,7 @@ _comp_cmd_groupdel()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/groupmems
+++ b/completions/groupmems
@@ -20,7 +20,7 @@ _comp_cmd_groupmems()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_groupmems groupmems
 

--- a/completions/groupmod
+++ b/completions/groupmod
@@ -19,7 +19,7 @@ _comp_cmd_groupmod()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/grpck
+++ b/completions/grpck
@@ -15,9 +15,7 @@ _comp_cmd_grpck()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/gssdp-discover
+++ b/completions/gssdp-discover
@@ -26,7 +26,7 @@ _comp_cmd_gssdp_discover()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -53,7 +53,7 @@ _comp_cmd_hcitool()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         else
             COMPREPLY=($(compgen -W 'dev inq scan name info spinq epinq cmd
                 con cc dc sr cpt rssi lq tpl afh lst auth enc key clkoff
@@ -125,7 +125,7 @@ _comp_cmd_sdptool()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         else
             COMPREPLY=($(compgen -W 'search browse records add del get
                 setattr setseq' -- "$cur"))
@@ -181,7 +181,7 @@ _comp_cmd_l2ping()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _comp_cmd_hcitool__bluetooth_addresses
     fi
@@ -209,7 +209,7 @@ _comp_cmd_rfcomm()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         else
             COMPREPLY=($(compgen -W 'show connect listen watch bind
                 release' -- "$cur"))
@@ -249,7 +249,7 @@ _comp_cmd_ciptool()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         else
             COMPREPLY=($(compgen -W 'show search connect release loopback' \
                 -- "$cur"))
@@ -281,7 +281,7 @@ _comp_cmd_dfutool()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         local args
         _count_args

--- a/completions/help
+++ b/completions/help
@@ -6,7 +6,7 @@ _comp_cmd_help()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" "-s $1")' -- "$cur"))
+        _comp_compgen_usage "$1" "-s $1"
         return
     fi
 

--- a/completions/help
+++ b/completions/help
@@ -6,7 +6,7 @@ _comp_cmd_help()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_usage "$1" "-s $1"
+        _comp_compgen_usage -c help -s "$1"
         return
     fi
 

--- a/completions/hostname
+++ b/completions/hostname
@@ -18,9 +18,7 @@ _comp_cmd_hostname()
     esac
 
     [[ $cur == -* ]] &&
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
 } &&
     complete -F _comp_cmd_hostname hostname
 

--- a/completions/hping2
+++ b/completions/hping2
@@ -27,7 +27,7 @@ _comp_cmd_hping2()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/htop
+++ b/completions/htop
@@ -25,7 +25,7 @@ _comp_cmd_htop()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/htop
+++ b/completions/htop
@@ -25,7 +25,7 @@ _comp_cmd_htop()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/htpasswd
+++ b/completions/htpasswd
@@ -19,7 +19,7 @@ _comp_cmd_htpasswd()
 
     if ((o == 0 || o == cword)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             return
         fi
         # Password file (first non-option argument)

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -31,7 +31,7 @@ _comp_cmd_hunspell()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/iconv
+++ b/completions/iconv
@@ -33,7 +33,7 @@ _comp_cmd_iconv()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/idn
+++ b/completions/idn
@@ -19,7 +19,7 @@ _comp_cmd_idn()
     esac
 
     if [[ ! $was_split && $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/ifstat
+++ b/completions/ifstat
@@ -59,9 +59,7 @@ _comp_cmd_ifstat()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/iftop
+++ b/completions/iftop
@@ -19,7 +19,7 @@ _comp_cmd_iftop()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+    _comp_compgen_help -- -h
 } &&
     complete -F _comp_cmd_iftop iftop
 

--- a/completions/ifup
+++ b/completions/ifup
@@ -24,7 +24,7 @@ _comp_cmd_ifupdown()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/influx
+++ b/completions/influx
@@ -28,7 +28,7 @@ _comp_cmd_influx()
     esac
 
     [[ $cur == -* ]] &&
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
 } &&
     complete -F _comp_cmd_influx influx
 

--- a/completions/info
+++ b/completions/info
@@ -36,7 +36,7 @@ _comp_cmd_info()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/inotifywait
+++ b/completions/inotifywait
@@ -38,7 +38,7 @@ _comp_cmd_inotifywait()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/interdiff
+++ b/completions/interdiff
@@ -16,7 +16,7 @@ _comp_cmd_interdiff()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/ipcalc
+++ b/completions/ipcalc
@@ -18,7 +18,7 @@ _comp_cmd_ipcalc()
     done
 
     [[ $cur != -* ]] ||
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
 } &&
     complete -F _comp_cmd_ipcalc ipcalc
 

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -58,7 +58,7 @@ _comp_cmd_ipmitool()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 

--- a/completions/isort
+++ b/completions/isort
@@ -30,7 +30,7 @@ _comp_cmd_isort()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/java
+++ b/completions/java
@@ -225,9 +225,9 @@ _comp_cmd_java()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         [[ $cur == -X* ]] &&
-            COMPREPLY+=($(compgen -W '$(_parse_help "$1" -X)' -- "$cur"))
+            _comp_compgen -a help -- -X
     else
         if [[ $prev == -jar ]]; then
             # jar file completion
@@ -281,7 +281,7 @@ _comp_cmd_javadoc()
     fi
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
     else
         # source files completion
         _comp_compgen_filedir java
@@ -321,9 +321,9 @@ _comp_cmd_javac()
     fi
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         [[ $cur == -X* ]] &&
-            COMPREPLY+=($(compgen -W '$(_parse_help "$1" -X)' -- "$cur"))
+            _comp_compgen -a help -- -X
     else
         # source files completion
         _comp_compgen_filedir java

--- a/completions/javaws
+++ b/completions/javaws
@@ -22,7 +22,7 @@ _comp_cmd_javaws()
     if [[ $cur == *= ]]; then
         return
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(_parse_help "$1" -help) " -- "$cur"))
+        _comp_compgen_help -- -help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/jpegoptim
+++ b/completions/jpegoptim
@@ -28,7 +28,7 @@ _comp_cmd_jpegoptim()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/jshint
+++ b/completions/jshint
@@ -26,7 +26,7 @@ _comp_cmd_jshint()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/jsonschema
+++ b/completions/jsonschema
@@ -16,7 +16,7 @@ _comp_cmd_jsonschema()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/k3b
+++ b/completions/k3b
@@ -37,7 +37,7 @@ _comp_cmd_k3b()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir

--- a/completions/kcov
+++ b/completions/kcov
@@ -51,7 +51,7 @@ _comp_cmd_kcov()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/kcov
+++ b/completions/kcov
@@ -51,7 +51,7 @@ _comp_cmd_kcov()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/kill
+++ b/completions/kill
@@ -18,7 +18,7 @@ _comp_cmd_kill()
     if [[ $cword -eq 1 && $cur == -* ]]; then
         # return list of available signals
         _signals -
-        COMPREPLY+=($(compgen -W '$(_parse_help help "$1")' -- "$cur"))
+        _comp_compgen -a help -c help "$1"
     else
         # return list of available PIDs and jobs
         _pids

--- a/completions/killall
+++ b/completions/killall
@@ -26,7 +26,7 @@ _comp_cmd_killall()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         ((cword == 1)) && _signals -
         return
     fi

--- a/completions/koji
+++ b/completions/koji
@@ -110,8 +110,7 @@ _comp_cmd_koji()
 
     if [[ $has_command ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W \
-                '$(_parse_help "$1" "$command --help")' -- "$cur"))
+            _comp_compgen_help -- "$command" --help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
         fi

--- a/completions/lastlog
+++ b/completions/lastlog
@@ -19,7 +19,7 @@ _comp_cmd_lastlog()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_lastlog lastlog

--- a/completions/ldapvi
+++ b/completions/ldapvi
@@ -45,7 +45,7 @@ _comp_cmd_ldapvi()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_ldapvi ldapvi

--- a/completions/lftp
+++ b/completions/lftp
@@ -18,7 +18,7 @@ _comp_cmd_lftp()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/lintian
+++ b/completions/lintian
@@ -173,7 +173,7 @@ _comp_cmd_lintian_info()
 
     case "$cur" in
         --*)
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             ;;
         *)
             _comp_compgen_filedir

--- a/completions/locale-gen
+++ b/completions/locale-gen
@@ -18,7 +18,7 @@ _comp_cmd_locale_gen()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/lrzip
+++ b/completions/lrzip
@@ -40,7 +40,7 @@ _comp_cmd_lrzip()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/lspci
+++ b/completions/lspci
@@ -33,7 +33,7 @@ _comp_cmd_lspci()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_lspci lspci

--- a/completions/lsscsi
+++ b/completions/lsscsi
@@ -20,7 +20,7 @@ _comp_cmd_lsscsi()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/lsusb
+++ b/completions/lsusb
@@ -14,7 +14,7 @@ _comp_cmd_lsusb()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_lsusb lsusb

--- a/completions/lua
+++ b/completions/lua
@@ -12,7 +12,7 @@ _comp_cmd_lua()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/luac
+++ b/completions/luac
@@ -16,7 +16,7 @@ _comp_cmd_luac()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/luseradd
+++ b/completions/luseradd
@@ -30,7 +30,7 @@ _comp_cmd_luseradd()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/luserdel
+++ b/completions/luserdel
@@ -12,7 +12,7 @@ _comp_cmd_luserdel()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/lvm
+++ b/completions/lvm
@@ -70,7 +70,7 @@ _comp_cmd_lvmdiskscan()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     fi
 } &&
     complete -F _comp_cmd_lvmdiskscan lvmdiskscan
@@ -81,7 +81,7 @@ _comp_cmd_pvscan()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     fi
 } &&
     complete -F _comp_cmd_pvscan pvscan
@@ -106,7 +106,7 @@ _comp_cmd_pvs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__physicalvolumes_all
     fi
@@ -126,7 +126,7 @@ _comp_cmd_pvdisplay()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__physicalvolumes_all
     fi
@@ -148,7 +148,7 @@ _comp_cmd_pvchange()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__physicalvolumes_all
     fi
@@ -182,7 +182,7 @@ _comp_cmd_pvcreate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__filedir
     fi
@@ -208,7 +208,7 @@ _comp_cmd_pvmove()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__physicalvolumes
     fi
@@ -221,7 +221,7 @@ _comp_cmd_pvremove()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__physicalvolumes_all
     fi
@@ -234,7 +234,7 @@ _comp_cmd_vgscan()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     fi
 } &&
     complete -F _comp_cmd_vgscan vgscan
@@ -261,7 +261,7 @@ _comp_cmd_vgs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -281,7 +281,7 @@ _comp_cmd_vgdisplay()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -303,7 +303,7 @@ _comp_cmd_vgchange()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -333,7 +333,7 @@ _comp_cmd_vgcreate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|--autobackup|-M|--metadatatype|-s|--physicalextentsize)'
@@ -352,7 +352,7 @@ _comp_cmd_vgremove()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -374,7 +374,7 @@ _comp_cmd_vgrename()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -396,7 +396,7 @@ _comp_cmd_vgreduce()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
 
     else
         local ret
@@ -429,7 +429,7 @@ _comp_cmd_vgextend()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|--autobackup|-L|--size)'
@@ -448,7 +448,7 @@ _comp_cmd_vgport()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -461,7 +461,7 @@ _comp_cmd_vgck()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -491,7 +491,7 @@ _comp_cmd_vgconvert()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -513,7 +513,7 @@ _comp_cmd_vgcfgbackup()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -543,7 +543,7 @@ _comp_cmd_vgcfgrestore()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -565,7 +565,7 @@ _comp_cmd_vgmerge()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -591,7 +591,7 @@ _comp_cmd_vgsplit()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|--autobackup|-M|--metadatatype)'
@@ -610,7 +610,7 @@ _comp_cmd_vgmknodes()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__volumegroups
     fi
@@ -623,7 +623,7 @@ _comp_cmd_lvscan()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     fi
 } &&
     complete -F _comp_cmd_lvscan lvscan
@@ -649,7 +649,7 @@ _comp_cmd_lvs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -669,7 +669,7 @@ _comp_cmd_lvdisplay()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -695,7 +695,7 @@ _comp_cmd_lvchange()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -729,7 +729,7 @@ _comp_cmd_lvcreate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|-C|-M|-Z|--autobackup|--contiguous|--persistent|--zero|-L|--size|-p|--permission|-n|--name)'
@@ -757,7 +757,7 @@ _comp_cmd_lvremove()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -779,7 +779,7 @@ _comp_cmd_lvrename()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -805,7 +805,7 @@ _comp_cmd_lvreduce()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _comp_cmd_lvm__logicalvolumes
     fi
@@ -831,7 +831,7 @@ _comp_cmd_lvresize()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|--autobackup|-L|--size)'
@@ -863,7 +863,7 @@ _comp_cmd_lvextend()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         local ret
         _comp_cmd_lvm__count_args '@(-A|--autobackup|-L|--size)'

--- a/completions/macof
+++ b/completions/macof
@@ -13,7 +13,7 @@ _comp_cmd_macof()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/make
+++ b/completions/make
@@ -173,9 +173,7 @@ _comp_cmd_make()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ $cur == *=* ]]; then
         prev=${cur%%=*}

--- a/completions/man
+++ b/completions/man
@@ -46,9 +46,7 @@ _comp_cmd_man()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" -h || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help -- -h || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/mc
+++ b/completions/mc
@@ -20,7 +20,7 @@ _comp_cmd_mc()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
+        _comp_compgen_help -- --help-all
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir -d

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -45,7 +45,7 @@ _comp_cmd_mcrypt()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     elif [[ ${words[0]} == mdecrypt ]]; then
         _comp_compgen_filedir nc
     else

--- a/completions/medusa
+++ b/completions/medusa
@@ -22,7 +22,7 @@ _comp_cmd_medusa()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_medusa medusa

--- a/completions/mii-diag
+++ b/completions/mii-diag
@@ -16,7 +16,7 @@ _comp_cmd_mii_diag()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         _available_interfaces -a
     fi

--- a/completions/mii-tool
+++ b/completions/mii-tool
@@ -23,7 +23,7 @@ _comp_cmd_mii_tool()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _available_interfaces -a

--- a/completions/minicom
+++ b/completions/minicom
@@ -28,7 +28,7 @@ _comp_cmd_minicom()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/modinfo
+++ b/completions/modinfo
@@ -28,9 +28,7 @@ _comp_cmd_modinfo()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -28,7 +28,7 @@ _comp_cmd_modprobe()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         if [[ ! ${COMPREPLY-} ]]; then
             COMPREPLY=($(compgen -W '-a --all -b --use-blacklist -C --config
                 -c --showconfig --dump-modversions -d --dirname --first-time

--- a/completions/monodevelop
+++ b/completions/monodevelop
@@ -8,7 +8,7 @@ _comp_cmd_monodevelop()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir

--- a/completions/munin-node-configure
+++ b/completions/munin-node-configure
@@ -25,7 +25,7 @@ _comp_cmd_munin_node_configure()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_munin_node_configure munin-node-configure

--- a/completions/munin-run
+++ b/completions/munin-run
@@ -17,7 +17,7 @@ _comp_cmd_munin_run()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         COMPREPLY=($(compgen -W \
             '$(command ls /etc/munin/plugins 2>/dev/null)' -- "$cur"))

--- a/completions/mussh
+++ b/completions/mussh
@@ -45,7 +45,7 @@ _comp_cmd_mussh()
     esac
 
     [[ $cur != -* ]] ||
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
 } &&
     complete -F _comp_cmd_mussh mussh
 

--- a/completions/mypy
+++ b/completions/mypy
@@ -49,7 +49,7 @@ _comp_cmd_mypy()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -51,7 +51,7 @@ _comp_cmd_mysqladmin()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 
     COMPREPLY+=($(compgen -W 'create debug drop extended-status flush-hosts
         flush-logs flush-status flush-tables flush-threads flush-privileges

--- a/completions/nc
+++ b/completions/nc
@@ -35,7 +35,7 @@ _comp_cmd_nc()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 

--- a/completions/ncftp
+++ b/completions/ncftp
@@ -12,7 +12,7 @@ _comp_cmd_ncftp()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 

--- a/completions/nethogs
+++ b/completions/nethogs
@@ -15,7 +15,7 @@ _comp_cmd_nethogs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" -h)' -- "$cur"))
+        _comp_compgen_usage -- -h
         return
     fi
 

--- a/completions/newlist
+++ b/completions/newlist
@@ -14,7 +14,7 @@ _comp_cmd_newlist()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_xfunc list_lists mailman_lists

--- a/completions/newusers
+++ b/completions/newusers
@@ -18,7 +18,7 @@ _comp_cmd_newusers()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/ngrep
+++ b/completions/ngrep
@@ -29,7 +29,7 @@ _comp_cmd_ngrep()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 } &&

--- a/completions/nproc
+++ b/completions/nproc
@@ -14,7 +14,7 @@ _comp_cmd_nproc()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/nslookup
+++ b/completions/nslookup
@@ -85,7 +85,7 @@ _comp_cmd_host()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/nsupdate
+++ b/completions/nsupdate
@@ -28,7 +28,7 @@ _comp_cmd_nsupdate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/ntpdate
+++ b/completions/ntpdate
@@ -25,9 +25,7 @@ _comp_cmd_ntpdate()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" -h || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help -- -h || _comp_compgen_usage
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/oggdec
+++ b/completions/oggdec
@@ -28,7 +28,7 @@ _comp_cmd_oggdec()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/opera
+++ b/completions/opera
@@ -35,7 +35,7 @@ _comp_cmd_opera()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/optipng
+++ b/completions/optipng
@@ -41,7 +41,7 @@ _comp_cmd_optipng()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/passwd
+++ b/completions/passwd
@@ -15,9 +15,7 @@ _comp_cmd_passwd()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/patch
+++ b/completions/patch
@@ -51,7 +51,7 @@ _comp_cmd_patch()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/pdftoppm
+++ b/completions/pdftoppm
@@ -24,7 +24,7 @@ _comp_cmd_pdftoppm()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/pdftotext
+++ b/completions/pdftotext
@@ -22,7 +22,7 @@ _comp_cmd_pdftotext()
     esac
 
     if [[ $cur == -* && ${prev,,} != *.pdf ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/perl
+++ b/completions/perl
@@ -126,7 +126,7 @@ _comp_cmd_perldoc()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
     else
         # return available modules (unless it is clearly a file)
         if [[ $cur != @(*/|[.~])* ]]; then

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -40,7 +40,7 @@ _comp_cmd_perlcritic()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/perltidy
+++ b/completions/perltidy
@@ -52,7 +52,7 @@ _comp_cmd_perltidy()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_filedir 'p[lm]|t'

--- a/completions/pidof
+++ b/completions/pidof
@@ -18,7 +18,7 @@ _comp_cmd_pidof()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/pine
+++ b/completions/pine
@@ -22,7 +22,7 @@ _comp_cmd_pine()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
     else
         COMPREPLY=($(compgen -W '$(awk "{print \$1}" ~/.addressbook \
             2>/dev/null)' -- "$cur"))

--- a/completions/ping
+++ b/completions/ping
@@ -58,9 +58,7 @@ _comp_cmd_ping()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/pkg-config
+++ b/completions/pkg-config
@@ -32,7 +32,7 @@ _comp_cmd_pkg_config()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         COMPREPLY=($(compgen -W "$("$1" --list-all \

--- a/completions/pngfix
+++ b/completions/pngfix
@@ -24,7 +24,7 @@ _comp_cmd_pngfix()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/postcat
+++ b/completions/postcat
@@ -13,7 +13,7 @@ _comp_cmd_postcat()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/postconf
+++ b/completions/postconf
@@ -23,7 +23,7 @@ _comp_cmd_postconf()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/postfix
+++ b/completions/postfix
@@ -17,8 +17,7 @@ _comp_cmd_postfix()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W \
-            '$(_parse_usage _bashcomp_try_faketty "$1 --help")' -- "$cur"))
+        _comp_compgen_usage _bashcomp_try_faketty "$1 --help"
         return
     fi
 

--- a/completions/postfix
+++ b/completions/postfix
@@ -17,7 +17,7 @@ _comp_cmd_postfix()
     esac
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_usage _bashcomp_try_faketty "$1 --help"
+        _comp_compgen_usage -c _bashcomp_try_faketty "$1" --help
         return
     fi
 

--- a/completions/postmap
+++ b/completions/postmap
@@ -16,7 +16,7 @@ _comp_cmd_postmap()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/postsuper
+++ b/completions/postsuper
@@ -46,7 +46,7 @@ _comp_cmd_postsuper()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/prelink
+++ b/completions/prelink
@@ -30,7 +30,7 @@ _comp_cmd_prelink()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/printenv
+++ b/completions/printenv
@@ -12,7 +12,7 @@ _comp_cmd_printenv()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/protoc
+++ b/completions/protoc
@@ -44,7 +44,7 @@ _comp_cmd_protoc()
             return
             ;;
         -*)
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             local i
             for i in "${!COMPREPLY[@]}"; do
                 [[ ${COMPREPLY[i]} == -oFILE ]] && unset -v 'COMPREPLY[i]'

--- a/completions/psql
+++ b/completions/psql
@@ -43,7 +43,7 @@ _comp_cmd_createdb()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_cmd_psql__databases
@@ -77,7 +77,7 @@ _comp_cmd_createuser()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
@@ -109,7 +109,7 @@ _comp_cmd_dropdb()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_cmd_psql__databases
@@ -143,7 +143,7 @@ _comp_cmd_dropuser()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_cmd_psql__users
@@ -188,7 +188,7 @@ _comp_cmd_psql()
 
     if [[ $cur == -* ]]; then
         # return list of available options
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         # return list of available databases

--- a/completions/puppet
+++ b/completions/puppet
@@ -56,7 +56,7 @@ _comp_cmd_puppet__subcmd_opts()
 {
     # puppet cmd help is somewhat slow, avoid if possible
     [[ ! $cur || $cur == -* ]] &&
-        _comp_compgen -a usage "$1" "help $2"
+        _comp_compgen -a usage -- help ${2:+"$2"}
 }
 
 _comp_cmd_puppet()
@@ -337,7 +337,7 @@ _comp_cmd_puppet()
             esac
             ;;
         resource | *)
-            _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
+            _comp_cmd_puppet__subcmd_opts "$1" ${subcommand:+"$subcommand"}
             return
             ;;
     esac

--- a/completions/puppet
+++ b/completions/puppet
@@ -56,8 +56,7 @@ _comp_cmd_puppet__subcmd_opts()
 {
     # puppet cmd help is somewhat slow, avoid if possible
     [[ ! $cur || $cur == -* ]] &&
-        COMPREPLY+=($(compgen -W \
-            '$(_parse_usage "$1" "help $2")' -- "$cur"))
+        _comp_compgen -a usage "$1" "help $2"
 }
 
 _comp_cmd_puppet()

--- a/completions/puppet
+++ b/completions/puppet
@@ -65,7 +65,7 @@ _comp_cmd_puppet()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local subcommand action
+    local subcommand="" action
 
     case $prev in
         -h | --help | -V | --version)

--- a/completions/pv
+++ b/completions/pv
@@ -24,7 +24,7 @@ _comp_cmd_pv()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         _comp_compgen_filedir
     fi

--- a/completions/pwck
+++ b/completions/pwck
@@ -6,9 +6,7 @@ _comp_cmd_pwck()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/pwd
+++ b/completions/pwd
@@ -11,7 +11,7 @@ _comp_cmd_pwd()
             ;;
     esac
 
-    _comp_compgen_usage help "-s $1"
+    _comp_compgen_usage -c help -s "$1"
 } &&
     complete -F _comp_cmd_pwd pwd
 

--- a/completions/pwd
+++ b/completions/pwd
@@ -11,7 +11,7 @@ _comp_cmd_pwd()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
+    _comp_compgen_usage help "-s $1"
 } &&
     complete -F _comp_cmd_pwd pwd
 

--- a/completions/pwgen
+++ b/completions/pwgen
@@ -20,7 +20,7 @@ _comp_cmd_pwgen()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/pycodestyle
+++ b/completions/pycodestyle
@@ -22,7 +22,7 @@ _comp_cmd_pycodestyle()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/pydocstyle
+++ b/completions/pydocstyle
@@ -23,7 +23,7 @@ _comp_cmd_pydocstyle()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/pyflakes
+++ b/completions/pyflakes
@@ -12,7 +12,7 @@ _comp_cmd_pyflakes()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/pylint
+++ b/completions/pylint
@@ -103,8 +103,7 @@ _comp_cmd_pylint()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W \
-            '$(_parse_help "$1" --long-help)' -- "$cur"))
+        _comp_compgen_help -- --long-help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/pytest
+++ b/completions/pytest
@@ -96,7 +96,7 @@ _comp_cmd_pytest()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/querybts
+++ b/completions/querybts
@@ -27,7 +27,7 @@ _comp_cmd_querybts()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         COMPREPLY=($(compgen -W 'wnpp boot-floppies kernel bugs.debian.org

--- a/completions/quota
+++ b/completions/quota
@@ -18,9 +18,7 @@ _comp_cmd_quota__user_or_group()
 
 _comp_cmd_quota__parse_help()
 {
-    COMPREPLY=($(
-        compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-    ))
+    _comp_compgen_help || _comp_compgen_usage
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 }
 

--- a/completions/radvdump
+++ b/completions/radvdump
@@ -15,7 +15,7 @@ _comp_cmd_radvdump()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+    _comp_compgen_usage -- --help
 } &&
     complete -F _comp_cmd_radvdump radvdump
 

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -60,7 +60,7 @@ _comp_cmd_reportbug()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == -*= ]] && compopt -o nospace
         return
     fi

--- a/completions/ri
+++ b/completions/ri
@@ -61,7 +61,7 @@ _comp_cmd_ri()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/rmmod
+++ b/completions/rmmod
@@ -13,7 +13,7 @@ _comp_cmd_rmmod()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/rpm
+++ b/completions/rpm
@@ -281,7 +281,7 @@ _comp_cmd_rpmbuild()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -6,7 +6,7 @@ _comp_cmd_sbopkg()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         [[ ${COMPREPLY-} ]] && return
     fi
 

--- a/completions/screen
+++ b/completions/screen
@@ -113,7 +113,7 @@ _comp_cmd_screen__sessions()
         esac
 
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
         fi
     } &&
         complete -F _comp_cmd_screen screen

--- a/completions/scrub
+++ b/completions/scrub
@@ -27,7 +27,7 @@ _comp_cmd_scrub()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -53,7 +53,7 @@ _comp_cmd_shellcheck()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -29,7 +29,7 @@ _comp_cmd_sitecopy()
 
     case $cur in
         --*)
-            COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
+            _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
             ;;

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -17,7 +17,7 @@ _comp_cmd_slapt_get()
     esac
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -17,7 +17,7 @@ _comp_cmd_slapt_get()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/slapt-src
+++ b/completions/slapt-src
@@ -19,7 +19,7 @@ _comp_cmd_slapt_src()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help -- --help
+        _comp_compgen_help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/slapt-src
+++ b/completions/slapt-src
@@ -19,7 +19,7 @@ _comp_cmd_slapt_src()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --help)' -- "$cur"))
+        _comp_compgen_help -- --help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -121,7 +121,7 @@ _comp_cmd_smartctl()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen -c "${cur:-/dev/}" filedir

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -101,7 +101,7 @@ _comp_cmd_smbclient()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
@@ -135,7 +135,7 @@ _comp_cmd_smbget()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
@@ -182,7 +182,7 @@ _comp_cmd_smbcacls()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
@@ -220,7 +220,7 @@ _comp_cmd_smbcquotas()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&
@@ -254,7 +254,7 @@ _comp_cmd_smbpasswd()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
     fi
 } &&
     complete -F _comp_cmd_smbpasswd smbpasswd
@@ -287,7 +287,7 @@ _comp_cmd_smbtar()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_smbtar smbtar
@@ -324,7 +324,7 @@ _comp_cmd_smbtree()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/snownews
+++ b/completions/snownews
@@ -7,7 +7,7 @@ _comp_cmd_snownews()
 
     if [[ $cur == -* ]]; then
         # return list of available options
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_snownews snownews

--- a/completions/sqlite3
+++ b/completions/sqlite3
@@ -27,7 +27,7 @@ _comp_cmd_sqlite3()
         return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         return
     fi
 

--- a/completions/ss
+++ b/completions/ss
@@ -30,7 +30,7 @@ _comp_cmd_ss()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ $prev == state ]]; then
         COMPREPLY=($(compgen -W 'all connected synchronized bucket big

--- a/completions/ssh
+++ b/completions/ssh
@@ -575,7 +575,7 @@ _comp_cmd_scp()
     else
         case $cur in
             -*)
-                _comp_compgen_usage -c "${words[0]}" --usage
+                _comp_compgen_usage
                 COMPREPLY=("${COMPREPLY[@]/%/ }")
                 return
                 ;;

--- a/completions/ssh
+++ b/completions/ssh
@@ -345,7 +345,7 @@ _comp_cmd_ssh()
         # Prefix completions with '-F'
         COMPREPLY=("${COMPREPLY[@]/#/-F}")
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         local args
         # Keep glob sort in sync with cases above
@@ -418,7 +418,7 @@ _comp_cmd_sftp()
         # Prefix completions with '-F'
         COMPREPLY=("${COMPREPLY[@]/#/-F}")
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _known_hosts_real ${ipvx:+"$ipvx"} -a ${configfile:+-F "$configfile"} -- "$cur"
     fi
@@ -575,8 +575,7 @@ _comp_cmd_scp()
     else
         case $cur in
             -*)
-                COMPREPLY=($(compgen -W '$(_parse_usage "${words[0]}")' \
-                    -- "$cur"))
+                _comp_compgen_usage "${words[0]}"
                 COMPREPLY=("${COMPREPLY[@]/%/ }")
                 return
                 ;;

--- a/completions/ssh
+++ b/completions/ssh
@@ -575,7 +575,7 @@ _comp_cmd_scp()
     else
         case $cur in
             -*)
-                _comp_compgen_usage "${words[0]}"
+                _comp_compgen_usage -c "${words[0]}" --usage
                 COMPREPLY=("${COMPREPLY[@]/%/ }")
                 return
                 ;;

--- a/completions/ssh-add
+++ b/completions/ssh-add
@@ -24,7 +24,7 @@ _comp_cmd_ssh_add()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" "-\?")' -- "$cur"))
+        _comp_compgen_help -- '-?'
         return
     fi
 

--- a/completions/ssh-copy-id
+++ b/completions/ssh-copy-id
@@ -22,7 +22,7 @@ _comp_cmd_ssh_copy_id()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1" --help)' -- "$cur"))
+        _comp_compgen_usage -- --help
     else
         _known_hosts_real -a -- "$cur"
     fi

--- a/completions/ssh-keyscan
+++ b/completions/ssh-keyscan
@@ -28,7 +28,7 @@ _comp_cmd_ssh_keyscan()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/sshmitm
+++ b/completions/sshmitm
@@ -6,7 +6,7 @@ _comp_cmd_sshmitm()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/sshow
+++ b/completions/sshow
@@ -17,7 +17,7 @@ _comp_cmd_sshow()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/strace
+++ b/completions/strace
@@ -88,7 +88,7 @@ _comp_cmd_strace()
         esac
 
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+            _comp_compgen_help -- -h
         else
             COMPREPLY=($(compgen -c -- "$cur"))
         fi

--- a/completions/sudo
+++ b/completions/sudo
@@ -45,9 +45,7 @@ _comp_cmd_sudo()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/synclient
+++ b/completions/synclient
@@ -12,7 +12,7 @@ _comp_cmd_synclient()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     elif [[ $cur != *=?* ]]; then
         COMPREPLY=($(compgen -S = -W '$("$1" -l 2>/dev/null | \
             awk "/^[ \t]/ { print \$1 }")' -- "$cur"))

--- a/completions/sysctl
+++ b/completions/sysctl
@@ -18,9 +18,7 @@ _comp_cmd_sysctl()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
     else
         local suffix=
         [[ $prev == -w ]] && suffix="="

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -56,7 +56,7 @@ _comp_cmd_tcpdump()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 

--- a/completions/tcpnice
+++ b/completions/tcpnice
@@ -13,7 +13,7 @@ _comp_cmd_tcpnice()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/timeout
+++ b/completions/timeout
@@ -32,9 +32,7 @@ _comp_cmd_timeout()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/tracepath
+++ b/completions/tracepath
@@ -12,9 +12,7 @@ _comp_cmd_tracepath()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/tree
+++ b/completions/tree
@@ -28,7 +28,7 @@ _comp_cmd_tree()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/truncate
+++ b/completions/truncate
@@ -20,7 +20,7 @@ _comp_cmd_truncate()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/tshark
+++ b/completions/tshark
@@ -124,8 +124,7 @@ _comp_cmd_tshark()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h 2>/dev/null)' \
-            -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 } &&

--- a/completions/tsig-keygen
+++ b/completions/tsig-keygen
@@ -23,7 +23,7 @@ _comp_cmd_tsig_keygen()
     esac
 
     [[ $cur != -* ]] ||
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
 } &&
     complete -F _comp_cmd_tsig_keygen tsig-keygen
 

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -51,7 +51,7 @@ _comp_cmd_tune2fs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
         return
     fi
 

--- a/completions/ulimit
+++ b/completions/ulimit
@@ -27,7 +27,7 @@ _comp_cmd_ulimit()
         done
 
         if [[ $cur == -* ]]; then
-            _comp_compgen_usage help "-s $1"
+            _comp_compgen_usage -c help -s "$1"
             return
         fi
     fi

--- a/completions/ulimit
+++ b/completions/ulimit
@@ -27,7 +27,7 @@ _comp_cmd_ulimit()
         done
 
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
+            _comp_compgen_usage help "-s $1"
             return
         fi
     fi

--- a/completions/unshunt
+++ b/completions/unshunt
@@ -6,7 +6,7 @@ _comp_cmd_unshunt()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         _comp_compgen_filedir -d
     fi

--- a/completions/update-alternatives
+++ b/completions/update-alternatives
@@ -83,7 +83,7 @@ _comp_cmd_update_alternatives()
             _comp_cmd_update_alternatives__installed
             ;;
         *)
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             ;;
     esac
 } &&

--- a/completions/urlsnarf
+++ b/completions/urlsnarf
@@ -17,7 +17,7 @@ _comp_cmd_urlsnarf()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     fi
 
 } &&

--- a/completions/uscan
+++ b/completions/uscan
@@ -27,7 +27,7 @@ _comp_cmd_uscan()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+    _comp_compgen_help
 } &&
     complete -F _comp_cmd_uscan uscan
 

--- a/completions/useradd
+++ b/completions/useradd
@@ -52,7 +52,7 @@ _comp_cmd_useradd()
     [[ $was_split ]] && return
 
     [[ $cur == -* ]] &&
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
 } &&
     complete -F _comp_cmd_useradd useradd
 

--- a/completions/userdel
+++ b/completions/userdel
@@ -18,7 +18,7 @@ _comp_cmd_userdel()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/usermod
+++ b/completions/usermod
@@ -53,7 +53,7 @@ _comp_cmd_usermod()
 
     if [[ $cur == -* ]]; then
         # TODO: -U/--unlock, -p/--password, -L/--lock mutually exclusive
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -13,7 +13,7 @@ _comp_cmd_valgrind()
         fi
     done
 
-    local word tool
+    local word tool=""
     for word in "${words[@]:1}"; do
         if [[ $word == --tool=?* ]]; then
             tool=$word
@@ -70,7 +70,7 @@ _comp_cmd_valgrind()
             # generic cases parsed from --help output
         --+([-A-Za-z0-9_]))
             # shellcheck disable=SC2086
-            local value=$("$1" --help-debug ${tool-} 2>/dev/null |
+            local value=$("$1" --help-debug $tool 2>/dev/null |
                 command sed \
                     -ne "s|^[[:blank:]]*$prev=\([^[:blank:]]\{1,\}\).*|\1|p")
             case $value in
@@ -101,7 +101,7 @@ _comp_cmd_valgrind()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help ${tool-}")' \
+        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help $tool")' \
             -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -101,8 +101,7 @@ _comp_cmd_valgrind()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" "--help $tool")' \
-            -- "$cur"))
+        _comp_compgen_help -- --help ${tool:+"$tool"}
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/vipw
+++ b/completions/vipw
@@ -17,9 +17,7 @@ _comp_cmd_vipw()
             ;;
     esac
 
-    COMPREPLY=($(
-        compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-    ))
+    _comp_compgen_help || _comp_compgen_usage
 } &&
     complete -F _comp_cmd_vipw vipw vigr
 

--- a/completions/vmstat
+++ b/completions/vmstat
@@ -19,9 +19,9 @@ _comp_cmd_vmstat()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} ]] ||
-            COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+            _comp_compgen_usage
     fi
 } &&
     complete -F _comp_cmd_vmstat vmstat

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -61,7 +61,7 @@ _vpnc()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" --long-help)' -- "$cur"))
+        _comp_compgen_help -- --long-help
     elif _comp_looks_like_path "$cur"; then
         # explicit filename
         _comp_compgen_filedir conf

--- a/completions/watch
+++ b/completions/watch
@@ -47,7 +47,7 @@ _comp_cmd_watch()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/webmitm
+++ b/completions/webmitm
@@ -6,7 +6,7 @@ _comp_cmd_webmitm()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_usage "$1")' -- "$cur"))
+        _comp_compgen_usage
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/wget
+++ b/completions/wget
@@ -169,7 +169,7 @@ _comp_cmd_wget()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 

--- a/completions/wol
+++ b/completions/wol
@@ -33,7 +33,7 @@ _comp_cmd_wol()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/wsimport
+++ b/completions/wsimport
@@ -35,7 +35,7 @@ _comp_cmd_wsimport()
         _known_hosts_real -- "${cur#-httpproxy:}"
         return
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
         _comp_ltrim_colon_completions "$cur"
         return

--- a/completions/wvdial
+++ b/completions/wvdial
@@ -18,7 +18,7 @@ _comp_cmd_wvdial()
 
     case $cur in
         -*)
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+            _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             ;;
         *)

--- a/completions/xev
+++ b/completions/xev
@@ -25,7 +25,7 @@ _comp_cmd_xev()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 } &&

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -49,7 +49,7 @@ _comp_cmd_xgamma()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         if [[ ${COMPREPLY-} ]]; then
             [[ $COMPREPLY == *= ]] && compopt -o nospace
             return

--- a/completions/xmllint
+++ b/completions/xmllint
@@ -41,7 +41,7 @@ _comp_cmd_xmllint()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         COMPREPLY=("${COMPREPLY[@]%:}")
         return
     fi

--- a/completions/xmlwf
+++ b/completions/xmlwf
@@ -21,9 +21,7 @@ _comp_cmd_xmlwf()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(
-            compgen -W '$(_parse_help "$1" || _parse_usage "$1")' -- "$cur"
-        ))
+        _comp_compgen_help || _comp_compgen_usage
         return
     fi
 

--- a/completions/xmms
+++ b/completions/xmms
@@ -20,7 +20,7 @@ _comp_cmd_xmms()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
     else
         _comp_compgen_filedir '@(mp[23]|ogg|wav|pls|m3u|xm|mod|s[3t]m|it|mtm|ult|flac)'
     fi

--- a/completions/xmodmap
+++ b/completions/xmodmap
@@ -12,7 +12,7 @@ _comp_cmd_xmodmap()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
+        _comp_compgen_help -- -help
         return
     fi
 

--- a/completions/xrdb
+++ b/completions/xrdb
@@ -16,7 +16,7 @@ _comp_cmd_xrdb()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         return
     fi
 

--- a/completions/xsltproc
+++ b/completions/xsltproc
@@ -37,7 +37,7 @@ _comp_cmd_xsltproc()
     [[ $cword -gt 2 && ${words[cword - 2]} == --?(string)param ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         COMPREPLY=("${COMPREPLY[@]%:}")
     else
         # TODO: 1st file xsl|xslt, 2nd XML

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -30,7 +30,7 @@ _comp_cmd_xvfb_run()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/xxd
+++ b/completions/xxd
@@ -13,7 +13,7 @@ _comp_cmd_xxd()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
+        _comp_compgen_help -- -h
         return
     fi
 

--- a/completions/xzdec
+++ b/completions/xzdec
@@ -19,7 +19,7 @@ _comp_cmd_xzdec()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi


### PR DESCRIPTION
This is based on #952 so would be kept to be Draft until PR #952 settles.

The own changes of this PR are 2ce600f6...39b15f38. This PR includes the API change of `_parse_{help,usage}` and trivial rewriting for switching from `_parse_{help,usage}`. Other non-trivial rewriting related to `_parse_{help,usage}` will be included in later PRs.