### PR TITLE
fix: use _comp_compgen for `COMPREPLY=($(compgen ...))`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -533,8 +533,7 @@ _comp_compgen()
 
     local _result
     _result=$(
-        IFS=$_ifs
-        compgen "$@" ${_cur:+-- "$_cur"}
+        IFS=$_ifs compgen "$@" ${_cur:+-- "$_cur"}
     ) || {
         local _status=$?
         if [[ $_append ]]; then

--- a/completions/7z
+++ b/completions/7z
@@ -6,7 +6,7 @@ _comp_cmd_7z()
     _comp_initialize -n = -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'a b d e h i l rn t u x' -- "$cur"))
+        _comp_compgen -- -W 'a b d e h i l rn t u x'
         return
     fi
 

--- a/completions/7z
+++ b/completions/7z
@@ -15,7 +15,7 @@ _comp_cmd_7z()
 
     case $cur in
         -ao*)
-            COMPREPLY=($(compgen -P"${cur:0:3}" -W 'a s t u' -- "${cur:3}"))
+            _comp_compgen -c "${cur:3}" -- -P"${cur:0:3}" -W 'a s t u'
             return
             ;;
         -?(a)[ix]*)
@@ -31,18 +31,18 @@ _comp_cmd_7z()
             elif [[ $cur == ?(r@(-|0|))@* ]]; then
                 local IFS=$' \t\n' reset=$(shopt -po noglob)
                 set -o noglob
-                COMPREPLY=($(compgen -P"${opt}${cur%%@*}@" -f -- "${cur#*@}"))
+                _comp_compgen -c "${cur#*@}" -- -P"${opt}${cur%%@*}@" -f
                 $reset
                 compopt -o filenames
             fi
             return
             ;;
         -mhe=* | -mhc=* | -ms=* | -mt=*)
-            COMPREPLY=($(compgen -W 'on off' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W 'on off'
             return
             ;;
         -mx=*)
-            COMPREPLY=($(compgen -W '0 1 3 5 7 9' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W '0 1 3 5 7 9'
             return
             ;;
         -o* | -w?*)
@@ -50,14 +50,14 @@ _comp_cmd_7z()
             set -o noglob
             compopt -o filenames
             local IFS=$'\n'
-            COMPREPLY=($(compgen -d -P"${cur:0:2}" -S/ -- "${cur:2}"))
+            _comp_compgen -c "${cur:2}" -- -d -P"${cur:0:2}" -S/
             _comp_unlocal IFS
             $reset
             compopt -o nospace
             return
             ;;
         -r?*)
-            COMPREPLY=($(compgen -P"${cur:0:2}" -W '- 0' -- "${cur:2}"))
+            _comp_compgen -c "${cur:2}" -- -P"${cur:0:2}" -W '- 0'
             return
             ;;
         -scs*)
@@ -66,7 +66,7 @@ _comp_cmd_7z()
             return
             ;;
         -ssc?*)
-            COMPREPLY=($(compgen -P"${cur:0:4}" -W '-' -- "${cur:4}"))
+            _comp_compgen -c "${cur:4}" -- -P"${cur:0:4}" -W '-'
             return
             ;;
         -t*)

--- a/completions/7z
+++ b/completions/7z
@@ -29,10 +29,7 @@ _comp_cmd_7z()
                 COMPREPLY=($(compgen -P"$opt" -W '@ ! r@ r-@ r0@ r! r-! r0!' \
                     -- "$cur"))
             elif [[ $cur == ?(r@(-|0|))@* ]]; then
-                local IFS=$' \t\n' reset=$(shopt -po noglob)
-                set -o noglob
                 _comp_compgen -c "${cur#*@}" -- -P"${opt}${cur%%@*}@" -f
-                $reset
                 compopt -o filenames
             fi
             return
@@ -46,13 +43,8 @@ _comp_cmd_7z()
             return
             ;;
         -o* | -w?*)
-            local reset=$(shopt -po noglob)
-            set -o noglob
             compopt -o filenames
-            local IFS=$'\n'
             _comp_compgen -c "${cur:2}" -- -d -P"${cur:0:2}" -S/
-            _comp_unlocal IFS
-            $reset
             compopt -o nospace
             return
             ;;

--- a/completions/_adb
+++ b/completions/_adb
@@ -44,7 +44,7 @@ _comp_cmd_adb()
             tmp+=(devices connect disconnect sideload)
         fi
         ((${#tmp[@]})) &&
-            COMPREPLY=($(compgen -W '"${tmp[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${tmp[@]}"'
         return
     fi
 
@@ -62,7 +62,7 @@ _comp_cmd_adb()
                     _parse_help -)' -- "$cur"))
             ;;
         reboot)
-            COMPREPLY=($(compgen -W 'bootloader recovery' -- "$cur"))
+            _comp_compgen -- -W 'bootloader recovery'
             ;;
     esac
 } &&

--- a/completions/_cal
+++ b/completions/_cal
@@ -11,7 +11,7 @@ _comp_cmd_cal()
     case $prev in
         -m)
             if [[ $OSTYPE == *bsd* ]]; then
-                COMPREPLY=($(compgen -W '{1..12}' -- "$cur"))
+                _comp_compgen -- -W '{1..12}'
                 return
             fi
             ;;
@@ -32,7 +32,7 @@ _comp_cmd_cal()
 
     local args
     _count_args
-    ((args == 1)) && COMPREPLY=($(compgen -W '{1..12}' -- "$cur"))
+    ((args == 1)) && _comp_compgen -- -W '{1..12}'
 } &&
     complete -F _comp_cmd_cal cal ncal
 

--- a/completions/_dmesg
+++ b/completions/_dmesg
@@ -20,7 +20,7 @@ _comp_cmd_dmesg()
             return
             ;;
         -l | --level | -n | --console-level)
-            COMPREPLY=($(compgen -W '{1..8}' -- "$cur"))
+            _comp_compgen -- -W '{1..8}'
             return
             ;;
     esac

--- a/completions/_eject
+++ b/completions/_eject
@@ -13,7 +13,7 @@ _comp_cmd_eject()
             return
             ;;
         -a | --auto | -i | --manualeject)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
     esac

--- a/completions/_ionice
+++ b/completions/_ionice
@@ -37,11 +37,11 @@ _comp_cmd_ionice()
 
     case $prev in
         -c)
-            COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
+            _comp_compgen -- -W '{0..3}'
             return
             ;;
         -n)
-            COMPREPLY=($(compgen -W '{0..7}' -- "$cur"))
+            _comp_compgen -- -W '{0..7}'
             return
             ;;
         -p)

--- a/completions/_mock
+++ b/completions/_mock
@@ -50,7 +50,7 @@ _comp_cmd_mock()
             return
             ;;
         --enable-plugin | --disable-plugin)
-            COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
+            _comp_compgen -- -W "$plugins"
             return
             ;;
     esac

--- a/completions/_modules
+++ b/completions/_modules
@@ -60,7 +60,7 @@ _comp_cmd_module()
         options="$(module help 2>&1 | command grep -E '^[[:space:]]*\+' |
             awk '{print $2}' | command sed -e 's/|/ /g' | sort)"
 
-        COMPREPLY=($(compgen -W "$options" -- "$cur"))
+        _comp_compgen -- -W "$options"
 
     elif ((cword == 2)); then
         case $prev in

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -32,7 +32,7 @@ _comp_cmd_mount()
             return
             ;;
         -p | --pass-fd)
-            COMPREPLY=($(compgen -W '{0..9}'))
+            _comp_compgen -R -- -W '{0..9}'
             compopt -o nospace
             return
             ;;

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -86,7 +86,7 @@ _comp_cmd_mount()
                 {,no}user users' -- "$cur"))
             case "$fstype" in
                 adfs | auto)
-                    COMPREPLY+=($(compgen -W '{u,g}id= {own,oth}mask=' -- "$cur"))
+                    _comp_compgen -a -- -W '{u,g}id= {own,oth}mask='
                     ;;&
                 affs | auto)
                     COMPREPLY+=($(compgen -W '{u,g}id= set{u,g}id= mode= protect
@@ -145,7 +145,7 @@ _comp_cmd_mount()
                     iocharset= utf8' -- "$cur"))
                     ;;&
                 jffs2 | auto)
-                    COMPREPLY+=($(compgen -W 'compr= rp_size=' -- "$cur"))
+                    _comp_compgen -a -- -W 'compr= rp_size='
                     ;;&
                 jfs | auto)
                     COMPREPLY+=($(compgen -W 'iocharset= resize= {,no}integrity
@@ -175,7 +175,7 @@ _comp_cmd_mount()
                     {,no}compression debug no_detach' -- "$cur"))
                     ;;&
                 proc | auto)
-                    COMPREPLY+=($(compgen -W '{u,g}id=' -- "$cur"))
+                    _comp_compgen -a -- -W '{u,g}id='
                     ;;&
                 reiserfs | auto)
                     COMPREPLY+=($(compgen -W 'conv hash= {,no_un}hashed_relocation

--- a/completions/_nmcli
+++ b/completions/_nmcli
@@ -5,7 +5,7 @@
 
 _comp_cmd_nmcli__list()
 {
-    COMPREPLY=($(compgen -W '$1' -- "$cur"))
+    _comp_compgen -- -W '$1'
 }
 
 _comp_cmd_nmcli__con_id()
@@ -41,11 +41,11 @@ _comp_cmd_nmcli()
 
     case $prev in
         -m | --mode)
-            COMPREPLY=($(compgen -W 'tabular multiline' -- "$cur"))
+            _comp_compgen -- -W 'tabular multiline'
             return
             ;;
         -f | --fields)
-            COMPREPLY=($(compgen -W 'all common' -- "$cur"))
+            _comp_compgen -- -W 'all common'
             return
             ;;
         -e | --escape)
@@ -79,7 +79,7 @@ _comp_cmd_nmcli()
             COMPREPLY=($(compgen -W '--terse --pretty --mode --fields
                 --escape --version --help' -- "$cur"))
         else
-            COMPREPLY=($(compgen -W "nm con dev" -- "$cur"))
+            _comp_compgen -- -W "nm con dev"
         fi
     else
         local object=${words[1]}
@@ -116,7 +116,7 @@ _comp_cmd_nmcli()
             con)
                 case $command in
                     list)
-                        COMPREPLY=($(compgen -W 'id uuid' -- "$cur"))
+                        _comp_compgen -- -W 'id uuid'
                         return
                         ;;
                     up)
@@ -130,11 +130,11 @@ _comp_cmd_nmcli()
                         return
                         ;;
                     down)
-                        COMPREPLY=($(compgen -W 'id uuid' -- "$cur"))
+                        _comp_compgen -- -W 'id uuid'
                         return
                         ;;
                     delete)
-                        COMPREPLY=($(compgen -W 'id uuid' -- "$cur"))
+                        _comp_compgen -- -W 'id uuid'
                         return
                         ;;
                 esac
@@ -145,7 +145,7 @@ _comp_cmd_nmcli()
             dev)
                 case $command in
                     list)
-                        COMPREPLY=($(compgen -W 'iface' -- "$cur"))
+                        _comp_compgen -- -W 'iface'
                         return
                         ;;
                     disconnect)
@@ -153,7 +153,7 @@ _comp_cmd_nmcli()
                             COMPREPLY=($(compgen -W '--nowait --timeout' \
                                 -- "$cur"))
                         else
-                            COMPREPLY=($(compgen -W 'iface' -- "$cur"))
+                            _comp_compgen -- -W 'iface'
                         fi
                         return
                         ;;
@@ -183,7 +183,7 @@ _comp_cmd_nmcli()
                                 ;;
                         esac
 
-                        COMPREPLY=($(compgen -W 'list connect' -- "$cur"))
+                        _comp_compgen -- -W 'list connect'
                         return
                         ;;
                 esac

--- a/completions/_rfkill
+++ b/completions/_rfkill
@@ -9,7 +9,7 @@ _comp_cmd_rfkill()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--version' -- "$cur"))
+        _comp_compgen -- -W '--version'
     else
         case $cword in
             1)

--- a/completions/_rtcwake
+++ b/completions/_rtcwake
@@ -13,13 +13,13 @@ _comp_cmd_rtcwake()
             return
             ;;
         --mode | -m)
-            COMPREPLY=($(compgen -W 'standby mem disk on no off' -- "$cur"))
+            _comp_compgen -- -W 'standby mem disk on no off'
             return
             ;;
         --device | -d)
             _comp_expand_glob COMPREPLY '/dev/rtc?*'
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]#/dev/}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]#/dev/}"'
             return
             ;;
     esac

--- a/completions/_slackpkg
+++ b/completions/_slackpkg
@@ -20,11 +20,11 @@ _comp_cmd_slackpkg()
         -delall | -checkmd5 | -checkgpg | -checksize | -postinst | -onoff | \
             -download_all | -dialog | -batch | -only_new_dotnew | \
             -use_includes | -spinning)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         -default_answer)
-            COMPREPLY=($(compgen -W 'yes no' -- "$cur"))
+            _comp_compgen -- -W 'yes no'
             return
             ;;
         -dialog_maxargs | -mirror)
@@ -98,7 +98,7 @@ _comp_cmd_slackpkg()
             ;;
         update)
             # we should complete the same as the next `list` + "gpg"
-            COMPREPLY=($(compgen -W 'gpg' -- "$cur"))
+            _comp_compgen -- -W 'gpg'
             ;&
         *)
             COMPREPLY+=($(compgen -W 'install reinstall upgrade remove

--- a/completions/_su
+++ b/completions/_su
@@ -21,7 +21,7 @@ _comp_cmd_su()
         -c | --command | --session-command)
             local IFS=$'\n'
             compopt -o filenames
-            COMPREPLY=($(compgen -d -c -- "$cur"))
+            _comp_compgen -- -d -c
             return
             ;;
     esac
@@ -34,7 +34,7 @@ _comp_cmd_su()
         return
     fi
 
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_su su
 

--- a/completions/_su
+++ b/completions/_su
@@ -19,7 +19,6 @@ _comp_cmd_su()
             return
             ;;
         -c | --command | --session-command)
-            local IFS=$'\n'
             compopt -o filenames
             _comp_compgen -- -d -c
             return

--- a/completions/_svn
+++ b/completions/_svn
@@ -18,9 +18,9 @@ _comp_cmd_svn()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--version' -- "$cur"))
+            _comp_compgen -- -W '--version'
         else
-            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            _comp_compgen -- -W "$commands"
         fi
     else
 
@@ -39,7 +39,7 @@ _comp_cmd_svn()
                 ;;
             --editor-cmd | --diff-cmd | --diff3-cmd)
                 compopt -o filenames
-                COMPREPLY=($(compgen -c -- "$cur"))
+                _comp_compgen -- -c
                 return
                 ;;
         esac
@@ -194,10 +194,10 @@ _comp_cmd_svn()
             esac
             options+=" --help --config-dir"
 
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             if [[ $command == @(help|[h?]) ]]; then
-                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+                _comp_compgen -- -W "$commands"
             else
                 _comp_compgen_filedir
             fi

--- a/completions/_svnadmin
+++ b/completions/_svnadmin
@@ -14,9 +14,9 @@ _comp_cmd_svnadmin()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--version' -- "$cur"))
+            _comp_compgen -- -W '--version'
         else
-            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            _comp_compgen -- -W "$commands"
         fi
     else
         case $prev in
@@ -25,7 +25,7 @@ _comp_cmd_svnadmin()
                 return
                 ;;
             --fs-type)
-                COMPREPLY=($(compgen -W 'fsfs bdb' -- "$cur"))
+                _comp_compgen -- -W 'fsfs bdb'
                 return
                 ;;
         esac
@@ -62,10 +62,10 @@ _comp_cmd_svnadmin()
             esac
 
             options+=" --help"
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             if [[ $command == @(help|[h?]) ]]; then
-                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+                _comp_compgen -- -W "$commands"
             else
                 _comp_compgen_filedir
             fi

--- a/completions/_svnlook
+++ b/completions/_svnlook
@@ -14,9 +14,9 @@ _comp_cmd_svnlook()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--version' -- "$cur"))
+            _comp_compgen -- -W '--version'
         else
-            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            _comp_compgen -- -W "$commands"
         fi
     else
         local command=${words[1]}
@@ -47,10 +47,10 @@ _comp_cmd_svnlook()
             esac
 
             options+=" --help"
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             if [[ $command == @(help|[h?]) ]]; then
-                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+                _comp_compgen -- -W "$commands"
             else
                 _comp_compgen_filedir
             fi

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -25,7 +25,7 @@ _comp_cmd_udevadm()
             return
             ;;
         --log-priority)
-            COMPREPLY=($(compgen -W 'err info debug' -- "$cur"))
+            _comp_compgen -- -W 'err info debug'
             return
             ;;
         --query)
@@ -42,11 +42,11 @@ _comp_cmd_udevadm()
             return
             ;;
         --action)
-            COMPREPLY=($(compgen -W 'add change remove' -- "$cur"))
+            _comp_compgen -- -W 'add change remove'
             return
             ;;
         --type)
-            COMPREPLY=($(compgen -W 'devices subsystems failed' -- "$cur"))
+            _comp_compgen -- -W 'devices subsystems failed'
             return
             ;;
     esac
@@ -56,7 +56,7 @@ _comp_cmd_udevadm()
     if [[ ! $has_udevcmd ]]; then
         case $cur in
             -*)
-                COMPREPLY=($(compgen -W '--help --version --debug' -- "$cur"))
+                _comp_compgen -- -W '--help --version --debug'
                 ;;
             *)
                 COMPREPLY=($(compgen -W "$("$1" --help 2>/dev/null |

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -28,7 +28,7 @@ _comp_cmd_umount__reply_compgen_array()
 
     # Actually generate completions.
     local IFS=$'\n'
-    COMPREPLY=($(compgen -W "$wlist" -- "${ecur}"))
+    _comp_compgen -c "${ecur}" -- -W "$wlist"
     _comp_unlocal IFS
 }
 

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -27,9 +27,7 @@ _comp_cmd_umount__reply_compgen_array()
     ecur=${ecur//\'/\\\'}
 
     # Actually generate completions.
-    local IFS=$'\n'
-    _comp_compgen -c "${ecur}" -- -W "$wlist"
-    _comp_unlocal IFS
+    _comp_compgen -lc "${ecur}" -- -W "$wlist"
 }
 
 # Unescape strings in the linux fstab(5) format (with octal escapes).

--- a/completions/_xm
+++ b/completions/_xm
@@ -31,7 +31,7 @@ _comp_cmd_xm()
         resetpolicy getpolicy shell help'
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        _comp_compgen -- -W "$commands"
     else
         if [[ $cur == *=* ]]; then
             prev=${cur/=*/}
@@ -72,7 +72,7 @@ _comp_cmd_xm()
                         -s --skipdtd -p --paused -c --console_autoconnect'
                     ;;
             esac
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             case $command in
                 console | destroy | domname | domid | list | mem-set | \
@@ -118,7 +118,7 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         3)
-                            COMPREPLY=($(compgen -W "r s e i u b" -- "$cur"))
+                            _comp_compgen -- -W "r s e i u b"
                             ;;
                     esac
                     ;;
@@ -129,10 +129,10 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         3)
-                            COMPREPLY=($(compgen -W "phy: file:" -- "$cur"))
+                            _comp_compgen -- -W "phy: file:"
                             ;;
                         5)
-                            COMPREPLY=($(compgen -W "w r" -- "$cur"))
+                            _comp_compgen -- -W "w r"
                             ;;
                         6)
                             _comp_cmd_xm__domain_names

--- a/completions/_yum
+++ b/completions/_yum
@@ -90,14 +90,14 @@ _comp_cmd_yum()
                 all' -- "$cur"))
             ;;
         repolist)
-            COMPREPLY=($(compgen -W 'all enabled disabled' -- "$cur"))
+            _comp_compgen -- -W 'all enabled disabled'
             ;;
         localinstall | localupdate)
             # TODO: should not match *src.rpm
             _comp_compgen_filedir rpm
             ;;
         -d | -e)
-            COMPREPLY=($(compgen -W '{0..10}' -- "$cur"))
+            _comp_compgen -- -W '{0..10}'
             ;;
         -c)
             _comp_compgen_filedir
@@ -119,7 +119,7 @@ _comp_cmd_yum()
             COMPREPLY=($(compgen -W '$(_yum_plugins)' -- "$cur"))
             ;;
         --color)
-            COMPREPLY=($(compgen -W 'always auto never' -- "$cur"))
+            _comp_compgen -- -W 'always auto never'
             ;;
         -R | -x | --exclude)
             # argument required but no completions available

--- a/completions/abook
+++ b/completions/abook
@@ -33,11 +33,11 @@ _comp_cmd_abook()
             ;;
         --infile)
             COMPREPLY=($(compgen -W stdin -- "$cur"))
-            _comp_compgen_filedir
+            _comp_compgen -a filedir
             ;;
         --outfile)
             COMPREPLY=($(compgen -W stdout -- "$cur"))
-            _comp_compgen_filedir
+            _comp_compgen -a filedir
             ;;
         --config | --datafile)
             _comp_compgen_filedir

--- a/completions/abook
+++ b/completions/abook
@@ -32,11 +32,11 @@ _comp_cmd_abook()
                 -- "$cur"))
             ;;
         --infile)
-            COMPREPLY=($(compgen -W stdin -- "$cur"))
+            _comp_compgen -- -W stdin
             _comp_compgen -a filedir
             ;;
         --outfile)
-            COMPREPLY=($(compgen -W stdout -- "$cur"))
+            _comp_compgen -- -W stdout
             _comp_compgen -a filedir
             ;;
         --config | --datafile)

--- a/completions/add_members
+++ b/completions/add_members
@@ -11,7 +11,7 @@ _comp_cmd_add_members()
             return
             ;;
         -w | -a | --welcome-msg | --admin-notify)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac

--- a/completions/alias
+++ b/completions/alias
@@ -10,7 +10,7 @@ _comp_cmd_alias()
             return
             ;;
         *[^=])
-            COMPREPLY=($(compgen -A alias -- "$cur"))
+            _comp_compgen -- -A alias
             ;;
         *=)
             COMPREPLY=("$(alias "${cur%=}" 2>/dev/null | command sed \

--- a/completions/ant
+++ b/completions/ant
@@ -47,7 +47,7 @@ _comp_cmd_ant()
             return
             ;;
         -nice)
-            COMPREPLY=($(compgen -W '{1..10}' -- "$cur"))
+            _comp_compgen -- -W '{1..10}'
             return
             ;;
         -lib)
@@ -92,7 +92,7 @@ _comp_cmd_ant()
         # fill targets
         _comp_cmd_ant__targets "$buildfile"
 
-        COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${ret[@]}"'
     fi
 } &&
     complete -F _comp_cmd_ant ant phing

--- a/completions/apache2ctl
+++ b/completions/apache2ctl
@@ -9,7 +9,7 @@ _comp_cmd_apache2ctl()
     APWORDS=$("$1" 2>&1 >/dev/null | awk 'NR<2 { print $3; exit }' |
         tr "|" " ")
 
-    COMPREPLY=($(compgen -W "$APWORDS" -- "$cur"))
+    _comp_compgen -- -W "$APWORDS"
 } &&
     complete -F _comp_cmd_apache2ctl apache2ctl
 

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -108,7 +108,7 @@ _comp_cmd_aptitude()
         done
 
         ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]}"'
     else
         COMPREPLY=($(compgen -W 'update upgrade safe-upgrade forget-new
             clean autoclean install reinstall remove hold unhold purge markauto

--- a/completions/arch
+++ b/completions/arch
@@ -10,7 +10,7 @@ _comp_have_command mailmanctl &&
 
         case $prev in
             -w | -g | -d | --welcome-msg | --goodbye-msg | --digest)
-                COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+                _comp_compgen -- -W 'y n'
                 return
                 ;;
             --file)

--- a/completions/arp
+++ b/completions/arp
@@ -41,7 +41,7 @@ _comp_cmd_arp()
         1)
             local ips=$("$1" -an | command sed -ne \
                 's/.*(\([0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\{3\}\)).*/\1/p')
-            COMPREPLY=($(compgen -W '$ips' -- "$cur"))
+            _comp_compgen -- -W '$ips'
             ;;
         2)
             # TODO if -d mode: "pub"; if not -f mode: hw_addr

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -2,7 +2,7 @@
 
 _comp_xfunc_asciidoc_doctype()
 {
-    COMPREPLY+=($(compgen -W 'article book manpage' -- "$cur"))
+    _comp_compgen -a -- -W 'article book manpage'
 }
 
 _comp_deprecate_func _asciidoc_doctype _comp_xfunc_asciidoc_doctype

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -19,7 +19,7 @@ _comp_cmd_asciidoc()
             return
             ;;
         --backend | -${noargopts}b)
-            COMPREPLY=($(compgen -W 'docbook html4 xhtml11' -- "$cur"))
+            _comp_compgen -- -W 'docbook html4 xhtml11'
             return
             ;;
         --conf-file | -${noargopts}f)
@@ -31,7 +31,7 @@ _comp_cmd_asciidoc()
             return
             ;;
         --help | -${noargopts}h)
-            COMPREPLY=($(compgen -W 'manpage syntax topics' -- "$cur"))
+            _comp_compgen -- -W 'manpage syntax topics'
             return
             ;;
         --out-file | -${noargopts}o)

--- a/completions/aspell
+++ b/completions/aspell
@@ -13,7 +13,7 @@ _comp_cmd_aspell__dictionary()
     # Then, add the canonical dicts
     COMPREPLY+=($("$aspell" dicts 2>/dev/null))
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -X '\*' -W '"${COMPREPLY[@]}"' -- "$cur"))
+        _comp_compgen -- -X '\*' -W '"${COMPREPLY[@]}"'
 }
 
 _comp_cmd_aspell()
@@ -31,7 +31,7 @@ _comp_cmd_aspell()
             return
             ;;
         dump | create | merge)
-            COMPREPLY=($(compgen -W 'master personal repl' -- "$cur"))
+            _comp_compgen -- -W 'master personal repl'
             return
             ;;
         --mode)
@@ -45,7 +45,7 @@ _comp_cmd_aspell()
             return
             ;;
         --keymapping)
-            COMPREPLY=($(compgen -W 'aspell ispell' -- "$cur"))
+            _comp_compgen -- -W 'aspell ispell'
             return
             ;;
         -d | --master)

--- a/completions/avctrl
+++ b/completions/avctrl
@@ -6,12 +6,12 @@ _comp_cmd_avctrl()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--help --quiet' -- "$cur"))
+        _comp_compgen -- -W '--help --quiet'
     else
         local args
         _count_args
         if ((args == 1)); then
-            COMPREPLY=($(compgen -W 'discover switch' -- "$cur"))
+            _comp_compgen -- -W 'discover switch'
         fi
     fi
 } &&

--- a/completions/bind
+++ b/completions/bind
@@ -29,7 +29,7 @@ _comp_cmd_bind()
         return
     fi
 
-    COMPREPLY=($(compgen -A binding -- "$cur"))
+    _comp_compgen -- -A binding
 } &&
     complete -F _comp_cmd_bind bind
 

--- a/completions/bk
+++ b/completions/bk
@@ -9,7 +9,7 @@ _comp_cmd_bk()
     local BKCMDS="$(bk help topics 2>/dev/null |
         awk '/^  bk/ { print $2 }' | xargs printf '%s ')"
 
-    COMPREPLY=($(compgen -W "$BKCMDS" -- "$cur"))
+    _comp_compgen -- -W "$BKCMDS"
     _comp_compgen -a filedir
 
 } &&

--- a/completions/brctl
+++ b/completions/brctl
@@ -29,7 +29,7 @@ _comp_cmd_brctl()
                     _configured_interfaces
                     ;;
                 stp)
-                    COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+                    _comp_compgen -- -W 'on off'
                     ;;
             esac
             ;;

--- a/completions/bts
+++ b/completions/bts
@@ -43,7 +43,7 @@ _comp_cmd_bts()
             return
             ;;
         block | unblock)
-            COMPREPLY=($(compgen -W 'by with' -- "$cur"))
+            _comp_compgen -- -W 'by with'
             return
             ;;
         severity)

--- a/completions/cancel
+++ b/completions/cancel
@@ -14,7 +14,7 @@ _comp_cmd_cancel()
             return
             ;;
         -u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac

--- a/completions/carton
+++ b/completions/carton
@@ -10,7 +10,7 @@ _comp_cmd_carton__commands()
 _comp_cmd_carton__command_help()
 {
     local help=$(PERLDOC_PAGER=cat PERLDOC=-otext "${1:-carton}" -h "$2" 2>&1)
-    COMPREPLY+=($(compgen -W '$help' -- "$cur"))
+    _comp_compgen -a -- -W '$help'
 }
 
 _comp_cmd_carton()
@@ -58,7 +58,7 @@ _comp_cmd_carton()
         --without)
             if [[ $command == install ]]; then
                 local phases="configure build test runtime develop"
-                COMPREPLY+=($(compgen -W '$phases' -- "$cur"))
+                _comp_compgen -a -- -W '$phases'
                 return
             fi
             ;;

--- a/completions/ccze
+++ b/completions/ccze
@@ -20,12 +20,12 @@ _comp_cmd_ccze()
             return
             ;;
         --mode | -${noargopts}m)
-            COMPREPLY=($(compgen -W "curses ansi html" -- "$cur"))
+            _comp_compgen -- -W "curses ansi html"
             return
             ;;
         --option | -${noargopts}o)
             local -a opts=(scroll wordcolor lookups transparent cssfile)
-            COMPREPLY=($(compgen -W '"${opts[@]}" "${opts[@]/#/no}"' -- "$cur"))
+            _comp_compgen -- -W '"${opts[@]}" "${opts[@]/#/no}"'
             return
             ;;
         --plugin | -${noargopts}p)

--- a/completions/cfrun
+++ b/completions/cfrun
@@ -22,7 +22,7 @@ _comp_cmd_cfrun()
             esac
 
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '-f -h -d -S -T -v' -- "$cur"))
+                _comp_compgen -- -W '-f -h -d -S -T -v'
             else
                 local hostfile=${CFINPUTS:-/var/lib/cfengine/inputs}/cfrun.hosts
                 for ((i = 1; i < cword; i++)); do

--- a/completions/chage
+++ b/completions/chage
@@ -25,7 +25,7 @@ _comp_cmd_chage()
         return
     fi
 
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_chage chage
 

--- a/completions/check_db
+++ b/completions/check_db
@@ -6,7 +6,7 @@ _comp_cmd_check_db()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--all --verbose --help' -- "$cur"))
+        _comp_compgen -- -W '--all --verbose --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/check_perms
+++ b/completions/check_perms
@@ -6,7 +6,7 @@ _comp_cmd_check_perms()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-f -v -h' -- "$cur"))
+        _comp_compgen -- -W '-f -v -h'
     fi
 
 } &&

--- a/completions/chkconfig
+++ b/completions/chkconfig
@@ -12,7 +12,7 @@ _comp_cmd_chkconfig()
             return
             ;;
         --level)
-            COMPREPLY=($(compgen -W '{1..6}' -- "$cur"))
+            _comp_compgen -- -W '{1..6}'
             return
             ;;
     esac

--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -23,13 +23,13 @@ _comp_cmd_chromium_browser()
                     ;;
                 *)
                     compopt -o nospace
-                    COMPREPLY=($(compgen -S :// -W 'http socks socks4 socks5' -- "$cur"))
+                    _comp_compgen -- -S :// -W 'http socks socks4 socks5'
                     ;;
             esac
             return
             ;;
         --password-store)
-            COMPREPLY=($(compgen -W 'basic gnome kwallet' -- "$cur"))
+            _comp_compgen -- -W 'basic gnome kwallet'
             return
             ;;
     esac

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -49,7 +49,7 @@ _comp_cmd_chronyc()
             _comp_cmd_chronyc__command_args "$1"
             if [[ ! ${COMPREPLY-} && $prev == sources?(tats) ]]; then
                 # [-v] not handled by _comp_cmd_chronyc__command_args yet
-                COMPREPLY=($(compgen -W '-v' -- "$cur"))
+                _comp_compgen -- -W '-v'
             fi
             ;;
         2)

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -9,7 +9,7 @@ _comp_cmd_chronyc__command_args()
         \<address\>) _known_hosts_real -- "$cur" ;;
         \<*) ;;
         *) ((${#args[@]})) &&
-            COMPREPLY+=($(compgen -W '"${args[@]}"' -- "$cur")) ;;
+            _comp_compgen -a -- -W '"${args[@]}"' ;;
     esac
 }
 

--- a/completions/complete
+++ b/completions/complete
@@ -21,17 +21,17 @@ _comp_cmd_complete()
             ;;
 
         -*C)
-            COMPREPLY=($(compgen -A command -- "$cur"))
+            _comp_compgen -- -A command
             return
             ;;
         -*F)
-            COMPREPLY=($(compgen -A function -- "$cur"))
+            _comp_compgen -- -A function
             return
             ;;
         -*p | -*r)
             COMPREPLY=($(complete -p | command sed -e 's|.* ||'))
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return
             ;;
     esac
@@ -40,9 +40,9 @@ _comp_cmd_complete()
         local -a opts=($(compgen -W '$(_parse_usage help "-s $1")' -- "$cur"))
         # -F, -C do not work the expected way with compgen
         [[ $1 != *compgen ]] || opts=("${opts[@]//-[FC]/}")
-        COMPREPLY=($(compgen -W '"${opts[@]}"' -X '' -- "$cur"))
+        _comp_compgen -- -W '"${opts[@]}"' -X ''
     else
-        COMPREPLY=($(compgen -A command -- "$cur"))
+        _comp_compgen -- -A command
     fi
 } &&
     complete -F _comp_cmd_complete compgen complete

--- a/completions/convert
+++ b/completions/convert
@@ -9,7 +9,7 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -colormap)
-            COMPREPLY=($(compgen -W 'shared private' -- "$cur"))
+            _comp_compgen -- -W 'shared private'
             return
             ;;
         -colorspace)
@@ -40,7 +40,7 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -endian)
-            COMPREPLY=($(compgen -W 'MSB LSB' -- "$cur"))
+            _comp_compgen -- -W 'MSB LSB'
             return
             ;;
         -filter)
@@ -66,11 +66,11 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -interlace)
-            COMPREPLY=($(compgen -W 'None Line Plane Partition' -- "$cur"))
+            _comp_compgen -- -W 'None Line Plane Partition'
             return
             ;;
         -limit)
-            COMPREPLY=($(compgen -W 'Disk File Map Memory' -- "$cur"))
+            _comp_compgen -- -W 'Disk File Map Memory'
             return
             ;;
         -list)
@@ -113,7 +113,7 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -virtual-pixel)
-            COMPREPLY=($(compgen -W 'Constant Edge mirror tile' -- "$cur"))
+            _comp_compgen -- -W 'Constant Edge mirror tile'
             return
             ;;
         -visual)
@@ -210,7 +210,7 @@ _comp_cmd_identify()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug' -- "$cur"))
+        _comp_compgen -- -W '+debug'
     else
         _comp_compgen_filedir
     fi
@@ -263,7 +263,7 @@ _comp_cmd_compare()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug' -- "$cur"))
+        _comp_compgen -- -W '+debug'
     else
         _comp_compgen_filedir
     fi
@@ -280,7 +280,7 @@ _comp_cmd_conjure()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug' -- "$cur"))
+        _comp_compgen -- -W '+debug'
     else
         _comp_compgen_filedir
     fi
@@ -297,7 +297,7 @@ _comp_cmd_import()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug' -- "$cur"))
+        _comp_compgen -- -W '+debug'
     else
         _comp_compgen_filedir
     fi
@@ -314,7 +314,7 @@ _comp_cmd_stream()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug' -- "$cur"))
+        _comp_compgen -- -W '+debug'
     else
         _comp_compgen_filedir
     fi

--- a/completions/cpio
+++ b/completions/cpio
@@ -24,7 +24,7 @@ _comp_cmd_cpio()
             ;;
         --rsh-command)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -30,7 +30,7 @@ _comp_cmd_cppcheck()
             return
             ;;
         --error-exitcode)
-            COMPREPLY=($(compgen -W '{0..255}' -- "$cur"))
+            _comp_compgen -- -W '{0..255}'
             return
             ;;
         --file-list)
@@ -47,7 +47,7 @@ _comp_cmd_cppcheck()
             return
             ;;
         --language | -x)
-            COMPREPLY=($(compgen -W 'c c++' -- "$cur"))
+            _comp_compgen -- -W 'c c++'
             return
             ;;
         --std)
@@ -72,7 +72,7 @@ _comp_cmd_cppcheck()
             return
             ;;
         --xml-version)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
     esac

--- a/completions/crontab
+++ b/completions/crontab
@@ -36,7 +36,7 @@ _comp_cmd_crontab()
     done
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '"${!opts[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${!opts[@]}"'
         return
     fi
 

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -27,7 +27,7 @@ _comp_cmd_cryptsetup()
             return
             ;;
         --type | -${noargopts}M)
-            COMPREPLY=($(compgen -W "luks plain loopaes tcrypt" -- "$cur"))
+            _comp_compgen -- -W "luks plain loopaes tcrypt"
             return
             ;;
     esac

--- a/completions/curl
+++ b/completions/curl
@@ -43,7 +43,7 @@ _comp_cmd_curl()
             return
             ;;
         --cert-type | --key-type | --proxy-cert-type | --proxy-key-type)
-            COMPREPLY=($(compgen -W 'DER PEM ENG' -- "$cur"))
+            _comp_compgen -- -W 'DER PEM ENG'
             return
             ;;
         --crlfile | --proxy-crlfile)
@@ -63,7 +63,7 @@ _comp_cmd_curl()
             return
             ;;
         --delegation)
-            COMPREPLY=($(compgen -W 'none policy always' -- "$cur"))
+            _comp_compgen -- -W 'none policy always'
             return
             ;;
         --dns-ipv[46]-addr)
@@ -81,7 +81,7 @@ _comp_cmd_curl()
                 "$1" --engine list 2>/dev/null |
                     command grep "^[[:space:]]"
             )
-            COMPREPLY=($(compgen -W '$engines list' -- "$cur"))
+            _comp_compgen -- -W '$engines list'
             return
             ;;
         --ftp-port | -${noargopts}P)
@@ -91,11 +91,11 @@ _comp_cmd_curl()
             return
             ;;
         --ftp-method)
-            COMPREPLY=($(compgen -W 'multicwd nocwd singlecwd' -- "$cur"))
+            _comp_compgen -- -W 'multicwd nocwd singlecwd'
             return
             ;;
         --ftp-ssl-ccc-mode)
-            COMPREPLY=($(compgen -W 'active passive' -- "$cur"))
+            _comp_compgen -- -W 'active passive'
             return
             ;;
         --interface)
@@ -112,12 +112,12 @@ _comp_cmd_curl()
                     # Looks like an option? Likely no --help category support
                     [[ $x != -* ]] || return
                 done
-                COMPREPLY=($(compgen -W '"${categories[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${categories[@]}"'
             fi
             return
             ;;
         --krb)
-            COMPREPLY=($(compgen -W 'clear safe confidential private' -- "$cur"))
+            _comp_compgen -- -W 'clear safe confidential private'
             return
             ;;
         --pinnedpubkey | --proxy-pinnedpubkey)
@@ -143,16 +143,16 @@ _comp_cmd_curl()
             return
             ;;
         --stderr)
-            COMPREPLY=($(compgen -W '-' -- "$cur"))
+            _comp_compgen -- -W '-'
             _comp_compgen -a filedir
             return
             ;;
         --tls-max)
-            COMPREPLY=($(compgen -W 'default 1.0 1.1 1.2 1.3' -- "$cur"))
+            _comp_compgen -- -W 'default 1.0 1.1 1.2 1.3'
             return
             ;;
         --tlsauthtype | --proxy-tlsauthtype)
-            COMPREPLY=($(compgen -W 'SRP' -- "$cur"))
+            _comp_compgen -- -W 'SRP'
             return
             ;;
     esac

--- a/completions/curl
+++ b/completions/curl
@@ -144,7 +144,7 @@ _comp_cmd_curl()
             ;;
         --stderr)
             COMPREPLY=($(compgen -W '-' -- "$cur"))
-            _comp_compgen_filedir
+            _comp_compgen -a filedir
             return
             ;;
         --tls-max)

--- a/completions/cvs
+++ b/completions/cvs
@@ -34,7 +34,7 @@ _comp_cmd_cvs__command_options()
 
 _comp_cmd_cvs__kflags()
 {
-    COMPREPLY=($(compgen -W 'kv kvl k o b v' -- "$cur"))
+    _comp_compgen -- -W 'kv kvl k o b v'
 }
 
 _comp_xfunc_cvs_roots()
@@ -44,7 +44,7 @@ _comp_xfunc_cvs_roots()
     [[ -r ~/.cvspass ]] && cvsroots+=($(awk '{ print $2 }' ~/.cvspass))
     [[ -r CVS/Root ]] && mapfile -tO ${#cvsroots[@]} cvsroots <CVS/Root
     ((${#cvsroots[@]})) &&
-        COMPREPLY=($(compgen -W '"${cvsroots[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${cvsroots[@]}"'
     _comp_ltrim_colon_completions "$cur"
 }
 
@@ -203,7 +203,7 @@ _comp_cmd_cvs()
             else
                 _cvs_entries
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             fi
             ;;
         annotate)
@@ -214,7 +214,7 @@ _comp_cmd_cvs()
             else
                 _cvs_entries
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             fi
             ;;
         checkout)
@@ -238,7 +238,7 @@ _comp_cmd_cvs()
                 COMPREPLY=($(cvs -d "$cvsroot" co -c 2>/dev/null |
                     awk '{print $1}'))
                 ((${#COMPREPLY[@]})) &&
-                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${COMPREPLY[@]}"'
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
             fi
@@ -270,11 +270,11 @@ _comp_cmd_cvs()
                     ((${#changed[@]})) && COMPREPLY+=("${changed[@]}")
                     ((${#newremoved[@]})) && COMPREPLY+=("${newremoved[@]}")
                     ((${#COMPREPLY[@]})) &&
-                        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                        _comp_compgen -- -W '"${COMPREPLY[@]}"'
                 else
                     _cvs_entries
                     ((${#entries[@]})) &&
-                        COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                        _comp_compgen -- -W '"${entries[@]}"'
                 fi
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
@@ -290,7 +290,7 @@ _comp_cmd_cvs()
             else
                 _cvs_entries
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             fi
             ;;
         editors | watchers)
@@ -299,7 +299,7 @@ _comp_cmd_cvs()
             else
                 _cvs_entries
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             fi
             ;;
         export)
@@ -322,7 +322,7 @@ _comp_cmd_cvs()
                 [[ ! $has_cvsroot ]] && cvsroot=${CVSROOT-}
                 COMPREPLY=($(cvs -d "$cvsroot" co -c | awk '{print $1}'))
                 ((${#COMPREPLY[@]})) &&
-                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${COMPREPLY[@]}"'
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
             fi
@@ -352,7 +352,7 @@ _comp_cmd_cvs()
                 pwd=${pwd##*/}
                 [[ $pwd ]] && COMPREPLY+=("$pwd")
                 ((${#COMPREPLY[@]})) &&
-                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${COMPREPLY[@]}"'
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
             fi
@@ -367,7 +367,7 @@ _comp_cmd_cvs()
                     done
                 fi
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
             fi
@@ -389,7 +389,7 @@ _comp_cmd_cvs()
             else
                 _cvs_entries
                 ((${#entries[@]})) &&
-                    COMPREPLY=($(compgen -W '"${entries[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${entries[@]}"'
             fi
             ;;
         "")
@@ -403,7 +403,7 @@ _comp_cmd_cvs()
                     return
                     ;;
                 -*z)
-                    COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+                    _comp_compgen -- -W '{1..9}'
                     return
                     ;;
             esac

--- a/completions/cvsps
+++ b/completions/cvsps
@@ -38,7 +38,7 @@ _comp_cmd_cvsps()
             return
             ;;
         -Z)
-            COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+            _comp_compgen -- -W '{1..9}'
             return
             ;;
         --root)

--- a/completions/dd
+++ b/completions/dd
@@ -26,7 +26,7 @@ _comp_cmd_dd()
             ;;
         status=*)
             cur=${cur#*=}
-            COMPREPLY=($(compgen -W 'none noxfer progress' -- "$cur"))
+            _comp_compgen -- -W 'none noxfer progress'
             return
             ;;
     esac

--- a/completions/declare
+++ b/completions/declare
@@ -11,7 +11,7 @@ _comp_cmd_declare()
         # Most options also have a '+' form.
         # We'll exclude the ones that don't with compgen.
         opts+=(${opts[*]/-/+})
-        COMPREPLY=($(compgen -W "${opts[*]}" -X '+[Ffgp]' -- "$cur"))
+        _comp_compgen -- -W "${opts[*]}" -X '+[Ffgp]'
         return
     fi
 
@@ -19,11 +19,11 @@ _comp_cmd_declare()
     while [[ ${words[i]} == [-+]* ]]; do
         case ${words[i]} in
             -*[aA]*)
-                COMPREPLY=($(compgen -A arrayvar -- "$cur"))
+                _comp_compgen -- -A arrayvar
                 return
                 ;;
             -*[fF]*)
-                COMPREPLY=($(compgen -A function -- "$cur"))
+                _comp_compgen -- -A function
                 return
                 ;;
         esac
@@ -33,7 +33,7 @@ _comp_cmd_declare()
         # There was at least one option and it was not one that limited
         # operations to functions and array variables
         _comp_variable_assignments "$cur" && return
-        COMPREPLY=($(compgen -A variable -- "$cur"))
+        _comp_compgen -- -A variable
     fi
 } &&
     complete -F _comp_cmd_declare declare typeset

--- a/completions/dhclient
+++ b/completions/dhclient
@@ -10,7 +10,7 @@ _comp_cmd_dhclient()
             return
             ;;
         -D)
-            COMPREPLY=($(compgen -W 'LL LLT' -- "$cur"))
+            _comp_compgen -- -W 'LL LLT'
             return
             ;;
         -*f)

--- a/completions/dnssec-keygen
+++ b/completions/dnssec-keygen
@@ -6,7 +6,7 @@ _comp_cmd_dnssec_keygen__optarg()
         command sed -e 's/|/ /g' -e 's/(.*//' \
             -ne '/^[[:space:]]*'"$2"'/,/^[[:space:]]*[(-]/p' |
         command sed -e 's/^[[:space:]]*'"$2"'.*://' -e '/^[[:space:]]*-/d')
-    COMPREPLY+=($(compgen -W '$args' -- "$cur"))
+    _comp_compgen -a -- -W '$args'
 }
 
 _comp_cmd_dnssec_keygen()

--- a/completions/dnssec-keygen
+++ b/completions/dnssec-keygen
@@ -31,7 +31,7 @@ _comp_cmd_dnssec_keygen()
             return
             ;;
         -v)
-            COMPREPLY=($(compgen -W '{0..10}' -- "$cur"))
+            _comp_compgen -- -W '{0..10}'
             return
             ;;
     esac

--- a/completions/dot
+++ b/completions/dot
@@ -15,14 +15,14 @@ _comp_cmd_dot()
             local langs=($("$1" -TNON_EXISTENT 2>&1 |
                 command sed -ne 's/.*one of://p'))
             ((${#langs[@]})) &&
-                COMPREPLY=($(compgen -P -T -W '"${langs[@]}"' -- "${cur#-T}"))
+                _comp_compgen -c "${cur#-T}" -- -P -T -W '"${langs[@]}"'
             return
             ;;
         -K*)
             local layouts=($("$1" -KNON_EXISTENT 2>&1 |
                 command sed -ne 's/.*one of://p'))
             ((${#layouts[@]})) &&
-                COMPREPLY=($(compgen -P -K -W '"${layouts[@]}"' -- "${cur#-K}"))
+                _comp_compgen -c "${cur#-K}" -- -P -K -W '"${layouts[@]}"'
             return
             ;;
         -o*)

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -86,7 +86,7 @@ _comp_cmd_dpkg()
             return
             ;;
         --debug | -${noargopts}D)
-            COMPREPLY=($(compgen -W 'help' -- "$cur"))
+            _comp_compgen -- -W 'help'
             return
             ;;
         --ignore-depends)
@@ -104,11 +104,11 @@ _comp_cmd_dpkg()
             return
             ;;
         --status-logger)
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --verify-format)
-            COMPREPLY=($(compgen -W 'rpm' -- "$cur"))
+            _comp_compgen -- -W 'rpm'
             return
             ;;
     esac
@@ -139,12 +139,12 @@ _comp_cmd_dpkg_reconfigure()
             if ((${#opt[@]})); then
                 opt=("${opt[@]##*/}")
                 opt=("${opt[@]%.pm}")
-                COMPREPLY=($(compgen -W '"${opt[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${opt[@]}"'
             fi
             return
             ;;
         --priority | -${noargopts}p)
-            COMPREPLY=($(compgen -W 'low medium high critical' -- "$cur"))
+            _comp_compgen -- -W 'low medium high critical'
             return
             ;;
     esac

--- a/completions/dpkg-source
+++ b/completions/dpkg-source
@@ -32,7 +32,7 @@ _comp_cmd_dpkg_source()
                     _comp_compgen_filedir 'dsc'
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W "$unpackopts" -- "$cur"))
+                    _comp_compgen -- -W "$unpackopts"
                     _comp_compgen -a filedir
                     ;;
             esac
@@ -69,13 +69,13 @@ _comp_cmd_dpkg_source()
                         # $cur contains a "="
                         COMPREPLY=()
                     else
-                        COMPREPLY=($(compgen -W "$fields" -- "$cur"))
+                        _comp_compgen -- -W "$fields"
                     fi
                     ;;
                 -U)
                     # -U: remove a field
                     # Suggest possible fieldnames
-                    COMPREPLY=($(compgen -W "$fields" -- "$cur"))
+                    _comp_compgen -- -W "$fields"
                     ;;
                 *)
                     COMPREPLY=($(compgen -W "$packopts $unpackopts" \
@@ -85,7 +85,7 @@ _comp_cmd_dpkg_source()
             return
             ;;
         *)
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
             return
             ;;
     esac

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -20,7 +20,7 @@ _comp_cmd_ebtables()
                 command sed -ne "$chain"`' -- "$cur"))
             ;;
         -${noargopts}t)
-            COMPREPLY=($(compgen -W 'nat filter broute' -- "$cur"))
+            _comp_compgen -- -W 'nat filter broute'
             ;;
         -${noargopts}j)
             if [[ $table == "filter" || ! $table ]]; then

--- a/completions/ecryptfs-migrate-home
+++ b/completions/ecryptfs-migrate-home
@@ -10,7 +10,7 @@ _comp_cmd_ecryptfs_migrate_home()
             return
             ;;
         --user | -u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac

--- a/completions/export
+++ b/completions/export
@@ -54,7 +54,7 @@ _comp_cmd_export()
                 suffix="="
                 compopt -o nospace
             fi
-            COMPREPLY=($(compgen -A $action -S "$suffix" -- "$cur"))
+            _comp_compgen -- -A $action -S "$suffix"
             ;;
     esac
 } &&

--- a/completions/faillog
+++ b/completions/faillog
@@ -12,7 +12,7 @@ _comp_cmd_faillog()
             return
             ;;
         --user | -${noargopts}u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -24,7 +24,7 @@ _comp_cmd_fbgs()
         -fp | --firstpage | -lp | --lastpage | -r | --resolution | -s | --scroll | -t | \
             --timeout)
             # expect integer value
-            COMPREPLY+=($(compgen -W '{0..9}'))
+            _comp_compgen -aR -- -W '{0..9}'
             compopt -o nospace
             return
             ;;

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -18,7 +18,7 @@ _comp_cmd_fbgs()
             return
             ;;
         -d | --device)
-            COMPREPLY=($(compgen -f -d -- "${cur:-/dev/}"))
+            _comp_compgen -c "${cur:-/dev/}" -- -f -d
             return
             ;;
         -fp | --firstpage | -lp | --lastpage | -r | --resolution | -s | --scroll | -t | \

--- a/completions/fbi
+++ b/completions/fbi
@@ -26,7 +26,7 @@ _comp_cmd_fbi()
             return
             ;;
         -d | --device)
-            COMPREPLY=($(compgen -f -d -- "${cur:-/dev/}"))
+            _comp_compgen -c "${cur:-/dev/}" -- -f -d
             return
             ;;
         --cachemem | --blend | -T | --vt | -s | --scroll | -t | --timeout | -g | --gamma)

--- a/completions/fbi
+++ b/completions/fbi
@@ -11,7 +11,7 @@ _comp_cmd_fbi()
             return
             ;;
         -r | --resolution)
-            COMPREPLY+=($(compgen -W '{1..5}'))
+            _comp_compgen -aR -- -W '{1..5}'
             return
             ;;
         -f | --font)

--- a/completions/feh
+++ b/completions/feh
@@ -23,7 +23,7 @@ _comp_cmd_feh()
         --font | --menu-font | --title-font | -${noargopts}[eM@])
             # expect string like "dejavu.ttf/12"
             if [[ $cur == */* ]]; then # expect integer value
-                COMPREPLY=($(compgen -P "$cur" -W '{0..9}'))
+                _comp_compgen -R -- -P "$cur" -W '{0..9}'
                 compopt -o nospace
                 return
             fi

--- a/completions/feh
+++ b/completions/feh
@@ -52,7 +52,7 @@ _comp_cmd_feh()
                 if [[ $theme_name == '#'* || $theme_name == "" ]]; then
                     continue
                 fi
-                COMPREPLY+=($(compgen -W "$theme_name" -- "$cur"))
+                _comp_compgen -a -- -W "$theme_name"
             done <"$conf_path"
             return
             ;;
@@ -83,7 +83,7 @@ _comp_cmd_feh()
             ;;
         --bg | -${noargopts}b)
             _comp_compgen_filedir
-            COMPREPLY+=($(compgen -W 'trans' -- "$cur"))
+            _comp_compgen -a -- -W 'trans'
             return
             ;;
         --geometry | --max-dimension | --min-dimension | -${noargopts}g)

--- a/completions/feh
+++ b/completions/feh
@@ -64,7 +64,7 @@ _comp_cmd_feh()
         --reload | --limit-height | --limit-width | --thumb-height | --thumb-width | \
             --thumb-redraw | --magick-timeout | -${noargopts}[RHWEyJ])
             # expect integer value
-            COMPREPLY+=($(compgen -W '{0..9}'))
+            _comp_compgen -aR -- -W '{0..9}'
             compopt -o nospace
             return
             ;;
@@ -72,7 +72,7 @@ _comp_cmd_feh()
             # expect integer value or "max", "fill"
             _comp_compgen -- -W 'max fill'
             if [[ ! $cur || ! ${COMPREPLY-} ]]; then
-                COMPREPLY+=($(compgen -W '{0..9}'))
+                _comp_compgen -aR -- -W '{0..9}'
                 compopt -o nospace
             fi
             return
@@ -91,7 +91,7 @@ _comp_cmd_feh()
             if [[ $cur && $cur != *x* ]]; then
                 COMPREPLY=(x)
             fi
-            COMPREPLY+=($(compgen -W "{0..9}"))
+            _comp_compgen -aR -- -W "{0..9}"
             compopt -o nospace
             return
             ;;

--- a/completions/feh
+++ b/completions/feh
@@ -9,7 +9,7 @@ _comp_cmd_feh()
     # shellcheck disable=SC2254
     case "$prev" in
         --image-bg | -B)
-            COMPREPLY=($(compgen -W 'checks white black' -- "$cur"))
+            _comp_compgen -- -W 'checks white black'
             return
             ;;
         --filelist | --output | --output-only | --start-at | -${noargopts}[foO\|])
@@ -70,7 +70,7 @@ _comp_cmd_feh()
             ;;
         --zoom)
             # expect integer value or "max", "fill"
-            COMPREPLY=($(compgen -W 'max fill' -- "$cur"))
+            _comp_compgen -- -W 'max fill'
             if [[ ! $cur || ! ${COMPREPLY-} ]]; then
                 COMPREPLY+=($(compgen -W '{0..9}'))
                 compopt -o nospace
@@ -78,7 +78,7 @@ _comp_cmd_feh()
             return
             ;;
         --alpha | -${noargopts}a)
-            COMPREPLY=($(compgen -W '{0..255}' -- "$cur"))
+            _comp_compgen -- -W '{0..255}'
             return
             ;;
         --bg | -${noargopts}b)

--- a/completions/find
+++ b/completions/find
@@ -17,7 +17,7 @@ _comp_cmd_find()
 
     case $prev in
         -maxdepth | -mindepth)
-            COMPREPLY=($(compgen -W '{0..9}' -- "$cur"))
+            _comp_compgen -- -W '{0..9}'
             return
             ;;
         -newer | -anewer | -cnewer | -fls | -fprint | -fprint0 | -fprintf | -name | -[il]name | \
@@ -40,7 +40,7 @@ _comp_cmd_find()
             return
             ;;
         -xtype | -type)
-            COMPREPLY=($(compgen -W 'b c d p f l s' -- "$cur"))
+            _comp_compgen -- -W 'b c d p f l s'
             return
             ;;
         -uid)
@@ -48,7 +48,7 @@ _comp_cmd_find()
             return
             ;;
         -user)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -[acm]min | -[acm]time | -inum | -path | -ipath | -regex | -iregex | -links | -perm | \

--- a/completions/find
+++ b/completions/find
@@ -28,7 +28,7 @@ _comp_cmd_find()
         -fstype)
             _fstypes
             [[ $OSTYPE == *bsd* ]] &&
-                COMPREPLY+=($(compgen -W 'local rdonly' -- "$cur"))
+                _comp_compgen -a -- -W 'local rdonly'
             return
             ;;
         -gid)

--- a/completions/fio
+++ b/completions/fio
@@ -24,11 +24,11 @@ _comp_cmd_fio()
             return
             ;;
         --output-format)
-            COMPREPLY=($(compgen -W "terse json json+ normal" -- "$cur"))
+            _comp_compgen -- -W "terse json json+ normal"
             return
             ;;
         --terse-version)
-            COMPREPLY=($(compgen -W "2 3 4 5" -- "$cur"))
+            _comp_compgen -- -W "2 3 4 5"
             return
             ;;
         --crctest)
@@ -37,16 +37,16 @@ _comp_cmd_fio()
             ;;
         --cmdhelp)
             ret=($("$1" --cmdhelp=all 2>/dev/null | awk '{print $1}') all)
-            COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${ret[@]}"'
             return
             ;;
         --enghelp)
             _comp_cmd_fio__engines "$1" &&
-                COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${ret[@]}"'
             return
             ;;
         --eta)
-            COMPREPLY=($(compgen -W "always never auto" -- "$cur"))
+            _comp_compgen -- -W "always never auto"
             return
             ;;
         --daemonize)
@@ -62,7 +62,7 @@ _comp_cmd_fio()
             return
             ;;
         --idle-prof)
-            COMPREPLY=($(compgen -W "system percpu calibrate" -- "$cur"))
+            _comp_compgen -- -W "system percpu calibrate"
             return
             ;;
         --inflate-log)
@@ -75,7 +75,7 @@ _comp_cmd_fio()
             ;;
         --trigger | --trigger-remote)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --aux-path)
@@ -84,11 +84,11 @@ _comp_cmd_fio()
             ;;
         --ioengine)
             _comp_cmd_fio__engines "$1" &&
-                COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${ret[@]}"'
             return
             ;;
         --exec_postrun | --exec_prerun)
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --uid)
@@ -108,7 +108,7 @@ _comp_cmd_fio()
                     # ignore
                     ;;
                 *" type: boolean "* | *" type: empty or boolean "*)
-                    COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+                    _comp_compgen -- -W '0 1'
                     return
                     ;;
                 *" valid values:"*)
@@ -129,7 +129,7 @@ _comp_cmd_fio()
                             ret+=("${BASH_REMATCH[1]}")
                         fi
                     done
-                    COMPREPLY=($(compgen -W '"${ret[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${ret[@]}"'
                     return
                     ;;
             esac

--- a/completions/firefox
+++ b/completions/firefox
@@ -33,7 +33,7 @@ _comp_cmd_firefox()
             return
             ;;
         --debugger | -d)
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac

--- a/completions/flake8
+++ b/completions/flake8
@@ -12,7 +12,7 @@ _comp_cmd_flake8()
             return
             ;;
         --format)
-            COMPREPLY=($(compgen -W 'default pylint' -- "$cur"))
+            _comp_compgen -- -W 'default pylint'
             return
             ;;
         --jobs | -${noargopts}j)

--- a/completions/freeciv
+++ b/completions/freeciv
@@ -14,11 +14,11 @@ _comp_cmd_freeciv()
             return
             ;;
         --Announce | -A)
-            COMPREPLY=($(compgen -W 'IPv4 IPv6 none' -- "$cur"))
+            _comp_compgen -- -W 'IPv4 IPv6 none'
             return
             ;;
         --debug | -d)
-            COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
+            _comp_compgen -- -W '{0..3}'
             return
             ;;
         --Meta | --server | -[Ms])
@@ -26,7 +26,7 @@ _comp_cmd_freeciv()
             return
             ;;
         --Plugin | -P)
-            COMPREPLY=($(compgen -W 'none esd sdl' -- "$cur"))
+            _comp_compgen -- -W 'none esd sdl'
             return
             ;;
     esac

--- a/completions/function
+++ b/completions/function
@@ -6,7 +6,7 @@ _comp_cmd_function()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -A function -- "$cur"))
+        _comp_compgen -- -A function
     else
         local funcdef=$(type -- "${words[1]}" 2>/dev/null | command sed -e 1,2d)
         COMPREPLY=("()${funcdef:+ $funcdef}")

--- a/completions/genaliases
+++ b/completions/genaliases
@@ -6,7 +6,7 @@ _comp_cmd_genaliases()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--quiet --help' -- "$cur"))
+        _comp_compgen -- -W '--quiet --help'
     fi
 
 } &&

--- a/completions/getconf
+++ b/completions/getconf
@@ -21,7 +21,7 @@ _comp_cmd_getconf()
     if [[ $prev == PATH_MAX ]]; then # TODO more path vars, better handling
         _comp_compgen_filedir
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-a -v' -- "$cur"))
+        _comp_compgen -- -W '-a -v'
     else
         COMPREPLY=($(compgen -W \
             '$("$1" -a 2>/dev/null | awk "{ print \$1 }")' -- "$cur"))

--- a/completions/getent
+++ b/completions/getent
@@ -29,19 +29,19 @@ _comp_cmd_getent()
 
     case ${db-} in
         passwd)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         group)
-            COMPREPLY=($(compgen -g -- "$cur"))
+            _comp_compgen -- -g
             return
             ;;
         services)
-            COMPREPLY=($(compgen -s -- "$cur"))
+            _comp_compgen -- -s
             return
             ;;
         hosts)
-            COMPREPLY=($(compgen -A hostname -- "$cur"))
+            _comp_compgen -- -A hostname
             return
             ;;
         protocols | networks | ahosts | ahostsv4 | ahostsv6 | rpc)

--- a/completions/gnokii
+++ b/completions/gnokii
@@ -3,7 +3,7 @@
 _comp_cmd_gnokii__memory_type()
 {
     # TODO: reduce the number of choices
-    COMPREPLY=($(compgen -W "IN OU SM ME MT" -- "$cur"))
+    _comp_compgen -- -W "IN OU SM ME MT"
 }
 
 _comp_cmd_gnokii()
@@ -41,7 +41,7 @@ _comp_cmd_gnokii()
 
         # MONITOR
         --monitor)
-            COMPREPLY=($(compgen -W 'delay once' -- "$cur"))
+            _comp_compgen -- -W 'delay once'
             return
             ;;
         --getdisplaystatus | --displayoutput)
@@ -97,7 +97,7 @@ _comp_cmd_gnokii()
             return
             ;;
         --divert)
-            COMPREPLY=($(compgen -W '--op' -- "$cur"))
+            _comp_compgen -- -W '--op'
             return
             ;;
 
@@ -112,7 +112,7 @@ _comp_cmd_gnokii()
 
         # SETTINGS
         --reset)
-            COMPREPLY=($(compgen -W 'soft hard' -- "$cur"))
+            _comp_compgen -- -W 'soft hard'
             return
             ;;
         --setdatetime | --setalarm)
@@ -131,7 +131,7 @@ _comp_cmd_gnokii()
 
         # LOGOS
         --sendlogo)
-            COMPREPLY=($(compgen -W 'caller op picture' -- "$cur"))
+            _comp_compgen -- -W 'caller op picture'
             return
             ;;
         --setlogo | --getlogo)
@@ -145,7 +145,7 @@ _comp_cmd_gnokii()
             ;;
 
         --entersecuritycode)
-            COMPREPLY=($(compgen -W 'PIN PIN2 PUK PUK2 SEC' -- "$cur"))
+            _comp_compgen -- -W 'PIN PIN2 PUK PUK2 SEC'
             return
             ;;
 
@@ -166,11 +166,11 @@ _comp_cmd_gnokii()
                 return
                 ;;
             --gettodo | --getcalendarnote)
-                COMPREPLY=($(compgen -W '{1..9} end --vCal' -- "$cur"))
+                _comp_compgen -- -W '{1..9} end --vCal'
                 return
                 ;;
             --deletecalendarnote)
-                COMPREPLY=($(compgen -W '{1..9} end' -- "$cur"))
+                _comp_compgen -- -W '{1..9} end'
                 return
                 ;;
             --divert)
@@ -186,20 +186,20 @@ _comp_cmd_gnokii()
         tprev=${words[cword - 3]}
         case $tprev in
             --deletesms | --deletemms)
-                COMPREPLY=($(compgen -W 'end' -- "$cur"))
+                _comp_compgen -- -W 'end'
                 return
                 ;;
             --getphonebook | --writetodo | --writecalendarnote)
-                COMPREPLY=($(compgen -W '{1..9} end' -- "$cur"))
+                _comp_compgen -- -W '{1..9} end'
                 return
                 ;;
             --gettodo | --getcalendarnote)
                 [[ ${words[cword - 1]} == end ]] &&
-                    COMPREPLY=($(compgen -W '--vCal' -- "$cur"))
+                    _comp_compgen -- -W '--vCal'
                 return
                 ;;
             --divert)
-                COMPREPLY=($(compgen -W '--type' -- "$cur"))
+                _comp_compgen -- -W '--type'
                 return
                 ;;
         esac
@@ -210,7 +210,7 @@ _comp_cmd_gnokii()
         fprev=${words[cword - 4]}
         case $fprev in
             --getphonebook)
-                COMPREPLY=($(compgen -W '--raw --vcard --ldif' -- "$cur"))
+                _comp_compgen -- -W '--raw --vcard --ldif'
                 return
                 ;;
             --divert)
@@ -234,7 +234,7 @@ _comp_cmd_gnokii()
     IFS=$' \t\n'
     [[ $COMP_LINE =~ $regex_main_cmd ]] && return
 
-    COMPREPLY=($(compgen -W "$all_cmd" -- "$cur"))
+    _comp_compgen -- -W "$all_cmd"
 } &&
     complete -F _comp_cmd_gnokii gnokii
 

--- a/completions/gnome-mplayer
+++ b/completions/gnome-mplayer
@@ -10,7 +10,7 @@ _comp_cmd_gnome_mplayer()
             return
             ;;
         --showcontrols | --showsubtitles | --autostart)
-            COMPREPLY=($(compgen -w '0 1' -- "$cur"))
+            _comp_compgen -- -w '0 1'
             return
             ;;
         --subtitle)
@@ -18,7 +18,7 @@ _comp_cmd_gnome_mplayer()
             return
             ;;
         --tvdriver)
-            COMPREPLY=($(compgen -W 'v4l v4l2' -- "$cur"))
+            _comp_compgen -- -W 'v4l v4l2'
             return
             ;;
     esac

--- a/completions/gnome-mplayer
+++ b/completions/gnome-mplayer
@@ -10,7 +10,7 @@ _comp_cmd_gnome_mplayer()
             return
             ;;
         --showcontrols | --showsubtitles | --autostart)
-            _comp_compgen -- -w '0 1'
+            _comp_compgen -- -W '0 1'
             return
             ;;
         --subtitle)

--- a/completions/gnome-screenshot
+++ b/completions/gnome-screenshot
@@ -12,7 +12,7 @@ _comp_cmd_gnome_screenshot()
             return
             ;;
         --border-effect | -${noargopts}e)
-            COMPREPLY=($(compgen -W 'shadow border vintage none' -- "$cur"))
+            _comp_compgen -- -W 'shadow border vintage none'
             return
             ;;
         --file | -${noargopts}f)

--- a/completions/gpasswd
+++ b/completions/gpasswd
@@ -9,7 +9,7 @@ _comp_cmd_gpasswd()
     # shellcheck disable=SC2254
     case $prev in
         --add | --delete | --administrators | --members | -${noargopts}[adAM])
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac
@@ -20,7 +20,7 @@ _comp_cmd_gpasswd()
         return
     fi
 
-    COMPREPLY=($(compgen -g -- "$cur"))
+    _comp_compgen -- -g
 } &&
     complete -F _comp_cmd_gpasswd gpasswd
 

--- a/completions/gpgv
+++ b/completions/gpgv
@@ -31,7 +31,7 @@ _comp_cmd_gpgv()
         if [[ ${COMP_LINE,,} == *.@(asc|sig|sign)\ * ]]; then
             # Detached signature, only complete one arbitrary file arg and -
             if ((args == 2)); then
-                COMPREPLY=($(compgen -W '-' -- "$cur"))
+                _comp_compgen -- -W '-'
                 _comp_compgen -a filedir
             fi
         else

--- a/completions/gprof
+++ b/completions/gprof
@@ -35,7 +35,7 @@ _comp_cmd_gprof()
             return
             ;;
         --file-format)
-            COMPREPLY=($(compgen -W 'auto bsd 4.4bsd magic prof' -- "$cur"))
+            _comp_compgen -- -W 'auto bsd 4.4bsd magic prof'
             return
             ;;
     esac

--- a/completions/groupdel
+++ b/completions/groupdel
@@ -20,7 +20,7 @@ _comp_cmd_groupdel()
         return
     fi
 
-    COMPREPLY=($(compgen -g -- "$cur"))
+    _comp_compgen -- -g
 } &&
     complete -F _comp_cmd_groupdel groupdel
 

--- a/completions/groupmems
+++ b/completions/groupmems
@@ -7,11 +7,11 @@ _comp_cmd_groupmems()
 
     case $prev in
         -a | --add | -d | --delete)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -g | --group)
-            COMPREPLY=($(compgen -g -- "$cur"))
+            _comp_compgen -- -g
             return
             ;;
         -R | --root)

--- a/completions/groupmod
+++ b/completions/groupmod
@@ -24,7 +24,7 @@ _comp_cmd_groupmod()
         return
     fi
 
-    COMPREPLY=($(compgen -g -- "$cur"))
+    _comp_compgen -- -g
 } &&
     complete -F _comp_cmd_groupmod groupmod
 

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -38,7 +38,7 @@ _comp_cmd_hcitool()
             return
             ;;
         --role)
-            COMPREPLY=($(compgen -W 'm s' -- "$cur"))
+            _comp_compgen -- -W 'm s'
             return
             ;;
         --pkt-type)
@@ -70,7 +70,7 @@ _comp_cmd_hcitool()
                 ;;
             cc)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '--role --pkt-type' -- "$cur"))
+                    _comp_compgen -- -W '--role --pkt-type'
                 else
                     _count_args
                     if ((args == 2)); then
@@ -83,7 +83,7 @@ _comp_cmd_hcitool()
                 if ((args == 2)); then
                     _comp_cmd_hcitool__bluetooth_addresses
                 else
-                    COMPREPLY=($(compgen -W 'master slave' -- "$cur"))
+                    _comp_compgen -- -W 'master slave'
                 fi
                 ;;
             cpt)
@@ -99,7 +99,7 @@ _comp_cmd_hcitool()
                 if ((args == 2)); then
                     _comp_cmd_hcitool__bluetooth_addresses
                 else
-                    COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+                    _comp_compgen -- -W '0 1'
                 fi
                 ;;
         esac
@@ -142,14 +142,14 @@ _comp_cmd_sdptool()
                 ;;
             browse | records)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '--tree --raw --xml' -- "$cur"))
+                    _comp_compgen -- -W '--tree --raw --xml'
                 else
                     _comp_cmd_hcitool__bluetooth_addresses
                 fi
                 ;;
             add)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '--handle --channel' -- "$cur"))
+                    _comp_compgen -- -W '--handle --channel'
                 else
                     _comp_cmd_hcitool__bluetooth_services
                 fi
@@ -307,7 +307,7 @@ _comp_cmd_hciconfig()
     _get_first_arg
     if [[ ! $arg ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --all' -- "$cur"))
+            _comp_compgen -- -W '--help --all'
         else
             COMPREPLY=($(compgen -W 'up down reset rstat auth noauth encrypt
                 noencrypt secmgr nosecmgr piscan noscan iscan pscan ptype name
@@ -348,7 +348,7 @@ _comp_cmd_hciattach()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-n -p -t -b -s -l' -- "$cur"))
+        _comp_compgen -- -W '-n -p -t -b -s -l'
     else
         local args
         _count_args
@@ -368,7 +368,7 @@ _comp_cmd_hciattach()
                     460800 921600' -- "$cur"))
                 ;;
             4)
-                COMPREPLY=($(compgen -W 'flow noflow' -- "$cur"))
+                _comp_compgen -- -W 'flow noflow'
                 ;;
             5)
                 _comp_cmd_hcitool__bluetooth_addresses

--- a/completions/hddtemp
+++ b/completions/hddtemp
@@ -17,7 +17,7 @@ _comp_cmd_hddtemp()
             return
             ;;
         --unit | -${noargopts}u)
-            COMPREPLY=($(compgen -W 'C F' -- "$cur"))
+            _comp_compgen -- -W 'C F'
             return
             ;;
         --port | --separator | --syslog | --version | --help | -${noargopts}[psSvh?])

--- a/completions/help
+++ b/completions/help
@@ -10,7 +10,6 @@ _comp_cmd_help()
         return
     fi
 
-    local IFS=$'\t\n'
     _comp_compgen -- -A helptopic
     ((${#COMPREPLY[*]} != 1)) || printf -v "COMPREPLY[0]" %q "$COMPREPLY"
 } &&

--- a/completions/help
+++ b/completions/help
@@ -11,7 +11,7 @@ _comp_cmd_help()
     fi
 
     local IFS=$'\t\n'
-    COMPREPLY=($(compgen -A helptopic -- "$cur"))
+    _comp_compgen -- -A helptopic
     ((${#COMPREPLY[*]} != 1)) || printf -v "COMPREPLY[0]" %q "$COMPREPLY"
 } &&
     complete -F _comp_cmd_help help

--- a/completions/hping2
+++ b/completions/hping2
@@ -17,7 +17,7 @@ _comp_cmd_hping2()
             return
             ;;
         --tos | -${noargopts}o)
-            COMPREPLY=($(compgen -W '02 04 08 10'))
+            _comp_compgen -R -- -W '02 04 08 10'
             return
             ;;
         --file | -${noargopts}E)

--- a/completions/hping2
+++ b/completions/hping2
@@ -17,7 +17,8 @@ _comp_cmd_hping2()
             return
             ;;
         --tos | -${noargopts}o)
-            _comp_compgen -R -- -W '02 04 08 10'
+            # TODO: parse choices from `--tos help`?
+            _comp_compgen -- -W '02 04 08 10'
             return
             ;;
         --file | -${noargopts}E)

--- a/completions/htop
+++ b/completions/htop
@@ -13,7 +13,7 @@ _comp_cmd_htop()
             return
             ;;
         --user | -${noargopts}u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         --delay | -${noargopts}d)

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -16,7 +16,7 @@ _comp_cmd_hunspell()
                 dicts=("${dicts[@]##*/}")
                 dicts=("${dicts[@]%.dic}")
                 local IFS=$'\n'
-                COMPREPLY=($(compgen -W '"${dicts[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${dicts[@]}"'
             fi
             return
             ;;

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -15,7 +15,6 @@ _comp_cmd_hunspell()
             if ((${#dicts[@]})); then
                 dicts=("${dicts[@]##*/}")
                 dicts=("${dicts[@]%.dic}")
-                local IFS=$'\n'
                 _comp_compgen -- -W '"${dicts[@]}"'
             fi
             return

--- a/completions/id
+++ b/completions/id
@@ -8,7 +8,7 @@ _comp_cmd_id()
     if [[ $cur == -* ]]; then
         local opts=$(_parse_help "$1")
         [[ $opts ]] || opts="-G -g -u" # POSIX fallback
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+        _comp_compgen -- -W "$opts"
     else
         COMPREPLY=($(compgen -u "$cur"))
     fi

--- a/completions/ifup
+++ b/completions/ifup
@@ -34,7 +34,7 @@ _comp_cmd_ifupdown()
     if ((args == 1)); then
         _configured_interfaces
         ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]}"'
     fi
 } &&
     complete -F _comp_cmd_ifupdown ifup ifdown ifquery ifstatus

--- a/completions/ifup
+++ b/completions/ifup
@@ -33,8 +33,6 @@ _comp_cmd_ifupdown()
 
     if ((args == 1)); then
         _configured_interfaces
-        ((${#COMPREPLY[@]})) &&
-            _comp_compgen -- -W '"${COMPREPLY[@]}"'
     fi
 } &&
     complete -F _comp_cmd_ifupdown ifup ifdown ifquery ifstatus

--- a/completions/inject
+++ b/completions/inject
@@ -15,7 +15,7 @@ _comp_cmd_inject()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--listname --queue --help' -- "$cur"))
+        _comp_compgen -- -W '--listname --queue --help'
     else
         _comp_compgen_filedir
     fi

--- a/completions/inotifywait
+++ b/completions/inotifywait
@@ -31,7 +31,7 @@ _comp_cmd_inotifywait()
             return
             ;;
         --ascending | --descending)
-            COMPREPLY=($(compgen -W 'total' -- "$cur"))
+            _comp_compgen -- -W 'total'
             _comp_cmd_inotifywait__events "$1"
             return
             ;;

--- a/completions/installpkg
+++ b/completions/installpkg
@@ -11,7 +11,7 @@ _comp_cmd_installpkg()
             return
             ;;
         --priority)
-            COMPREPLY=($(compgen -W 'ADD REC OPT SKP' -- "$cur"))
+            _comp_compgen -- -W 'ADD REC OPT SKP'
             return
             ;;
         --tagfile)

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -26,7 +26,7 @@ _comp_cmd_invoke_rc_d()
         ((${#valid_options[@]})) && COMPREPLY+=("${valid_options[@]}")
         ((${#services[@]})) && COMPREPLY+=("${services[@]}")
         ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]}"'
     elif [[ -x $sysvdir/$prev ]]; then
         COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
             -ne "s/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}\"]*\).*$/\1/p" \

--- a/completions/ip
+++ b/completions/ip
@@ -334,8 +334,7 @@ _comp_cmd_ip()
                     if [[ $cword -eq $subcword+1 || $prev == dev ]]; then
                         _available_interfaces
                         if [[ $prev != dev ]]; then
-                            COMPREPLY+=(dev)
-                            _comp_compgen -- -W '"${COMPREPLY[@]}"'
+                            _comp_compgen -a -W dev
                         fi
                     fi
                     ;;

--- a/completions/ip
+++ b/completions/ip
@@ -26,7 +26,7 @@ _comp_cmd_ip()
             return
             ;;
         -f | -family)
-            COMPREPLY=($(compgen -W 'inet inet6 ipx dnet link' -- "$cur"))
+            _comp_compgen -- -W 'inet inet6 ipx dnet link'
             return
             ;;
         -b | -batch)
@@ -38,7 +38,7 @@ _comp_cmd_ip()
             return
             ;;
         -force)
-            COMPREPLY=($(compgen -W '-batch' -- "$cur"))
+            _comp_compgen -- -W '-batch'
             return
             ;;
     esac
@@ -95,7 +95,7 @@ _comp_cmd_ip()
                             _available_interfaces
                             ;;
                         2)
-                            COMPREPLY=($(compgen -W 'type' -- "$cur"))
+                            _comp_compgen -- -W 'type'
                             ;;
                         3)
                             [[ $prev == type ]] &&
@@ -111,7 +111,7 @@ _comp_cmd_ip()
                         case $prev in
                             arp | dynamic | multicast | allmulticast | promisc | \
                                 trailers)
-                                COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+                                _comp_compgen -- -W 'on off'
                                 ;;
                             txqueuelen | name | address | broadcast | mtu | netns | alias) ;;
 
@@ -120,7 +120,7 @@ _comp_cmd_ip()
                                     promisc trailers txqueuelen name address
                                     broadcast mtu netns alias"
                                 [[ $prev != @(up|down) ]] && c+=" up down"
-                                COMPREPLY=($(compgen -W "$c" -- "$cur"))
+                                _comp_compgen -- -W "$c"
                                 ;;
                         esac
                     fi
@@ -227,9 +227,9 @@ _comp_cmd_ip()
                     elif [[ $prev == dev ]]; then
                         _available_interfaces -a
                     elif [[ $prev == table ]]; then
-                        COMPREPLY=($(compgen -W 'local main default' -- "$cur"))
+                        _comp_compgen -- -W 'local main default'
                     else
-                        COMPREPLY=($(compgen -W 'via dev weight' -- "$cur"))
+                        _comp_compgen -- -W 'via dev weight'
                     fi
                     ;;
                 *)
@@ -252,7 +252,7 @@ _comp_cmd_ip()
                             _available_interfaces -a
                             ;;
                         table | lookup)
-                            COMPREPLY=($(compgen -W 'local main default' -- "$cur"))
+                            _comp_compgen -- -W 'local main default'
                             ;;
                         *)
                             COMPREPLY=($(compgen -W 'from to tos dsfield fwmark
@@ -266,7 +266,7 @@ _comp_cmd_ip()
                     if [[ $prev == protocol ]]; then
                         :
                     else
-                        COMPREPLY=($(compgen -W 'protocol' -- "$cur"))
+                        _comp_compgen -- -W 'protocol'
                     fi
                     ;;
                 restore | show) ;;
@@ -335,7 +335,7 @@ _comp_cmd_ip()
                         _available_interfaces
                         if [[ $prev != dev ]]; then
                             COMPREPLY+=(dev)
-                            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                            _comp_compgen -- -W '"${COMPREPLY[@]}"'
                         fi
                     fi
                     ;;
@@ -354,7 +354,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help show' -- "$cur"))
+                        _comp_compgen -- -W 'help show'
                     ;;
             esac
             ;;
@@ -364,7 +364,7 @@ _comp_cmd_ip()
                 all) ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help all' -- "$cur"))
+                        _comp_compgen -- -W 'help all'
                     ;;
             esac
             ;;

--- a/completions/ip
+++ b/completions/ip
@@ -128,7 +128,7 @@ _comp_cmd_ip()
                 show)
                     if ((cword == subcword + 1)); then
                         _available_interfaces
-                        COMPREPLY+=($(compgen -W 'dev group up' -- "$cur"))
+                        _comp_compgen -a -- -W 'dev group up'
                     elif [[ $prev == dev ]]; then
                         _available_interfaces
                     elif [[ $prev == group ]]; then

--- a/completions/iperf
+++ b/completions/iperf
@@ -23,7 +23,7 @@ _comp_cmd_iperf()
                     command sed -ne 's/^.*--format .*\[\([a-zA-Z]\{1,\}\)\].*/\1/p' |
                     command sed -e 's/./& /g'
             )
-            COMPREPLY=($(compgen -W '$formats' -- "$cur"))
+            _comp_compgen -- -W '$formats'
             return
             ;;
         --pidfile | -${noargopts}I)
@@ -49,11 +49,11 @@ _comp_cmd_iperf()
             return
             ;;
         --reportexclude | -${noargopts}x)
-            COMPREPLY=($(compgen -W 'C D M S V' -- "$cur"))
+            _comp_compgen -- -W 'C D M S V'
             return
             ;;
         --reportstyle | -${noargopts}y)
-            COMPREPLY=($(compgen -W 'C' -- "$cur"))
+            _comp_compgen -- -W 'C'
             return
             ;;
         --logfile)

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -38,7 +38,7 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*C)
-            COMPREPLY=($(compgen -W '{0..14}' -- "$cur"))
+            _comp_compgen -- -W '{0..14}'
             return
             ;;
         -*L)
@@ -47,7 +47,7 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*A)
-            COMPREPLY=($(compgen -W 'NONE PASSWORD MD2 MD5 OEM' -- "$cur"))
+            _comp_compgen -- -W 'NONE PASSWORD MD2 MD5 OEM'
             return
             ;;
         -*o)
@@ -76,7 +76,7 @@ _comp_cmd_ipmitool()
     done
 
     if [[ ! $has_cmd ]]; then
-        COMPREPLY=($(compgen -W '"${cmds[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${cmds[@]}"'
         return
     fi
 
@@ -100,11 +100,11 @@ _comp_cmd_ipmitool()
 
                 alert)
                     [[ $prev == alert ]] &&
-                        COMPREPLY=($(compgen -W 'print set' -- "$cur"))
+                        _comp_compgen -- -W 'print set'
                     ;;
                 stats)
                     [[ $prev == stats ]] &&
-                        COMPREPLY=($(compgen -W 'print set' -- "$cur"))
+                        _comp_compgen -- -W 'print set'
                     ;;
                 *)
                     COMPREPLY=($(compgen -W 'print set alert stats' \
@@ -127,7 +127,7 @@ _comp_cmd_ipmitool()
                 fill)
                     case $prev in
                         fill)
-                            COMPREPLY=($(compgen -W 'sensors file' -- "$cur"))
+                            _comp_compgen -- -W 'sensors file'
                             ;;
                         file)
                             _comp_compgen_filedir
@@ -146,7 +146,7 @@ _comp_cmd_ipmitool()
                 list | get | thresh) ;;
 
                 *)
-                    COMPREPLY=($(compgen -W 'list get thresh' -- "$cur"))
+                    _comp_compgen -- -W 'list get thresh'
                     ;;
             esac
             ;;
@@ -160,7 +160,7 @@ _comp_cmd_ipmitool()
                     ;;
                 time)
                     [[ $prev == time ]] &&
-                        COMPREPLY=($(compgen -W 'get set' -- "$cur"))
+                        _comp_compgen -- -W 'get set'
                     ;;
                 *)
                     COMPREPLY=($(compgen -W 'info clear list elist delete add
@@ -175,7 +175,7 @@ _comp_cmd_ipmitool()
 
                 set)
                     [[ $prev == set ]] &&
-                        COMPREPLY=($(compgen -W 'name password' -- "$cur"))
+                        _comp_compgen -- -W 'name password'
                     ;;
                 *)
                     COMPREPLY=($(compgen -W 'summary list set disable enable

--- a/completions/ipsec
+++ b/completions/ipsec
@@ -11,7 +11,7 @@ _comp_cmd_ipsec__connections()
         [[ $keyword == conn && $name != '%default' ]] && COMPREPLY+=("$name")
     done
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${COMPREPLY[@]}"'
 }
 
 _comp_cmd_ipsec__freeswan()
@@ -37,10 +37,10 @@ _comp_cmd_ipsec__freeswan()
                 -- "$cur"))
             ;;
         ranbits)
-            COMPREPLY=($(compgen -W '--quick --continuous --bytes' -- "$cur"))
+            _comp_compgen -- -W '--quick --continuous --bytes'
             ;;
         setup)
-            COMPREPLY=($(compgen -W '--start --stop --restart' -- "$cur"))
+            _comp_compgen -- -W '--start --stop --restart'
             ;;
         *) ;;
 
@@ -71,7 +71,7 @@ _comp_cmd_ipsec__strongswan()
             _comp_cmd_ipsec__connections <"$confdir/ipsec.conf"
             ;;
         list*)
-            COMPREPLY=($(compgen -W '--utc' -- "$cur"))
+            _comp_compgen -- -W '--utc'
             ;;
         restart | start)
             COMPREPLY=($(compgen -W '--attach-gdb --auto-update --debug

--- a/completions/iptables
+++ b/completions/iptables
@@ -17,7 +17,7 @@ _comp_cmd_iptables()
                 command sed -ne "s/^Chain \([^ ]\{1,\}\).*$/\1/p"`' -- "$cur"))
             ;;
         -*t)
-            COMPREPLY=($(compgen -W 'nat filter mangle' -- "$cur"))
+            _comp_compgen -- -W 'nat filter mangle'
             ;;
         -j)
             if [[ $table == "filter" || ! $table ]]; then

--- a/completions/iscsiadm
+++ b/completions/iscsiadm
@@ -14,15 +14,15 @@ _comp_cmd_iscsiadm()
             return
             ;;
         --op | -${noargopts}o)
-            COMPREPLY=($(compgen -W 'new delete update show' -- "$cur"))
+            _comp_compgen -- -W 'new delete update show'
             return
             ;;
         --type | -${noargopts}t)
-            COMPREPLY=($(compgen -W 'sendtargets st slp isns fw' -- "$cur"))
+            _comp_compgen -- -W 'sendtargets st slp isns fw'
             return
             ;;
         --loginall | --logoutall | -${noargopts}[LU])
-            COMPREPLY=($(compgen -W 'all manual automatic' -- "$cur"))
+            _comp_compgen -- -W 'all manual automatic'
             return
             ;;
     esac
@@ -61,7 +61,7 @@ _comp_cmd_iscsiadm()
         options='--mode'
     fi
 
-    COMPREPLY=($(compgen -W "$options" -- "$cur"))
+    _comp_compgen -- -W "$options"
 } &&
     complete -F _comp_cmd_iscsiadm iscsiadm
 

--- a/completions/isort
+++ b/completions/isort
@@ -19,7 +19,7 @@ _comp_cmd_isort()
             return
             ;;
         --multi-line | -m)
-            COMPREPLY=($(compgen -W '{0..5}' -- "$cur"))
+            _comp_compgen -- -W '{0..5}'
             return
             ;;
         --section-default | -sd)

--- a/completions/iwconfig
+++ b/completions/iwconfig
@@ -12,7 +12,7 @@ _comp_cmd_iwconfig()
             return
             ;;
         essid)
-            COMPREPLY=($(compgen -W 'on off any' -- "$cur"))
+            _comp_compgen -- -W 'on off any'
             if [[ ${BASH_COMPLETION_CMD_IWCONFIG_SCAN-${COMP_IWLIST_SCAN-}} ]]; then
                 COMPREPLY+=($(compgen -W \
                     "$(iwlist "${words[1]}" scan |
@@ -21,7 +21,7 @@ _comp_cmd_iwconfig()
             return
             ;;
         nwid)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         channel)
@@ -36,7 +36,7 @@ _comp_cmd_iwconfig()
             return
             ;;
         ap)
-            COMPREPLY=($(compgen -W 'on off any' -- "$cur"))
+            _comp_compgen -- -W 'on off any'
             if [[ ${BASH_COMPLETION_CMD_IWCONFIG_SCAN-${COMP_IWLIST_SCAN-}} ]]; then
                 COMPREPLY+=($(compgen -W \
                     "$(iwlist "${words[1]}" scan |
@@ -45,37 +45,37 @@ _comp_cmd_iwconfig()
             return
             ;;
         rate)
-            COMPREPLY=($(compgen -W 'auto fixed' -- "$cur"))
+            _comp_compgen -- -W 'auto fixed'
             COMPREPLY+=($(compgen -W \
                 "$(iwlist "${words[1]}" rate |
                     awk '/^[ \t]*[0-9]/ {print $1"M"}')" -- "$cur"))
             return
             ;;
         rts | frag)
-            COMPREPLY=($(compgen -W 'auto fixed off' -- "$cur"))
+            _comp_compgen -- -W 'auto fixed off'
             return
             ;;
         key | enc)
-            COMPREPLY=($(compgen -W 'off on open restricted' -- "$cur"))
+            _comp_compgen -- -W 'off on open restricted'
             return
             ;;
         power)
-            COMPREPLY=($(compgen -W 'period timeout off on' -- "$cur"))
+            _comp_compgen -- -W 'period timeout off on'
             return
             ;;
         txpower)
-            COMPREPLY=($(compgen -W 'off on auto' -- "$cur"))
+            _comp_compgen -- -W 'off on auto'
             return
             ;;
         retry)
-            COMPREPLY=($(compgen -W 'limit lifetime' -- "$cur"))
+            _comp_compgen -- -W 'limit lifetime'
             return
             ;;
     esac
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
+            _comp_compgen -- -W '--help --version'
         else
             _available_interfaces -w
         fi

--- a/completions/iwlist
+++ b/completions/iwlist
@@ -7,7 +7,7 @@ _comp_cmd_iwlist()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
+            _comp_compgen -- -W '--help --version'
         else
             _available_interfaces -w
         fi

--- a/completions/iwpriv
+++ b/completions/iwpriv
@@ -7,23 +7,23 @@ _comp_cmd_iwpriv()
 
     case $prev in
         roam)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         port)
-            COMPREPLY=($(compgen -W 'ad-hoc managed' -- "$cur"))
+            _comp_compgen -- -W 'ad-hoc managed'
             return
             ;;
     esac
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
+            _comp_compgen -- -W '--help --version'
         else
             _available_interfaces -w
         fi
     else
-        COMPREPLY=($(compgen -W '--all roam port' -- "$cur"))
+        _comp_compgen -- -W '--all roam port'
     fi
 } &&
     complete -F _comp_cmd_iwpriv iwpriv

--- a/completions/iwspy
+++ b/completions/iwspy
@@ -7,12 +7,12 @@ _comp_cmd_iwspy()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
+            _comp_compgen -- -W '--help --version'
         else
             _available_interfaces -w
         fi
     else
-        COMPREPLY=($(compgen -W 'setthr getthr off' -- "$cur"))
+        _comp_compgen -- -W 'setthr getthr off'
     fi
 } &&
     complete -F _comp_cmd_iwspy iwspy

--- a/completions/jar
+++ b/completions/jar
@@ -6,7 +6,7 @@ _comp_cmd_jar()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'c t x u' -- "$cur"))
+        _comp_compgen -- -W 'c t x u'
         return
     fi
 

--- a/completions/jarsigner
+++ b/completions/jarsigner
@@ -7,7 +7,7 @@ _comp_cmd_jarsigner()
 
     case $prev in
         -keystore)
-            COMPREPLY=($(compgen -W 'NONE' -- "$cur"))
+            _comp_compgen -- -W 'NONE'
             _comp_compgen -a filedir '@(jks|ks|p12|pfx)'
             return
             ;;
@@ -21,7 +21,7 @@ _comp_cmd_jarsigner()
             return
             ;;
         -storetype)
-            COMPREPLY=($(compgen -W 'JKS PKCS11 PKCS12' -- "$cur"))
+            _comp_compgen -- -W 'JKS PKCS11 PKCS12'
             return
             ;;
         -signedjar)

--- a/completions/java
+++ b/completions/java
@@ -160,7 +160,7 @@ _comp_cmd_java()
     case $cur in
         # standard option completions
         -verbose:*)
-            COMPREPLY=($(compgen -W 'class gc jni' -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'class gc jni'
             return
             ;;
         -javaagent:*)
@@ -181,7 +181,7 @@ _comp_cmd_java()
             return
             ;;
         -Xcheck:*)
-            COMPREPLY=($(compgen -W 'jni' -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'jni'
             return
             ;;
         -Xgc:*)
@@ -199,7 +199,7 @@ _comp_cmd_java()
             return
             ;;
         -Xshare:*)
-            COMPREPLY=($(compgen -W 'auto off on' -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'auto off on'
             return
             ;;
         -Xverbose:*)
@@ -208,7 +208,7 @@ _comp_cmd_java()
             return
             ;;
         -Xverify:*)
-            COMPREPLY=($(compgen -W 'all none remote' -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'all none remote'
             return
             ;;
         # the rest that we have no completions for
@@ -316,7 +316,7 @@ _comp_cmd_javac()
         # the others.
         local opts=$("$1" $helpopt 2>&1 | command sed -e 's/-g:none/-g:{none}/' -ne \
             "s/^[[:space:]]*${cur%%:*}:{\([^}]\{1,\}\)}.*/\1/p")
-        COMPREPLY=($(compgen -W "${opts//,/ }" -- "${cur#*:}"))
+        _comp_compgen -c "${cur#*:}" -- -W "${opts//,/ }"
         return
     fi
 

--- a/completions/jpegoptim
+++ b/completions/jpegoptim
@@ -16,11 +16,11 @@ _comp_cmd_jpegoptim()
             return
             ;;
         --max | --threshold | -${noargopts}[mT])
-            COMPREPLY=($(compgen -W '{0..100}' -- "$cur"))
+            _comp_compgen -- -W '{0..100}'
             return
             ;;
         --size | -${noargopts}S)
-            COMPREPLY=($(compgen -W '{1..99}%' -- "$cur"))
+            _comp_compgen -- -W '{1..99}%'
             return
             ;;
     esac

--- a/completions/jps
+++ b/completions/jps
@@ -14,7 +14,7 @@ _comp_cmd_jps()
     if [[ $cur == -* ]]; then
         # Not using _parse_usage because output has [-help] which does not
         # mean -h, -e, -l, -p...
-        COMPREPLY=($(compgen -W "-q -m -l -v -V -J -help" -- "$cur"))
+        _comp_compgen -- -W "-q -m -l -v -V -J -help"
         [[ ${COMPREPLY-} == -J* ]] && compopt -o nospace
     else
         _known_hosts_real -- "$cur"

--- a/completions/jq
+++ b/completions/jq
@@ -12,7 +12,7 @@ _comp_cmd_jq()
             return
             ;;
         --indent)
-            COMPREPLY=($(compgen -W '{1..8}' -- "$cur"))
+            _comp_compgen -- -W '{1..8}'
             return
             ;;
         --from-file | --run-tests | -${noargopts}f)

--- a/completions/jshint
+++ b/completions/jshint
@@ -14,11 +14,11 @@ _comp_cmd_jshint()
             return
             ;;
         --reporter)
-            COMPREPLY=($(compgen -W "jslint checkstyle unix" -- "$cur"))
+            _comp_compgen -- -W "jslint checkstyle unix"
             return
             ;;
         --extract)
-            COMPREPLY=($(compgen -W "auto always never" -- "$cur"))
+            _comp_compgen -- -W "auto always never"
             return
             ;;
     esac

--- a/completions/k3b
+++ b/completions/k3b
@@ -31,7 +31,7 @@ _comp_cmd_k3b()
             return
             ;;
         --ao)
-            COMPREPLY=($(compgen -W 'alsa arts' -- "$cur"))
+            _comp_compgen -- -W 'alsa arts'
             return
             ;;
     esac

--- a/completions/kcov
+++ b/completions/kcov
@@ -32,11 +32,11 @@ _comp_cmd_kcov()
             if [[ $cur == ?*,* ]]; then
                 prev="${cur%,*}"
                 cur="${cur##*,}"
-                COMPREPLY=($(compgen -W "{0..100}" -- "$cur"))
+                _comp_compgen -- -W "{0..100}"
                 ((${#COMPREPLY[@]} == 1)) &&
                     COMPREPLY=(${COMPREPLY/#/$prev,})
             else
-                COMPREPLY=($(compgen -W "{0..100}" -- "$cur"))
+                _comp_compgen -- -W "{0..100}"
                 ((${#COMPREPLY[@]} == 1)) && COMPREPLY=(${COMPREPLY/%/,})
                 compopt -o nospace
             fi

--- a/completions/kill
+++ b/completions/kill
@@ -22,7 +22,7 @@ _comp_cmd_kill()
     else
         # return list of available PIDs and jobs
         _pids
-        COMPREPLY+=($(compgen -j -P % -- "${cur#%}"))
+        _comp_compgen -ac "${cur#%}" -- -j -P %
     fi
 } &&
     complete -F _comp_cmd_kill kill

--- a/completions/koji
+++ b/completions/koji
@@ -61,7 +61,7 @@ _comp_cmd_koji()
             return
             ;;
         --authtype)
-            COMPREPLY=($(compgen -W 'noauth ssl password kerberos' -- "$cur"))
+            _comp_compgen -- -W 'noauth ssl password kerberos'
             return
             ;;
         --topdir)
@@ -71,7 +71,7 @@ _comp_cmd_koji()
         --type)
             case ${command-} in
                 latest-pkg | list-tagged)
-                    COMPREPLY=($(compgen -W 'maven' -- "$cur"))
+                    _comp_compgen -- -W 'maven'
                     ;;
             esac
             return

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -97,7 +97,7 @@ _comp_cmd_ktutil()
                 options='-k --keytab -v --verbose --version -v --help'
                 ;;
         esac
-        COMPREPLY=($(compgen -W "$options" -- "$cur"))
+        _comp_compgen -- -W "$options"
     else
         case ${command-} in
             copy)
@@ -110,7 +110,7 @@ _comp_cmd_ktutil()
                 _comp_cmd_ktutil__heimdal_principals
                 ;;
             *)
-                COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+                _comp_compgen -- -W "$commands"
                 ;;
         esac
     fi

--- a/completions/lastlog
+++ b/completions/lastlog
@@ -12,7 +12,7 @@ _comp_cmd_lastlog()
             return
             ;;
         --user | -${noargopts}u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac

--- a/completions/ldapsearch
+++ b/completions/ldapsearch
@@ -2,12 +2,12 @@
 
 _comp_cmd_ldapsearch__ldap_uris()
 {
-    COMPREPLY=($(compgen -W 'ldap:// ldaps://' -- "$cur"))
+    _comp_compgen -- -W 'ldap:// ldaps://'
 }
 
 _comp_cmd_ldapsearch__ldap_protocols()
 {
-    COMPREPLY=($(compgen -W '2 3' -- "$cur"))
+    _comp_compgen -- -W '2 3'
 }
 
 _comp_cmd_ldapsearch()
@@ -33,11 +33,11 @@ _comp_cmd_ldapsearch()
             return
             ;;
         -*s)
-            COMPREPLY=($(compgen -W 'base one sub children' -- "$cur"))
+            _comp_compgen -- -W 'base one sub children'
             return
             ;;
         -*a)
-            COMPREPLY=($(compgen -W 'never always search find' -- "$cur"))
+            _comp_compgen -- -W 'never always search find'
             return
             ;;
         -*P)

--- a/completions/ldapvi
+++ b/completions/ldapvi
@@ -18,15 +18,15 @@ _comp_cmd_ldapvi()
             return
             ;;
         --bind)
-            COMPREPLY=($(compgen -W 'simple sasl' -- "$cur"))
+            _comp_compgen -- -W 'simple sasl'
             return
             ;;
         --bind-dialog)
-            COMPREPLY=($(compgen -W 'never auto always' -- "$cur"))
+            _comp_compgen -- -W 'never auto always'
             return
             ;;
         --scope)
-            COMPREPLY=($(compgen -W 'base one sub' -- "$cur"))
+            _comp_compgen -- -W 'base one sub'
             return
             ;;
         --deref)
@@ -35,11 +35,11 @@ _comp_cmd_ldapvi()
             return
             ;;
         --encoding)
-            COMPREPLY=($(compgen -W 'ASCII UTF-8 binary' -- "$cur"))
+            _comp_compgen -- -W 'ASCII UTF-8 binary'
             return
             ;;
         --tls)
-            COMPREPLY=($(compgen -W 'never allow try strict' -- "$cur"))
+            _comp_compgen -- -W 'never allow try strict'
             return
             ;;
     esac

--- a/completions/lftpget
+++ b/completions/lftpget
@@ -6,7 +6,7 @@ _comp_cmd_lftpget()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-c -d -v' -- "$cur"))
+        _comp_compgen -- -W '-c -d -v'
     fi
 } &&
     complete -F _comp_cmd_lftpget lftpget

--- a/completions/links
+++ b/completions/links
@@ -7,11 +7,11 @@ _comp_cmd_links()
 
     case $prev in
         -html-t-text-color | -html-t-link-color)
-            COMPREPLY=($(compgen -W '{0..15}' -- "$cur"))
+            _comp_compgen -- -W '{0..15}'
             return
             ;;
         -http.fake-firefox | -html-[gt]-ignore-document-color)
-            COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+            _comp_compgen -- -W '0 1'
             return
             ;;
         --help | -help | -mode | -display | -source | -dump | -width | -max-connections | \
@@ -30,7 +30,7 @@ _comp_cmd_links()
             local drivers=$("$1" -driver foo 2>&1 |
                 command sed -ne '$!d' -e '/^[a-z0-9, ]\{1,\}$/s/,/ /gp')
             [[ $drivers ]] || drivers='x svgalib fb directfb pmshell atheos'
-            COMPREPLY=($(compgen -W "$drivers" -- "$cur"))
+            _comp_compgen -- -W "$drivers"
             return
             ;;
         -codepage | -bookmarks-codepage | -http-assume-codepage)
@@ -54,15 +54,15 @@ _comp_cmd_links()
             -http-bugs.* | -http.do-not-track | -ftp.use-* | -ftp.fast | -ftp.set-iptos | \
             -smb.allow-hyperlinks-to-smb | -save-url-history | -dither-letters | \
             -dither-images | -overwrite-instead-of-scroll | -html-*)
-            COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+            _comp_compgen -- -W '0 1'
             return
             ;;
         -address-preference | -http.referer)
-            COMPREPLY=($(compgen -W '{0..4}' -- "$cur"))
+            _comp_compgen -- -W '{0..4}'
             return
             ;;
         -ssl-certificates | -display-optimize | -gamma-correction)
-            COMPREPLY=($(compgen -W '{0..2}' -- "$cur"))
+            _comp_compgen -- -W '{0..2}'
             return
             ;;
         -ssl.client-cert-key)

--- a/completions/lintian
+++ b/completions/lintian
@@ -105,7 +105,7 @@ _comp_cmd_lintian()
                 return
                 ;;
             --color)
-                COMPREPLY=($(compgen -W "never always auto html" -- "$cur"))
+                _comp_compgen -- -W "never always auto html"
                 return
                 ;;
             -U | --unpack-info)
@@ -113,7 +113,7 @@ _comp_cmd_lintian()
                 return
                 ;;
             --area | --section)
-                COMPREPLY=($(compgen -W "main contrib non-free" -- "$cur"))
+                _comp_compgen -- -W "main contrib non-free"
                 return
                 ;;
             --arch)

--- a/completions/lintian
+++ b/completions/lintian
@@ -12,7 +12,7 @@ _comp_cmd_lintian__tags()
         for item in $search; do
             tags=$(command sed -e "s/\<$item\>//g" <<<"$tags")
         done
-        COMPREPLY+=($(compgen -W "$tags"))
+        _comp_compgen -aR -- -W "$tags"
     elif [[ $cur == *,* ]]; then
         _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$tags"
     else
@@ -38,7 +38,7 @@ _comp_cmd_lintian__checks()
                 checks=$(command sed -e "s/\<$name\>//g" <<<"$checks")
             done
         done
-        COMPREPLY+=($(compgen -W "$checks"))
+        _comp_compgen -aR -- -W "$checks"
     elif [[ $cur == *,* ]]; then
         _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$checks"
     else
@@ -59,7 +59,7 @@ _comp_cmd_lintian__infos()
         for item in $search; do
             infos=$(command sed -e "s/\<$item\>//g" <<<"$infos")
         done
-        COMPREPLY+=($(compgen -W "$infos"))
+        _comp_compgen -aR -- -W "$infos"
     elif [[ $cur == *,* ]]; then
         _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$infos"
     else

--- a/completions/lintian
+++ b/completions/lintian
@@ -14,7 +14,7 @@ _comp_cmd_lintian__tags()
         done
         COMPREPLY+=($(compgen -W "$tags"))
     elif [[ $cur == *,* ]]; then
-        COMPREPLY+=($(compgen -P "${cur%,*}," -W "$tags" -- "${cur##*,}"))
+        _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$tags"
     else
         _comp_compgen -a -- -W "$tags"
     fi
@@ -40,7 +40,7 @@ _comp_cmd_lintian__checks()
         done
         COMPREPLY+=($(compgen -W "$checks"))
     elif [[ $cur == *,* ]]; then
-        COMPREPLY+=($(compgen -P "${cur%,*}," -W "$checks" -- "${cur##*,}"))
+        _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$checks"
     else
         _comp_compgen -a -- -W "$checks"
     fi
@@ -61,7 +61,7 @@ _comp_cmd_lintian__infos()
         done
         COMPREPLY+=($(compgen -W "$infos"))
     elif [[ $cur == *,* ]]; then
-        COMPREPLY+=($(compgen -P "${cur%,*}," -W "$infos" -- "${cur##*,}"))
+        _comp_compgen -ac "${cur##*,}" -- -P "${cur%,*}," -W "$infos"
     else
         _comp_compgen -a -- -W "$infos"
     fi

--- a/completions/lintian
+++ b/completions/lintian
@@ -16,7 +16,7 @@ _comp_cmd_lintian__tags()
     elif [[ $cur == *,* ]]; then
         COMPREPLY+=($(compgen -P "${cur%,*}," -W "$tags" -- "${cur##*,}"))
     else
-        COMPREPLY+=($(compgen -W "$tags" -- "$cur"))
+        _comp_compgen -a -- -W "$tags"
     fi
 }
 
@@ -42,7 +42,7 @@ _comp_cmd_lintian__checks()
     elif [[ $cur == *,* ]]; then
         COMPREPLY+=($(compgen -P "${cur%,*}," -W "$checks" -- "${cur##*,}"))
     else
-        COMPREPLY+=($(compgen -W "$checks" -- "$cur"))
+        _comp_compgen -a -- -W "$checks"
     fi
 }
 
@@ -63,7 +63,7 @@ _comp_cmd_lintian__infos()
     elif [[ $cur == *,* ]]; then
         COMPREPLY+=($(compgen -P "${cur%,*}," -W "$infos" -- "${cur##*,}"))
     else
-        COMPREPLY+=($(compgen -W "$infos" -- "$cur"))
+        _comp_compgen -a -- -W "$infos"
     fi
 }
 

--- a/completions/list_admins
+++ b/completions/list_admins
@@ -6,7 +6,7 @@ _comp_cmd_list_admins()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--all-vhost --all --help' -- "$cur"))
+        _comp_compgen -- -W '--all-vhost --all --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/list_members
+++ b/completions/list_members
@@ -11,7 +11,7 @@ _comp_cmd_list_members()
             return
             ;;
         -d | --digest)
-            COMPREPLY=($(compgen -W 'mime plain' -- "$cur"))
+            _comp_compgen -- -W 'mime plain'
             return
             ;;
         -n | --nomail)

--- a/completions/lpq
+++ b/completions/lpq
@@ -11,13 +11,13 @@ _comp_cmd_lpq()
             return
             ;;
         -U)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac
 
     if [[ $cur == - ]]; then
-        COMPREPLY=($(compgen -W '-E -P -U -a -h -l' -- "$cur"))
+        _comp_compgen -- -W '-E -P -U -a -h -l'
         return
     fi
 

--- a/completions/lpr
+++ b/completions/lpr
@@ -11,18 +11,18 @@ _comp_cmd_lpr()
             return
             ;;
         -U)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -o)
-            COMPREPLY=($(compgen -W "media= landscape orientation-requested= sides= fitplot number-up= scaling= cpi= lpi= page-bottom= page-top= page-left= page-right=" -- "$cur"))
+            _comp_compgen -- -W "media= landscape orientation-requested= sides= fitplot number-up= scaling= cpi= lpi= page-bottom= page-top= page-left= page-right="
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
             ;;
     esac
 
     if [[ $cur == - ]]; then
-        COMPREPLY=($(compgen -W '-E -H -C -J -T -P -U -h -l -m -o -p -q -r' -- "$cur"))
+        _comp_compgen -- -W '-E -H -C -J -T -P -U -h -l -m -o -p -q -r'
         return
     fi
 

--- a/completions/lrzip
+++ b/completions/lrzip
@@ -26,11 +26,11 @@ _comp_cmd_lrzip()
             return
             ;;
         --level | -${noargopts}L)
-            COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+            _comp_compgen -- -W '{1..9}'
             return
             ;;
         --nice-level | -${noargopts}N)
-            COMPREPLY=($(compgen -W '{-20..19}' -- "$cur"))
+            _comp_compgen -- -W '{-20..19}'
             return
             ;;
         --threads | -${noargopts}p)

--- a/completions/lsof
+++ b/completions/lsof
@@ -18,11 +18,11 @@ _comp_cmd_lsof()
             return
             ;;
         -D)
-            COMPREPLY=($(compgen -W '? b i r u' -- "$cur"))
+            _comp_compgen -- -W '? b i r u'
             return
             ;;
         -f)
-            COMPREPLY=($(compgen -W 'c f g G n' -- "$cur"))
+            _comp_compgen -- -W 'c f g G n'
             return
             ;;
         -g)
@@ -37,7 +37,7 @@ _comp_cmd_lsof()
             ;;
         -u)
             # TODO: handle ^foo exclusions, comma separated lists
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
     esac

--- a/completions/lspci
+++ b/completions/lspci
@@ -23,7 +23,7 @@ _comp_cmd_lspci()
             return
             ;;
         -*H)
-            COMPREPLY+=($(compgen -W "1 2" -- "$cur"))
+            _comp_compgen -a -- -W "1 2"
             return
             ;;
         -*F)

--- a/completions/luseradd
+++ b/completions/luseradd
@@ -35,7 +35,7 @@ _comp_cmd_luseradd()
         return
     fi
 
-    [[ ${1##*/} == luseradd ]] || COMPREPLY=($(compgen -u -- "$cur"))
+    [[ ${1##*/} == luseradd ]] || _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_luseradd luseradd lusermod
 

--- a/completions/luserdel
+++ b/completions/luserdel
@@ -16,7 +16,7 @@ _comp_cmd_luserdel()
         return
     fi
 
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_luserdel luserdel
 

--- a/completions/lvm
+++ b/completions/lvm
@@ -38,12 +38,12 @@ _comp_cmd_lvm__logicalvolumes()
 
 _comp_cmd_lvm__units()
 {
-    COMPREPLY=($(compgen -W 'h s b k m g t H K M G T' -- "$cur"))
+    _comp_compgen -- -W 'h s b k m g t H K M G T'
 }
 
 _comp_cmd_lvm__sizes()
 {
-    COMPREPLY=($(compgen -W 'k K m M g G t T' -- "$cur"))
+    _comp_compgen -- -W 'k K m M g G t T'
 }
 
 # @param $1 glob matching args known to take an argument
@@ -142,7 +142,7 @@ _comp_cmd_pvchange()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | --allocatable | -${noargopts}[Ax])
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -168,11 +168,11 @@ _comp_cmd_pvcreate()
             return
             ;;
         --metadatatype | -${noargopts}M)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
         --metadatacopies)
-            COMPREPLY=($(compgen -W '0 1 2' -- "$cur"))
+            _comp_compgen -- -W '0 1 2'
             return
             ;;
         --metadatasize | --setphysicalvolumesize)
@@ -198,7 +198,7 @@ _comp_cmd_pvmove()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --name | -${noargopts}n)
@@ -297,7 +297,7 @@ _comp_cmd_vgchange()
     # shellcheck disable=SC2254
     case $prev in
         --available | --autobackup | --resizeable | -${noargopts}[aAx])
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -319,11 +319,11 @@ _comp_cmd_vgcreate()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --metadatatype | -${noargopts}M)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
         --physicalextentsize | -${noargopts}s)
@@ -368,7 +368,7 @@ _comp_cmd_vgrename()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -390,7 +390,7 @@ _comp_cmd_vgreduce()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -419,7 +419,7 @@ _comp_cmd_vgextend()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --size | -${noargopts}L)
@@ -477,11 +477,11 @@ _comp_cmd_vgconvert()
     # shellcheck disable=SC2254
     case $prev in
         --metadatatype | -${noargopts}M)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
         --metadatacopies)
-            COMPREPLY=($(compgen -W '0 1 2' -- "$cur"))
+            _comp_compgen -- -W '0 1 2'
             return
             ;;
         --metadatasize)
@@ -533,7 +533,7 @@ _comp_cmd_vgcfgrestore()
             return
             ;;
         --metadatatype | -${noargopts}M)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
         --name | -${noargopts}n)
@@ -559,7 +559,7 @@ _comp_cmd_vgmerge()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -581,11 +581,11 @@ _comp_cmd_vgsplit()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --metadatatype | -${noargopts}M)
-            COMPREPLY=($(compgen -W '1 2' -- "$cur"))
+            _comp_compgen -- -W '1 2'
             return
             ;;
     esac
@@ -685,11 +685,11 @@ _comp_cmd_lvchange()
     # shellcheck disable=SC2254
     case $prev in
         --available | --autobackup | --contiguous | --persistent | -${noargopts}[aACM])
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --permission | -${noargopts}p)
-            COMPREPLY=($(compgen -W 'r rw' -- "$cur"))
+            _comp_compgen -- -W 'r rw'
             return
             ;;
     esac
@@ -711,7 +711,7 @@ _comp_cmd_lvcreate()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | --contiguous | --persistent | --zero | -${noargopts}[ACMZ])
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --size | -${noargopts}L)
@@ -719,7 +719,7 @@ _comp_cmd_lvcreate()
             return
             ;;
         --permission | -${noargopts}p)
-            COMPREPLY=($(compgen -W 'r rw' -- "$cur"))
+            _comp_compgen -- -W 'r rw'
             return
             ;;
         --name | -${noargopts}n)
@@ -751,7 +751,7 @@ _comp_cmd_lvremove()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -773,7 +773,7 @@ _comp_cmd_lvrename()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac
@@ -795,7 +795,7 @@ _comp_cmd_lvreduce()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --size | -${noargopts}L)
@@ -821,7 +821,7 @@ _comp_cmd_lvresize()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --size | -${noargopts}L)
@@ -853,7 +853,7 @@ _comp_cmd_lvextend()
     # shellcheck disable=SC2254
     case $prev in
         --autobackup | -${noargopts}A)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --size | -${noargopts}L)

--- a/completions/mailmanctl
+++ b/completions/mailmanctl
@@ -9,7 +9,7 @@ _comp_cmd_mailmanctl()
         COMPREPLY=($(compgen -W '--no-restart --run-as-user
             --stale-lock-cleanup --quiet --help' -- "$cur"))
     else
-        COMPREPLY=($(compgen -W 'start stop restart reopen' -- "$cur"))
+        _comp_compgen -- -W 'start stop restart reopen'
     fi
 
 } &&

--- a/completions/make
+++ b/completions/make
@@ -158,7 +158,7 @@ _comp_cmd_make()
             return
             ;;
         -${noargopts}E)
-            COMPREPLY=($(compgen -v -- "$cur"))
+            _comp_compgen -- -v
             return
             ;;
         --eval | -${noargopts}[DVx])

--- a/completions/makepkg
+++ b/completions/makepkg
@@ -8,7 +8,7 @@ _comp_cmd_makepkg__slackware()
 
     case "$prev" in
         -l | --linkadd | -c | --chown)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
     esac

--- a/completions/man
+++ b/completions/man
@@ -30,11 +30,11 @@ _comp_cmd_man()
             ;;
         --pager | -${noargopts}P)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --preprocessor | -${noargopts}p)
-            COMPREPLY=($(compgen -W 'e p t g r v' -- "$cur"))
+            _comp_compgen -- -W 'e p t g r v'
             return
             ;;
         --locale | --systems | --extension | --prompt | --recode | --encoding | \

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -8,7 +8,7 @@ _comp_cmd_mcrypt()
 
     case $prev in
         -g | --openpgp-z)
-            COMPREPLY=($(compgen -W '{0..9}' -- "$cur"))
+            _comp_compgen -- -W '{0..9}'
             return
             ;;
         -o | --keymode)

--- a/completions/mdadm
+++ b/completions/mdadm
@@ -48,7 +48,7 @@ _comp_cmd_mdadm__raid_layout()
                 right-asymmetric right-symmetric la ra ls rs' -- "$cur"))
             ;;
         raid10)
-            COMPREPLY=($(compgen -W 'n o p' -- "$cur"))
+            _comp_compgen -- -W 'n o p'
             ;;
         faulty)
             COMPREPLY=($(compgen -W 'write-transient wt read-transient rt
@@ -60,7 +60,7 @@ _comp_cmd_mdadm__raid_layout()
 
 _comp_cmd_mdadm__auto_flag()
 {
-    COMPREPLY=($(compgen -W 'no yes md mdp part p' -- "$cur"))
+    _comp_compgen -- -W 'no yes md mdp part p'
 }
 
 _comp_cmd_mdadm__update_flag()

--- a/completions/mdtool
+++ b/completions/mdtool
@@ -33,7 +33,7 @@ _comp_cmd_mdtool()
                 ;;
             "generate-makefiles")
                 compopt -o filenames
-                COMPREPLY=($(compgen -o filenames -G"*.mds" -- "$cur"))
+                _comp_compgen -- -o filenames -G"*.mds"
                 if [[ $prev == *mds ]]; then
                     COMPREPLY=($(compgen -W '--simple-makefiles --s --d:' \
                         -- "$cur"))

--- a/completions/minicom
+++ b/completions/minicom
@@ -9,7 +9,7 @@ _comp_cmd_minicom()
     # shellcheck disable=SC2254
     case $prev in
         --attrib | --color | -${noargopts}[ac])
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --script | --capturefile | -${noargopts}[SC])
@@ -36,7 +36,7 @@ _comp_cmd_minicom()
     local -a files
     _comp_expand_glob files '{/etc/,/etc/minicom/,~/.}minirc.?*'
     ((${#files[@]})) &&
-        COMPREPLY=($(compgen -W '"${files[@]##*minirc.}"' -- "$cur"))
+        _comp_compgen -- -W '"${files[@]##*minirc.}"'
 } &&
     complete -F _comp_cmd_minicom -o default minicom
 

--- a/completions/mktemp
+++ b/completions/mktemp
@@ -22,7 +22,7 @@ _comp_cmd_mktemp()
     if [[ $cur == -* ]]; then
         local opts=$(_parse_help "$1")
         [[ $opts ]] || opts="-d -u -q -p -t" # non-GNU fallback
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+        _comp_compgen -- -W "$opts"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/mmsitepass
+++ b/completions/mmsitepass
@@ -6,7 +6,7 @@ _comp_cmd_mmsitepass()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--listcreator --help' -- "$cur"))
+        _comp_compgen -- -W '--listcreator --help'
     fi
 
 } &&

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -93,7 +93,7 @@ _comp_cmd_modprobe()
                         command grep -q "^$prev:.*(bool)"; then
                         local choices="on off"
                         [[ $cur ]] && choices="1 0 y Y n N on off"
-                        COMPREPLY=($(compgen -W "$choices" -- "$cur"))
+                        _comp_compgen -- -W "$choices"
                     fi
                 else
                     COMPREPLY=($(compgen -S = -W "$(PATH="$PATH:/sbin" \

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -60,9 +60,9 @@ _comp_cmd_mplayer()
             cp=($(iconv --list 2>/dev/null | command sed -e "s@//@@;" 2>/dev/null))
             if ((${#cp[@]})); then
                 if [[ $cur == "${cur,,}" ]]; then
-                    COMPREPLY=($(compgen -W '"${cp[@],,}"' -- "$cur"))
+                    _comp_compgen -- -W '"${cp[@],,}"'
                 else
-                    COMPREPLY=($(compgen -W '"${cp[@]^^}"' -- "$cur"))
+                    _comp_compgen -- -W '"${cp[@]^^}"'
                 fi
             fi
             return
@@ -138,7 +138,7 @@ _comp_cmd_mplayer()
             return
             ;;
         -channels)
-            COMPREPLY=($(compgen -W '2 4 6 8' -- "$cur"))
+            _comp_compgen -- -W '2 4 6 8'
             return
             ;;
         -aspect | -monitoraspect)
@@ -167,7 +167,7 @@ _comp_cmd_mplayer()
             return
             ;;
         -ssf)
-            COMPREPLY=($(compgen -W 'lgb= cgb= ls= cs= chs= cvs=' -- "$cur"))
+            _comp_compgen -- -W 'lgb= cgb= ls= cs= chs= cvs='
             return
             ;;
         -jpeg)
@@ -176,7 +176,7 @@ _comp_cmd_mplayer()
             return
             ;;
         -xvidopts)
-            COMPREPLY=($(compgen -W 'dr2 nodr2' -- "$cur"))
+            _comp_compgen -- -W 'dr2 nodr2'
             return
             ;;
         -xvidencopts)
@@ -236,7 +236,7 @@ _comp_cmd_mplayer()
             return
             ;;
         -mf)
-            COMPREPLY=($(compgen -W 'on w= h= fps= type=' -- "$cur"))
+            _comp_compgen -- -W 'on w= h= fps= type='
             return
             ;;
         -cdda)
@@ -251,11 +251,11 @@ _comp_cmd_mplayer()
             return
             ;;
         -af-adv)
-            COMPREPLY=($(compgen -W 'force= list=' -- "$cur"))
+            _comp_compgen -- -W 'force= list='
             return
             ;;
         -noconfig)
-            COMPREPLY=($(compgen -W 'all gui system user' -- "$cur"))
+            _comp_compgen -- -W 'all gui system user'
             return
             ;;
         -*)

--- a/completions/mr
+++ b/completions/mr
@@ -43,18 +43,18 @@ _comp_cmd_mr()
                 ;;
             clean)
                 if [[ ${cur} == -* ]]; then
-                    COMPREPLY=($(compgen -W '-f' -- "${cur}"))
+                    _comp_compgen -- -W '-f'
                 fi
                 return
                 ;;
             commit | ci | record)
                 if [[ ${cur} == -* ]]; then
-                    COMPREPLY=($(compgen -W '-m' -- "${cur}"))
+                    _comp_compgen -- -W '-m'
                 fi
                 return
                 ;;
             run)
-                COMPREPLY=($(compgen -c -- "${cur}"))
+                _comp_compgen -- -c
                 return
                 ;;
             *)
@@ -84,9 +84,9 @@ _comp_cmd_mr()
         options="${options//-[a-z]$'\n'/}"
         # Remove deprecated options.
         options="${options//--path/}"
-        COMPREPLY=($(compgen -W "${options}" -- "${cur}"))
+        _comp_compgen -- -W "${options}"
     else
-        COMPREPLY=($(compgen -W "${commands}" -- "${cur}"))
+        _comp_compgen -- -W "${commands}"
     fi
 } &&
     complete -F _comp_cmd_mr mr

--- a/completions/mtx
+++ b/completions/mtx
@@ -23,10 +23,10 @@ _comp_cmd_mtx()
     if ((cword > 1)); then
         case $prev in
             load)
-                COMPREPLY=($(compgen -W "$tapes" -- "$cur"))
+                _comp_compgen -- -W "$tapes"
                 ;;
             unload | first | last | next)
-                COMPREPLY=($(compgen -W "$drives" -- "$cur"))
+                _comp_compgen -- -W "$drives"
                 ;;
             -f)
                 true
@@ -36,7 +36,7 @@ _comp_cmd_mtx()
                 ;;
         esac
     else
-        COMPREPLY=($(compgen -W "$options" -- "$cur"))
+        _comp_compgen -- -W "$options"
     fi
 } &&
     complete -F _comp_cmd_mtx mtx

--- a/completions/munin-node-configure
+++ b/completions/munin-node-configure
@@ -19,7 +19,7 @@ _comp_cmd_munin_node_configure()
             return
             ;;
         --snmpversion)
-            COMPREPLY=($(compgen -W '1 2c 3' -- "$cur"))
+            _comp_compgen -- -W '1 2c 3'
             return
             ;;
     esac

--- a/completions/mussh
+++ b/completions/mussh
@@ -10,11 +10,11 @@ _comp_cmd_mussh()
             return
             ;;
         -d)
-            COMPREPLY=($(compgen -W '{0..2}' -- "$cur"))
+            _comp_compgen -- -W '{0..2}'
             return
             ;;
         -v)
-            COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
+            _comp_compgen -- -W '{0..3}'
             return
             ;;
         -i | -H | -C)
@@ -26,7 +26,7 @@ _comp_cmd_mussh()
             return
             ;;
         -l | -L)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -s)

--- a/completions/mussh
+++ b/completions/mussh
@@ -39,7 +39,7 @@ _comp_cmd_mussh()
             ;;
         -c)
             compopt -o filenames
-            COMPREPLY+=($(compgen -c -- "$cur"))
+            _comp_compgen -a -- -c
             return
             ;;
     esac

--- a/completions/mutt
+++ b/completions/mutt
@@ -141,7 +141,7 @@ _comp_cmd_mutt__filedir()
         # Match any file in $folder beginning with $cur
         # (minus the leading '=' sign).
         compopt -o filenames
-        COMPREPLY=($(compgen -f -- "$folder/${cur:1}"))
+        _comp_compgen -c "$folder/${cur:1}" -- -f
         COMPREPLY=(${COMPREPLY[@]#$folder/})
         return
     elif [[ $cur == !* ]]; then

--- a/completions/mutt
+++ b/completions/mutt
@@ -106,7 +106,7 @@ _comp_cmd_mutt__aliases()
     aliases=($(command sed -n 's|^alias[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*$|\1|p' \
         "${conffiles[@]}"))
     ((${#aliases[@]})) &&
-        COMPREPLY+=($(compgen -W '"${aliases[@]}"' -- "$cur"))
+        _comp_compgen -a -- -W '"${aliases[@]}"'
 }
 
 # @param $1 (cur) Current word to complete
@@ -125,7 +125,7 @@ _comp_cmd_mutt__query()
             command sed -n '2,$s|^\([^[:space:]]\{1,\}\).*|\1|p'))
     fi
 
-    COMPREPLY+=($(compgen -W "${queryresults[*]}" -- "$cur"))
+    _comp_compgen -a -- -W "${queryresults[*]}"
 }
 
 # @param $1 (cur) Current word to complete

--- a/completions/mutt
+++ b/completions/mutt
@@ -9,7 +9,7 @@ _comp_cmd_mutt__addresses()
     _comp_cmd_mutt__aliases "$1"
     _comp_cmd_mutt__query "$1"
 
-    COMPREPLY+=($(compgen -u -- "$1"))
+    _comp_compgen -ac "$1" -- -u
 }
 
 # Find muttrc to use

--- a/completions/mypy
+++ b/completions/mypy
@@ -21,7 +21,7 @@ _comp_cmd_mypy()
             return
             ;;
         --follow-imports)
-            COMPREPLY=($(compgen -W 'normal silent skip error' -- "$cur"))
+            _comp_compgen -- -W 'normal silent skip error'
             return
             ;;
         --python-executable)

--- a/completions/mypy
+++ b/completions/mypy
@@ -25,7 +25,7 @@ _comp_cmd_mypy()
             return
             ;;
         --python-executable)
-            COMPREPLY=($(compgen -c -- "${cur:-py}"))
+            _comp_compgen -c "${cur:-py}" -- -c
             return
             ;;
         --*-dir | --*-report)

--- a/completions/mysql
+++ b/completions/mysql
@@ -7,7 +7,6 @@ _comp_xfunc_mysql_character_sets()
     charsets+=(utf8)
     charsets=("${charsets[@]##*/}")
     charsets=("${charsets[@]%.xml}")
-    local IFS=$'\n'
     _comp_compgen -a -- -W '"${charsets[@]}"' -X ''
 }
 

--- a/completions/mysql
+++ b/completions/mysql
@@ -22,7 +22,7 @@ _comp_cmd_mysql()
     # shellcheck disable=SC2254
     case $prev in
         --user | -${noargopts}u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         --database | -${noargopts}D)
@@ -48,7 +48,7 @@ _comp_cmd_mysql()
             return
             ;;
         --protocol)
-            COMPREPLY=($(compgen -W 'tcp socket pipe memory' -- "$cur"))
+            _comp_compgen -- -W 'tcp socket pipe memory'
             return
             ;;
         --defaults-file | --defaults-extra-file | --tee)
@@ -81,7 +81,7 @@ _comp_cmd_mysql()
             local help=$(_parse_help "$1")
             help+=" --skip-comments --skip-ssl"
 
-            COMPREPLY=($(compgen -W "$help" -- "$cur"))
+            _comp_compgen -- -W "$help"
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
             ;;

--- a/completions/mysql
+++ b/completions/mysql
@@ -8,7 +8,7 @@ _comp_xfunc_mysql_character_sets()
     charsets=("${charsets[@]##*/}")
     charsets=("${charsets[@]%.xml}")
     local IFS=$'\n'
-    COMPREPLY+=($(compgen -W '"${charsets[@]}"' -X '' -- "$cur"))
+    _comp_compgen -a -- -W '"${charsets[@]}"' -X ''
 }
 
 _comp_deprecate_func _mysql_character_sets _comp_xfunc_mysql_character_sets

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -9,7 +9,7 @@ _comp_cmd_mysqladmin()
     # shellcheck disable=SC2254
     case $prev in
         --user | -${noargopts}u)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         --host | -${noargopts}h)

--- a/completions/nc
+++ b/completions/nc
@@ -25,7 +25,7 @@ _comp_cmd_nc()
             return
             ;;
         -*X)
-            COMPREPLY=($(compgen -W '4 5 connect' -- "$cur"))
+            _comp_compgen -- -W '4 5 connect'
             return
             ;;
         -*x)

--- a/completions/nethogs
+++ b/completions/nethogs
@@ -8,7 +8,7 @@ _comp_cmd_nethogs()
     case "$prev" in
         -d)
             # expect integer value
-            COMPREPLY+=($(compgen -W '{0..9}'))
+            _comp_compgen -aR -- -W '{0..9}'
             compopt -o nospace
             return
             ;;

--- a/completions/newusers
+++ b/completions/newusers
@@ -7,7 +7,7 @@ _comp_cmd_newusers()
 
     case $prev in
         -c | --crypt)
-            COMPREPLY=($(compgen -W 'DES MD5 NONE SHA256 SHA512' -- "$cur"))
+            _comp_compgen -- -W 'DES MD5 NONE SHA256 SHA512'
             return
             ;;
         -s | --sha-rounds)

--- a/completions/ngrep
+++ b/completions/ngrep
@@ -19,7 +19,7 @@ _comp_cmd_ngrep()
             return
             ;;
         -W)
-            COMPREPLY=($(compgen -W 'normal byline single none' -- "$cur"))
+            _comp_compgen -- -W 'normal byline single none'
             return
             ;;
         -F)

--- a/completions/ngrep
+++ b/completions/ngrep
@@ -15,7 +15,7 @@ _comp_cmd_ngrep()
             ;;
         -d)
             _available_interfaces -a
-            COMPREPLY+=($(compgen -W 'any' -- "$cur"))
+            _comp_compgen -a -- -W 'any'
             return
             ;;
         -W)

--- a/completions/nslookup
+++ b/completions/nslookup
@@ -76,7 +76,7 @@ _comp_cmd_host()
             return
             ;;
         -m)
-            COMPREPLY=($(compgen -W 'trace record usage' -- "$cur"))
+            _comp_compgen -- -W 'trace record usage'
             return
             ;;
         -N | -R | -W)

--- a/completions/nslookup
+++ b/completions/nslookup
@@ -2,7 +2,7 @@
 
 _comp_cmd_nslookup__queryclass()
 {
-    COMPREPLY+=($(compgen -W 'IN CH HS ANY' -- "$cur"))
+    _comp_compgen -a -- -W 'IN CH HS ANY'
 }
 
 _comp_cmd_nslookup__querytype()
@@ -20,7 +20,7 @@ _comp_cmd_nslookup__querytype()
     # Selected obsolete record types
     types+=(SPF)
 
-    COMPREPLY+=($(compgen -W '"${types[@]}"' -- "$cur"))
+    _comp_compgen -a -- -W '"${types[@]}"'
 }
 
 _comp_cmd_nslookup()

--- a/completions/ntpdate
+++ b/completions/ntpdate
@@ -11,11 +11,11 @@ _comp_cmd_ntpdate()
             return
             ;;
         -*U)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -*p)
-            COMPREPLY=($(compgen -W '{1..8}' -- "$cur"))
+            _comp_compgen -- -W '{1..8}'
             return
             ;;
 

--- a/completions/oggdec
+++ b/completions/oggdec
@@ -12,11 +12,11 @@ _comp_cmd_oggdec()
             return
             ;;
         --bits | -${noargopts}b)
-            COMPREPLY=($(compgen -W "8 16" -- "$cur"))
+            _comp_compgen -- -W "8 16"
             return
             ;;
         --endianness | --sign | -${noargopts}[es])
-            COMPREPLY=($(compgen -W "0 1" -- "$cur"))
+            _comp_compgen -- -W "0 1"
             return
             ;;
         --output | -${noargopts}o)

--- a/completions/openssl
+++ b/completions/openssl
@@ -57,7 +57,7 @@ _comp_cmd_openssl()
         sha224 sha256 sha384 sha512 genpkey pkey pkeyparam pkeyutl'
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+        _comp_compgen -- -W "$commands"
     else
         command=${words[1]}
         case $prev in
@@ -91,7 +91,7 @@ _comp_cmd_openssl()
                         formats+=" ENGINE"
                         ;;
                 esac
-                COMPREPLY=($(compgen -W "$formats" -- "$cur"))
+                _comp_compgen -- -W "$formats"
                 return
                 ;;
             -connect)
@@ -110,7 +110,7 @@ _comp_cmd_openssl()
                 return
                 ;;
             -kdf)
-                COMPREPLY=($(compgen -W 'TLS1-PRF HKDF' -- "$cur"))
+                _comp_compgen -- -W 'TLS1-PRF HKDF'
                 return
                 ;;
         esac
@@ -121,7 +121,7 @@ _comp_cmd_openssl()
             case $command in
                 dgst | req | x509) options+=" $(_openssl_digests "$1")" ;;
             esac
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             if [[ $command == speed ]]; then
                 COMPREPLY=($(compgen -W 'md2 mdc2 md5 hmac sha1 rmd160

--- a/completions/opera
+++ b/completions/opera
@@ -23,7 +23,7 @@ _comp_cmd_opera()
             return
             ;;
         ?(-)-windowname)
-            COMPREPLY=($(compgen -W 'first last opera{1..9}' -- "$cur"))
+            _comp_compgen -- -W 'first last opera{1..9}'
             return
             ;;
         ?(-)-geometry | ?(-)-window | ?(-)-display | ?(-)-urllistloadtimeout | \

--- a/completions/optipng
+++ b/completions/optipng
@@ -10,7 +10,7 @@ _comp_cmd_optipng()
             return
             ;;
         -o)
-            COMPREPLY=($(compgen -W '{0..7}' -- "$cur"))
+            _comp_compgen -- -W '{0..7}'
             return
             ;;
         -out | -log)
@@ -22,11 +22,11 @@ _comp_cmd_optipng()
             return
             ;;
         -i)
-            COMPREPLY=($(compgen -W '0 1' -- "$cur"))
+            _comp_compgen -- -W '0 1'
             return
             ;;
         -zc | -zm)
-            COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+            _comp_compgen -- -W '{1..9}'
             return
             ;;
         -zw)
@@ -35,7 +35,7 @@ _comp_cmd_optipng()
             return
             ;;
         -strip)
-            COMPREPLY=($(compgen -W 'all' -- "$cur"))
+            _comp_compgen -- -W 'all'
             return
             ;;
     esac

--- a/completions/p4
+++ b/completions/p4
@@ -15,7 +15,7 @@ _comp_cmd_p4()
         text binary resource"
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W "$p4commands" -- "$cur"))
+        _comp_compgen -- -W "$p4commands"
     elif ((cword == 2)); then
         case $prev in
             help)
@@ -24,7 +24,7 @@ _comp_cmd_p4()
                     -- "$cur"))
                 ;;
             admin)
-                COMPREPLY=($(compgen -W "checkpoint stop" -- "$cur"))
+                _comp_compgen -- -W "checkpoint stop"
                 ;;
             *) ;;
 
@@ -34,7 +34,7 @@ _comp_cmd_p4()
             -t)
                 case ${words[cword - 2]} in
                     add | edit | reopen)
-                        COMPREPLY=($(compgen -W "$p4filetypes" -- "$cur"))
+                        _comp_compgen -- -W "$p4filetypes"
                         ;;
                     *) ;;
 

--- a/completions/pack200
+++ b/completions/pack200
@@ -12,19 +12,19 @@ _comp_cmd_pack200()
             return
             ;;
         -E | --effort)
-            COMPREPLY=($(compgen -W '{0..9}' -- "$cur"))
+            _comp_compgen -- -W '{0..9}'
             return
             ;;
         -H | --deflate-hint)
-            COMPREPLY=($(compgen -W 'true false keep' -- "$cur"))
+            _comp_compgen -- -W 'true false keep'
             return
             ;;
         -m | --modification-time)
-            COMPREPLY=($(compgen -W 'latest keep' -- "$cur"))
+            _comp_compgen -- -W 'latest keep'
             return
             ;;
         -U | --unknown-attribute)
-            COMPREPLY=($(compgen -W 'error strip pass' -- "$cur"))
+            _comp_compgen -- -W 'error strip pass'
             return
             ;;
         -f | --config-file)
@@ -32,7 +32,7 @@ _comp_cmd_pack200()
             return
             ;;
         -l | --log-file)
-            COMPREPLY=($(compgen -W '-' -- "$cur"))
+            _comp_compgen -- -W '-'
             _comp_compgen -a filedir log
             return
             ;;

--- a/completions/pack200
+++ b/completions/pack200
@@ -33,7 +33,7 @@ _comp_cmd_pack200()
             ;;
         -l | --log-file)
             COMPREPLY=($(compgen -W '-' -- "$cur"))
-            _comp_compgen_filedir log
+            _comp_compgen -a filedir log
             return
             ;;
         -r | --repack)

--- a/completions/patch
+++ b/completions/patch
@@ -22,7 +22,7 @@ _comp_cmd_patch()
             ;;
         --output | --reject-file | -${noargopts}[or])
             [[ ! $cur || $cur == - ]] && COMPREPLY=(-)
-            _comp_compgen_filedir
+            _comp_compgen -a filedir
             return
             ;;
         --quoting-style)

--- a/completions/patch
+++ b/completions/patch
@@ -13,7 +13,7 @@ _comp_cmd_patch()
             return
             ;;
         --fuzz | -${noargopts}F)
-            COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
+            _comp_compgen -- -W '{0..3}'
             return
             ;;
         --input | -${noargopts}i)
@@ -31,7 +31,7 @@ _comp_cmd_patch()
             return
             ;;
         --version-control | -${noargopts}V)
-            COMPREPLY=($(compgen -W 'simple numbered existing' -- "$cur"))
+            _comp_compgen -- -W 'simple numbered existing'
             return
             ;;
         --directory | -${noargopts}d)
@@ -39,11 +39,11 @@ _comp_cmd_patch()
             return
             ;;
         --reject-format)
-            COMPREPLY=($(compgen -W 'context unified' -- "$cur"))
+            _comp_compgen -- -W 'context unified'
             return
             ;;
         --read-only)
-            COMPREPLY=($(compgen -W 'ignore warn fail' -- "$cur"))
+            _comp_compgen -- -W 'ignore warn fail'
             return
             ;;
     esac

--- a/completions/pdftoppm
+++ b/completions/pdftoppm
@@ -10,15 +10,15 @@ _comp_cmd_pdftoppm()
             return
             ;;
         -tiffcompression)
-            COMPREPLY=($(compgen -W 'none packbits jpeg lzw deflate' -- "$cur"))
+            _comp_compgen -- -W 'none packbits jpeg lzw deflate'
             return
             ;;
         -freetype | -aa | -aaVector)
-            COMPREPLY=($(compgen -W 'yes no' -- "$cur"))
+            _comp_compgen -- -W 'yes no'
             return
             ;;
         -thinlinemode)
-            COMPREPLY=($(compgen -W 'none solid shape' -- "$cur"))
+            _comp_compgen -- -W 'none solid shape'
             return
             ;;
     esac

--- a/completions/pdftotext
+++ b/completions/pdftotext
@@ -16,7 +16,7 @@ _comp_cmd_pdftotext()
             return
             ;;
         -eol)
-            COMPREPLY=($(compgen -W "unix dos mac" -- "$cur"))
+            _comp_compgen -- -W "unix dos mac"
             return
             ;;
     esac
@@ -29,7 +29,7 @@ _comp_cmd_pdftotext()
     case ${prev,,} in
         - | *.txt) ;;
         *.pdf)
-            COMPREPLY=($(compgen -W '-' -- "$cur"))
+            _comp_compgen -- -W '-'
             _comp_compgen -a filedir txt
             ;;
         *) _comp_compgen_filedir pdf ;;

--- a/completions/perl
+++ b/completions/perl
@@ -33,7 +33,6 @@ _comp_cmd_perl()
                 return
                 ;;
             -*[Ix])
-                local IFS=$'\n'
                 compopt -o filenames
                 _comp_compgen -- -d "$optPrefix" $optSuffix
                 return
@@ -78,7 +77,6 @@ _comp_cmd_perl()
     # Likewise, `-I' also accepts a space between option and argument
     # and it takes a directory as value.
     elif [[ $prev == -I ]]; then
-        local IFS=$'\n'
         compopt -o filenames
         # shellcheck disable=SC2086
         _comp_compgen -- -d ${optPrefix-} ${optSuffix-}

--- a/completions/perl
+++ b/completions/perl
@@ -139,7 +139,7 @@ _comp_cmd_perldoc()
                     -- "$cur"))
             fi
         fi
-        _comp_compgen_filedir 'p@([lm]|od)'
+        _comp_compgen -a filedir 'p@([lm]|od)'
     fi
 } &&
     complete -F _comp_cmd_perldoc -o bashdefault perldoc

--- a/completions/perl
+++ b/completions/perl
@@ -35,7 +35,7 @@ _comp_cmd_perl()
             -*[Ix])
                 local IFS=$'\n'
                 compopt -o filenames
-                COMPREPLY=($(compgen -d "$optPrefix" $optSuffix -- "$cur"))
+                _comp_compgen -- -d "$optPrefix" $optSuffix
                 return
                 ;;
             -*[mM])
@@ -81,7 +81,7 @@ _comp_cmd_perl()
         local IFS=$'\n'
         compopt -o filenames
         # shellcheck disable=SC2086
-        COMPREPLY=($(compgen -d ${optPrefix-} ${optSuffix-} -- "$cur"))
+        _comp_compgen -- -d ${optPrefix-} ${optSuffix-}
         return
 
     elif [[ $cur == -* ]]; then

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -25,16 +25,16 @@ _comp_cmd_perlcritic()
             return
             ;;
         --profile-strictness)
-            COMPREPLY=($(compgen -W 'warn fatal quiet' -- "$cur"))
+            _comp_compgen -- -W 'warn fatal quiet'
             return
             ;;
         --verbose)
-            COMPREPLY=($(compgen -W '{1..11}' -- "$cur"))
+            _comp_compgen -- -W '{1..11}'
             return
             ;;
         --pager)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac

--- a/completions/perltidy
+++ b/completions/perltidy
@@ -21,7 +21,7 @@ _comp_cmd_perltidy()
             return
             ;;
         -ole=* | --output-line-ending=*)
-            COMPREPLY=($(compgen -W 'dos win mac unix' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W 'dos win mac unix'
             return
             ;;
         -bt=* | --brace-tightness=* | -pt=* | --paren-tightness=* | \
@@ -35,15 +35,15 @@ _comp_cmd_perltidy()
             -cti=* | --closing-token-indentation=* | \
             -kbl=* | --keep-old-blank-lines=* | \
             -vt=* | --vertical-tightness=*)
-            COMPREPLY=($(compgen -W '0 1 2' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W '0 1 2'
             return
             ;;
         -vtc=* | --vertical-tightness-closing=*)
-            COMPREPLY=($(compgen -W '0 1' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W '0 1'
             return
             ;;
         -cab=* | --comma-arrow-breakpoints=*)
-            COMPREPLY=($(compgen -W '0 1 2 3' -- "${cur#*=}"))
+            _comp_compgen -c "${cur#*=}" -- -W '0 1 2 3'
             return
             ;;
         -*=)

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -24,7 +24,7 @@ _comp_cmd_pgrep()
             return
             ;;
         -j)
-            COMPREPLY=($(compgen -W 'any none' -- "$cur"))
+            _comp_compgen -- -W 'any none'
             return
             ;;
         --parent | --ns | -${noargopts}P)
@@ -52,7 +52,7 @@ _comp_cmd_pgrep()
         [[ $help ]] || help='$("$1" --usage 2>&1 |
             command sed -e "s/\[-signal\]//" -e "s/\[-SIGNAL\]//" |
             _parse_usage -)'
-        COMPREPLY=($(compgen -W "$help" -- "$cur"))
+        _comp_compgen -- -W "$help"
         [[ $cword -eq 1 && $1 == *pkill ]] && _signals -
         return
     fi

--- a/completions/ping
+++ b/completions/ping
@@ -19,7 +19,7 @@ _comp_cmd_ping()
             # Path MTU strategy in Linux, mask|time in FreeBSD
             local opts="do want dont"
             [[ $OSTYPE == *bsd* ]] && opts="mask time"
-            COMPREPLY=($(compgen -W '$opts' -- "$cur"))
+            _comp_compgen -- -W '$opts'
             return
             ;;
         -*N)
@@ -34,7 +34,7 @@ _comp_cmd_ping()
         -*Q)
             # TOS in Linux, "somewhat quiet" (no args) in FreeBSD
             if [[ $OSTYPE != *bsd* ]]; then
-                COMPREPLY=($(compgen -W '{0..7}' -- "$cur"))
+                _comp_compgen -- -W '{0..7}'
                 return
             fi
             ;;
@@ -46,7 +46,7 @@ _comp_cmd_ping()
         -*T)
             # Timestamp option in Linux, TTL in FreeBSD
             [[ $OSTYPE == *bsd* ]] ||
-                COMPREPLY=($(compgen -W 'tsonly tsandaddr' -- "$cur"))
+                _comp_compgen -- -W 'tsonly tsandaddr'
             return
             ;;
         -*4*)

--- a/completions/pkg-get
+++ b/completions/pkg-get
@@ -50,7 +50,7 @@ _comp_cmd_pkg_get__catalog_file()
                 _comp_cmd_pkg_get__catalog_file "$url"
                 if [[ -f $ret ]]; then
                     local packages_list=$(awk '$0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "$ret")
-                    COMPREPLY=($(compgen -W "${packages_list}" -- "${cur}"))
+                    _comp_compgen -- -W "${packages_list}"
                 fi
             fi
             return
@@ -58,14 +58,14 @@ _comp_cmd_pkg_get__catalog_file()
 
         if [[ ${cur} == -* ]]; then
             local -a opts=(-c -d -D -f -i -l -s -S -u -U -v)
-            COMPREPLY=($(compgen -W '"${opts[@]}"' -- "${cur}"))
+            _comp_compgen -- -W '"${opts[@]}"'
             return
         fi
 
         local -a commands=(
             available describe download install list updatecatalog upgrade
         )
-        COMPREPLY=($(compgen -W '"${commands[@]}"' -- "${cur}"))
+        _comp_compgen -- -W '"${commands[@]}"'
     } &&
         complete -F _comp_cmd_pkg_get pkg-get
 

--- a/completions/pkg_delete
+++ b/completions/pkg_delete
@@ -9,7 +9,7 @@ _comp_cmd_pkg_delete()
 
     [[ $prev == -o || $prev == -p || $prev == -W ]] && return
 
-    COMPREPLY=($(compgen -d -- "$pkgdir$cur"))
+    _comp_compgen -c "$pkgdir$cur" -- -d
     ((${#COMPREPLY[@]} == 0)) || COMPREPLY=(${COMPREPLY[@]#$pkgdir})
 
 } &&

--- a/completions/pkgadd
+++ b/completions/pkgadd
@@ -36,7 +36,7 @@ _comp_cmd_pkgadd()
         *)
             if [[ ${cur} == -* ]]; then
                 local -a opts=(-a -A -d -k -n -M -P -r -R -s -v -V -x)
-                COMPREPLY=($(compgen -W '"${opts[@]}"' -- "${cur}"))
+                _comp_compgen -- -W '"${opts[@]}"'
             else
                 local -a pkginst_list
                 if [[ -d $device ]]; then
@@ -52,7 +52,7 @@ _comp_cmd_pkgadd()
                         command sed -n 's/^PKG=//p' | sort -u)"
                 fi
                 ((${#pkginst_list[@]})) &&
-                    COMPREPLY=($(compgen -W '"${pkginst_list[@]}"' -- "${cur}"))
+                    _comp_compgen -- -W '"${pkginst_list[@]}"'
             fi
             ;;
     esac

--- a/completions/pkgrm
+++ b/completions/pkgrm
@@ -34,7 +34,7 @@ _comp_cmd_pkgrm()
         *)
             if [[ ${cur} == -* ]]; then
                 local opts="-a -A -n -M -R -s -v -V -Y"
-                COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
+                _comp_compgen -- -W "${opts}"
             else
                 COMPREPLY=($(compgen -W "$(/bin/ls -1 "$spool")" -- "${cur}"))
             fi

--- a/completions/pkgtool
+++ b/completions/pkgtool
@@ -15,7 +15,7 @@ _comp_cmd_pkgtool()
             return
             ;;
         --source_device)
-            COMPREPLY=($(compgen -f -d -- "${cur:-/dev/}"))
+            _comp_compgen -c "${cur:-/dev/}" -- -f -d
             return
             ;;
         --tagfile)

--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -87,7 +87,7 @@ _comp_cmd_pkgutil()
 
         if [[ $command == -@([dius]|-download|-install|-upgrade|-stream) ]]; then
             local packages_list=$(awk ' $0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "${catalog_files[@]}")
-            COMPREPLY=($(compgen -W "${packages_list}" -- "$cur"))
+            _comp_compgen -- -W "${packages_list}"
 
         elif [[ $command == @(-r|--remove) ]]; then
             local packages_list=$(
@@ -95,7 +95,7 @@ _comp_cmd_pkgutil()
             )
             packages_list=${packages_list%|}
             packages_list=$(nawk " \$3 ~ /^$packages_list\$/ { print \$1 }" "${catalog_files[@]}")
-            COMPREPLY=($(compgen -W "${packages_list}" -- "$cur"))
+            _comp_compgen -- -W "${packages_list}"
         fi
         return
     fi
@@ -108,7 +108,7 @@ _comp_cmd_pkgutil()
         --findfile --deptree --extract --stream --output --target --single
         --param --parse --cleanup --catinfo
     )
-    COMPREPLY=($(compgen -W '"${commands[@]}"' -- "$cur"))
+    _comp_compgen -- -W '"${commands[@]}"'
 
 } &&
     complete -F _comp_cmd_pkgutil pkgutil

--- a/completions/pm-powersave
+++ b/completions/pm-powersave
@@ -5,7 +5,7 @@ _comp_cmd_pm_powersave()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W "true false" -- "$cur"))
+    _comp_compgen -- -W "true false"
 } &&
     complete -F _comp_cmd_pm_powersave pm-powersave
 

--- a/completions/portsnap
+++ b/completions/portsnap
@@ -18,7 +18,7 @@ _comp_cmd_portsnap()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W "fetch cron extract update" -- "$cur"))
+    _comp_compgen -- -W "fetch cron extract update"
 } &&
     complete -F _comp_cmd_portsnap portsnap
 

--- a/completions/portupgrade
+++ b/completions/portupgrade
@@ -9,7 +9,7 @@ _comp_cmd_portupgrade()
 
     local pkgdir=${PKG_DBDIR:-/var/db/pkg}/
 
-    COMPREPLY=($(compgen -d -- "$pkgdir$cur"))
+    _comp_compgen -c "$pkgdir$cur" -- -d
     COMPREPLY=(${COMPREPLY[@]#$pkgdir})
     COMPREPLY=(${COMPREPLY[@]%-*})
 

--- a/completions/postfix
+++ b/completions/postfix
@@ -11,7 +11,7 @@ _comp_cmd_postfix()
             return
             ;;
         -D)
-            COMPREPLY=($(compgen -W 'start' -- "$cur"))
+            _comp_compgen -- -W 'start'
             return
             ;;
     esac

--- a/completions/postmap
+++ b/completions/postmap
@@ -32,7 +32,7 @@ _comp_cmd_postmap()
         done
         if [[ ! ${COMPREPLY-} ]]; then
             compopt -o filenames
-            COMPREPLY=($(compgen -f -- "$cur"))
+            _comp_compgen -- -f
         fi
     fi
 } &&

--- a/completions/postmap
+++ b/completions/postmap
@@ -22,7 +22,7 @@ _comp_cmd_postmap()
 
     if [[ $cur == *:* ]]; then
         compopt -o filenames
-        COMPREPLY=($(compgen -f -- "${cur#*:}"))
+        _comp_compgen -c "${cur#*:}" -- -f
     else
         local len=${#cur} pval
         for pval in $(/usr/sbin/postconf -m 2>/dev/null); do

--- a/completions/postsuper
+++ b/completions/postsuper
@@ -50,7 +50,7 @@ _comp_cmd_postsuper()
         return
     fi
 
-    COMPREPLY=($(compgen -W 'hold incoming active deferred' -- "$cur"))
+    _comp_compgen -- -W 'hold incoming active deferred'
 } &&
     complete -F _comp_cmd_postsuper postsuper
 

--- a/completions/printenv
+++ b/completions/printenv
@@ -16,7 +16,7 @@ _comp_cmd_printenv()
         return
     fi
 
-    COMPREPLY=($(compgen -v -- "$cur"))
+    _comp_compgen -- -v
 } &&
     complete -F _comp_cmd_printenv printenv
 

--- a/completions/protoc
+++ b/completions/protoc
@@ -14,13 +14,13 @@ _comp_cmd_protoc()
             return
             ;;
         --error_format)
-            COMPREPLY=($(compgen -W 'gcc msvs' -- "$cur"))
+            _comp_compgen -- -W 'gcc msvs'
             return
             ;;
         --plugin)
             if [[ $cur != *=* ]]; then
                 compopt -o filenames
-                COMPREPLY=($(compgen -c -- "$cur"))
+                _comp_compgen -- -c
             fi
             return
             ;;

--- a/completions/ps
+++ b/completions/ps
@@ -19,7 +19,7 @@ _comp_cmd_ps()
             return
             ;;
         -[Gg] | --[Gg]roup)
-            COMPREPLY=($(compgen -g -- "$cur"))
+            _comp_compgen -- -g
             return
             ;;
         ?(-)p | [^-]*p | --pid)
@@ -46,7 +46,7 @@ _comp_cmd_ps()
             return
             ;;
         ?(-)U | [^-]*U | -u | --[Uu]ser)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         --format | ?(-)[Oo] | [^-]*[Oo])

--- a/completions/psql
+++ b/completions/psql
@@ -13,7 +13,7 @@ _comp_cmd_psql__users()
     # -w was introduced in 8.4, https://launchpad.net/bugs/164772
     COMPREPLY=($(compgen -W "$(psql -XAtqwc 'select usename from pg_user' \
         template1 2>/dev/null)" -- "$cur"))
-    ((${#COMPREPLY[@]} == 0)) && COMPREPLY=($(compgen -u -- "$cur"))
+    ((${#COMPREPLY[@]} == 0)) && _comp_compgen -- -u
 }
 
 # createdb(1) completion

--- a/completions/puppet
+++ b/completions/puppet
@@ -3,16 +3,16 @@
 _comp_cmd_puppet__logdest()
 {
     if [[ ! $cur ]]; then
-        COMPREPLY=($(compgen -W 'syslog console /' -- "$cur"))
+        _comp_compgen -- -W 'syslog console /'
     else
-        COMPREPLY=($(compgen -W 'syslog console' -- "$cur"))
+        _comp_compgen -- -W 'syslog console'
         _comp_compgen -a filedir
     fi
 }
 
 _comp_cmd_puppet__digest()
 {
-    COMPREPLY=($(compgen -W 'MD5 MD2 SHA1 SHA256' -- "$cur"))
+    _comp_compgen -- -W 'MD5 MD2 SHA1 SHA256'
 }
 
 _comp_cmd_puppet__certs()
@@ -140,11 +140,11 @@ _comp_cmd_puppet()
                     return
                     ;;
                 --masterport)
-                    COMPREPLY=($(compgen -W '8140' -- "$cur"))
+                    _comp_compgen -- -W '8140'
                     return
                     ;;
                 -w | --waitforcert)
-                    COMPREPLY=($(compgen -W '0 15 30 60 120' -- "$cur"))
+                    _comp_compgen -- -W '0 15 30 60 120'
                     return
                     ;;
                 *)
@@ -158,7 +158,7 @@ _comp_cmd_puppet()
         apply)
             case $prev in
                 --catalog)
-                    COMPREPLY=($(compgen -W '-' -- "$cur"))
+                    _comp_compgen -- -W '-'
                     _comp_compgen -a filedir json
                     return
                     ;;
@@ -233,7 +233,7 @@ _comp_cmd_puppet()
                     return
                     ;;
                 -m | --mode)
-                    COMPREPLY=($(compgen -W 'text trac pdf rdoc' -- "$cur"))
+                    _comp_compgen -- -W 'text trac pdf rdoc'
                     return
                     ;;
                 -r | --reference)
@@ -316,7 +316,7 @@ _comp_cmd_puppet()
                     return
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'validate' -- "$cur"))
+                    _comp_compgen -- -W 'validate'
                     return
                     ;;
             esac

--- a/completions/puppet
+++ b/completions/puppet
@@ -29,7 +29,7 @@ _comp_cmd_puppet__certs()
     else
         cert_list=$("$puppetca" --list)
     fi
-    COMPREPLY+=($(compgen -W "$cert_list" -- "$cur"))
+    _comp_compgen -a -- -W "$cert_list"
 }
 
 _comp_cmd_puppet__types()
@@ -37,7 +37,7 @@ _comp_cmd_puppet__types()
     puppet_types=$(
         puppet describe --list | command sed -e 's/^\(\S\{1,\}\).*$/\1/'
     )
-    COMPREPLY+=($(compgen -W "$puppet_types" -- "$cur"))
+    _comp_compgen -a -- -W "$puppet_types"
 }
 
 _comp_cmd_puppet__references()
@@ -49,7 +49,7 @@ _comp_cmd_puppet__references()
     puppet_doc_list=$(
         $puppetdoc --list | command sed -e 's/^\(\S\{1,\}\).*$/\1/'
     )
-    COMPREPLY+=($(compgen -W "$puppet_doc_list" -- "$cur"))
+    _comp_compgen -a -- -W "$puppet_doc_list"
 }
 
 _comp_cmd_puppet__subcmd_opts()
@@ -150,7 +150,7 @@ _comp_cmd_puppet()
                 *)
                     _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     # _parse_usage doesn't grok [-D|--daemonize|--no-daemonize]
-                    COMPREPLY+=($(compgen -W '--no-daemonize' -- "$cur"))
+                    _comp_compgen -a -- -W '--no-daemonize'
                     return
                     ;;
             esac
@@ -192,7 +192,7 @@ _comp_cmd_puppet()
                     case $action in
                         fingerprint | list | verify | --fingerprint | --list | \
                             --verify)
-                            COMPREPLY+=($(compgen -W '--all' -- "$cur"))
+                            _comp_compgen -a -- -W '--all'
                             _comp_cmd_puppet__certs --all
                             return
                             ;;
@@ -205,7 +205,7 @@ _comp_cmd_puppet()
                             return
                             ;;
                         sign | --sign)
-                            COMPREPLY+=($(compgen -W '--all' -- "$cur"))
+                            _comp_compgen -a -- -W '--all'
                             _comp_cmd_puppet__certs
                             return
                             ;;
@@ -303,7 +303,7 @@ _comp_cmd_puppet()
                 *)
                     _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     # _parse_usage doesn't grok [-D|--daemonize|--no-daemonize]
-                    COMPREPLY+=($(compgen -W '--no-daemonize' -- "$cur"))
+                    _comp_compgen -a -- -W '--no-daemonize'
                     return
                     ;;
             esac

--- a/completions/pwdx
+++ b/completions/pwdx
@@ -12,9 +12,9 @@ _comp_cmd_pwdx()
     esac
 
     if [[ $cur == -* ]]; then
-        local help='$(_parse_help "$1")'
+        local help=$(_parse_help "$1")
         [[ $help ]] || help=-V
-        COMPREPLY=($(compgen -W "$help" -- "$cur"))
+        COMPREPLY=($(compgen -W '$help' -- "$cur"))
     else
         _pids
     fi

--- a/completions/pwdx
+++ b/completions/pwdx
@@ -14,7 +14,7 @@ _comp_cmd_pwdx()
     if [[ $cur == -* ]]; then
         local help=$(_parse_help "$1")
         [[ $help ]] || help=-V
-        COMPREPLY=($(compgen -W '$help' -- "$cur"))
+        _comp_compgen -- -W '$help'
     else
         _pids
     fi

--- a/completions/pycodestyle
+++ b/completions/pycodestyle
@@ -10,7 +10,7 @@ _comp_cmd_pycodestyle()
             return
             ;;
         --format)
-            COMPREPLY=($(compgen -W 'default pylint' -- "$cur"))
+            _comp_compgen -- -W 'default pylint'
             return
             ;;
         --config)

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -22,7 +22,7 @@ _comp_cmd_pydoc()
         return
     fi
 
-    COMPREPLY=($(compgen -W 'keywords topics modules' -- "$cur"))
+    _comp_compgen -- -W 'keywords topics modules'
 
     if ! _comp_looks_like_path "$cur"; then
         local python=python

--- a/completions/pydocstyle
+++ b/completions/pydocstyle
@@ -15,7 +15,7 @@ _comp_cmd_pydocstyle()
             return
             ;;
         --convention)
-            COMPREPLY=($(compgen -W "pep257 numpy" -- "$cur"))
+            _comp_compgen -- -W "pep257 numpy"
             return
             ;;
     esac

--- a/completions/pylint
+++ b/completions/pylint
@@ -68,7 +68,7 @@ _comp_cmd_pylint()
             --reports | --comment | --ignore-comments | --ignore-docstrings | \
             --ignore-imports | --init-import | --ignore-mixin-members | \
             --zope | --suggestion-mode | -${noargopts}[isr])
-            COMPREPLY=($(compgen -W 'yes no' -- "$cur"))
+            _comp_compgen -- -W 'yes no'
             return
             ;;
         --load-plugins | --deprecated-modules)

--- a/completions/pylint
+++ b/completions/pylint
@@ -57,7 +57,7 @@ _comp_cmd_pylint()
             ;;
         --disable | -${noargopts}d)
             _comp_cmd_pylint__message_ids "$1" Enabled
-            COMPREPLY+=($(compgen -W 'all' -- "$cur"))
+            _comp_compgen -a -- -W 'all'
             return
             ;;
         --rcfile)

--- a/completions/pytest
+++ b/completions/pytest
@@ -5,7 +5,7 @@ _comp_cmd_pytest__option_choice_args()
     local modes=$("${2:-pytest}" "$1=bash-completion-nonexistent" 2>&1 |
         command sed -e 's/[^[:space:][:alnum:]-]\{1,\}//g' \
             -ne 's/.*choose from //p')
-    COMPREPLY+=($(compgen -W '$modes' -- "$cur"))
+    _comp_compgen -a -- -W '$modes'
 }
 
 _comp_cmd_pytest()

--- a/completions/pytest
+++ b/completions/pytest
@@ -21,15 +21,15 @@ _comp_cmd_pytest()
             return
             ;;
         --import-mode)
-            COMPREPLY=($(compgen -W "prepend append" -- "$cur"))
+            _comp_compgen -- -W "prepend append"
             return
             ;;
         --capture)
-            COMPREPLY=($(compgen -W "fd sys no tee-sys" -- "$cur"))
+            _comp_compgen -- -W "fd sys no tee-sys"
             return
             ;;
         --lfnf | --last-failed-no-failures)
-            COMPREPLY=($(compgen -W "all none" -- "$cur"))
+            _comp_compgen -- -W "all none"
             return
             ;;
         --tb)
@@ -38,15 +38,15 @@ _comp_cmd_pytest()
             return
             ;;
         --show-capture)
-            COMPREPLY=($(compgen -W "no stdout stderr log all" -- "$cur"))
+            _comp_compgen -- -W "no stdout stderr log all"
             return
             ;;
         --color)
-            COMPREPLY=($(compgen -W "yes no auto" -- "$cur"))
+            _comp_compgen -- -W "yes no auto"
             return
             ;;
         --pastebin)
-            COMPREPLY=($(compgen -W "failed all" -- "$cur"))
+            _comp_compgen -- -W "failed all"
             return
             ;;
         --junit-xml)
@@ -72,7 +72,7 @@ _comp_cmd_pytest()
             return
             ;;
         --assert)
-            COMPREPLY=($(compgen -W "plain reinterp rewrite" -- "$cur"))
+            _comp_compgen -- -W "plain reinterp rewrite"
             return
             ;;
         --genscript)

--- a/completions/python
+++ b/completions/python
@@ -58,7 +58,7 @@ _comp_cmd_python()
             ;;
         --jit)
             # TODO: quite a few others, parse from "--jit help" output?
-            COMPREPLY=($(compgen -W "help off" -- "$cur"))
+            _comp_compgen -- -W "help off"
             return
             ;;
         !(?(*/)python*([0-9.])|?(*/)pypy*([0-9.])|-?))

--- a/completions/qemu
+++ b/completions/qemu
@@ -16,14 +16,14 @@ _comp_cmd_qemu()
             return
             ;;
         -boot)
-            COMPREPLY=($(compgen -W 'a c d n' -- "$cur"))
+            _comp_compgen -- -W 'a c d n'
             return
             ;;
         -k)
             local -a keymaps
             _comp_expand_glob keymaps '/usr/{local/,}share/qemu/keymaps/!(common|modifiers)'
             ((${#keymaps[@]})) &&
-                COMPREPLY=($(compgen -W '"${keymaps[@]##*/}"}' -- "$cur"))
+                _comp_compgen -- -W '"${keymaps[@]##*/}"}'
             return
             ;;
         -soundhw)
@@ -57,15 +57,15 @@ _comp_cmd_qemu()
             return
             ;;
         -redir)
-            COMPREPLY=($(compgen -S":" -W 'tcp udp' -- "$cur"))
+            _comp_compgen -- -S":" -W 'tcp udp'
             return
             ;;
         -bt)
-            COMPREPLY=($(compgen -W 'hci vhci device' -- "$cur"))
+            _comp_compgen -- -W 'hci vhci device'
             return
             ;;
         -vga)
-            COMPREPLY=($(compgen -W 'cirrus std vmware xenfb none' -- "$cur"))
+            _comp_compgen -- -W 'cirrus std vmware xenfb none'
             return
             ;;
         -drive)
@@ -74,11 +74,11 @@ _comp_cmd_qemu()
             return
             ;;
         -balloon)
-            COMPREPLY=($(compgen -W 'none virtio' -- "$cur"))
+            _comp_compgen -- -W 'none virtio'
             return
             ;;
         -smbios)
-            COMPREPLY=($(compgen -W 'file type' -- "$cur"))
+            _comp_compgen -- -W 'file type'
             return
             ;;
         -watchdog)

--- a/completions/querybts
+++ b/completions/querybts
@@ -14,12 +14,12 @@ _comp_cmd_querybts()
             return
             ;;
         --ui | --interface | -${noargopts}u)
-            COMPREPLY=($(compgen -W "newt text gnome" -- "$cur"))
+            _comp_compgen -- -W "newt text gnome"
             return
             ;;
         --mbox-reader-cmd)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac

--- a/completions/quota
+++ b/completions/quota
@@ -7,13 +7,13 @@ _comp_cmd_quota__user_or_group()
     # complete on groups if -g was given
     for ((i = 1; i < cword; i++)); do
         if [[ ${words[i]} == -@(g|-group) ]]; then
-            COMPREPLY=($(compgen -g -- "$cur"))
+            _comp_compgen -- -g
             return
         fi
     done
 
     # otherwise complete on users
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 }
 
 _comp_cmd_quota__parse_help()
@@ -26,7 +26,7 @@ _comp_cmd_quota__parse_help()
 
 _comp_cmd_quota__formats()
 {
-    COMPREPLY=($(compgen -W 'vfsold vfsv0 rpc xfs' -- "$cur"))
+    _comp_compgen -- -W 'vfsold vfsv0 rpc xfs'
 }
 
 _comp_cmd_quota__filesystems()
@@ -171,7 +171,7 @@ _comp_cmd_quotaon()
             return
             ;;
         -x | --xfs-command)
-            COMPREPLY=($(compgen -W 'delete enforce' -- "$cur"))
+            _comp_compgen -- -W 'delete enforce'
             return
             ;;
         -h | --help | -V | --version)

--- a/completions/radvdump
+++ b/completions/radvdump
@@ -10,7 +10,7 @@ _comp_cmd_radvdump()
             return
             ;;
         -d | --debug)
-            COMPREPLY=($(compgen -W '{1..4}' -- "$cur"))
+            _comp_compgen -- -W '{1..4}'
             return
             ;;
     esac

--- a/completions/rcs
+++ b/completions/rcs
@@ -13,7 +13,7 @@ _comp_cmd_rcs()
     # deal with relative directory
     [[ $file == "$dir" ]] && dir=.
 
-    COMPREPLY=($(compgen -f -- "$dir/RCS/$file"))
+    _comp_compgen -c "$dir/RCS/$file" -- -f
 
     for i in ${!COMPREPLY[*]}; do
         file=${COMPREPLY[i]##*/}

--- a/completions/rcs
+++ b/completions/rcs
@@ -21,7 +21,7 @@ _comp_cmd_rcs()
         COMPREPLY[i]=$dir$file
     done
 
-    COMPREPLY+=($(compgen -G "$dir/$file*,v"))
+    _comp_compgen -aR -- -G "$dir/$file*,v"
 
     for i in ${!COMPREPLY[*]}; do
         COMPREPLY[i]=${COMPREPLY[i]%,v}

--- a/completions/rdesktop
+++ b/completions/rdesktop
@@ -13,15 +13,15 @@ _comp_cmd_rdesktop()
             COMPREPLY+=($(command ls "$HOME/.rdesktop/keymaps" 2>/dev/null))
             COMPREPLY+=($(command ls ./keymaps 2>/dev/null))
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return
             ;;
         -*a)
-            COMPREPLY=($(compgen -W '8 15 16 24' -- "$cur"))
+            _comp_compgen -- -W '8 15 16 24'
             return
             ;;
         -*x)
-            COMPREPLY=($(compgen -W 'broadband modem lan' -- "$cur"))
+            _comp_compgen -- -W 'broadband modem lan'
             return
             ;;
         -*r)
@@ -48,7 +48,7 @@ _comp_cmd_rdesktop()
     if [[ $cur == -* ]]; then
         local opts=($(_parse_help "$1"))
         ((${#opts[@]})) &&
-            COMPREPLY=($(compgen -W '"${opts[@]%:}"}' -- "$cur"))
+            _comp_compgen -- -W '"${opts[@]%:}"}'
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/removepkg
+++ b/completions/removepkg
@@ -5,7 +5,7 @@ _comp_cmd_removepkg()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-copy -keep -preserve -warn' -- "$cur"))
+        _comp_compgen -- -W '-copy -keep -preserve -warn'
         return
     fi
 

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -39,7 +39,7 @@ _comp_cmd_reportbug()
             ;;
         --editor | --mua | --mbox-reader-cmd | -${noargopts}e)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --from-buildd)

--- a/completions/resolvconf
+++ b/completions/resolvconf
@@ -13,7 +13,7 @@ _comp_cmd_resolvconf()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-a -d -u' -- "$cur"))
+        _comp_compgen -- -W '-a -d -u'
     fi
 } &&
     complete -F _comp_cmd_resolvconf resolvconf

--- a/completions/ri
+++ b/completions/ri
@@ -45,7 +45,7 @@ _comp_cmd_ri()
             return
             ;;
         --format | -${noargopts}f)
-            COMPREPLY=($(compgen -W 'ansi bs html rdoc' -- "$cur"))
+            _comp_compgen -- -W 'ansi bs html rdoc'
             return
             ;;
         --doc-dir | -${noargopts}d)
@@ -107,7 +107,7 @@ _comp_cmd_ri()
     fi
 
     ((${#classes[@]})) &&
-        COMPREPLY=($(compgen -W '"${classes[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${classes[@]}"'
     _comp_ltrim_colon_completions "$cur"
 
     if [[ $cur == [A-Z]* ]]; then

--- a/completions/ri
+++ b/completions/ri
@@ -29,7 +29,7 @@ _comp_cmd_ri__methods()
             end' | sort -u)")
     fi
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen "$prefix" -W '"${COMPREPLY[@]}"' -- "$method"))
+        _comp_compgen -c "$method" -- "$prefix" -W '"${COMPREPLY[@]}"'
 }
 
 # needs at least Ruby 1.8.0 in order to use -W0

--- a/completions/rmlist
+++ b/completions/rmlist
@@ -6,7 +6,7 @@ _comp_cmd_rmlist()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--archives --help' -- "$cur"))
+        _comp_compgen -- -W '--archives --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/route
+++ b/completions/route
@@ -24,7 +24,7 @@ _comp_cmd_route()
     done
 
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${COMPREPLY[@]}"'
 } &&
     complete -F _comp_cmd_route route
 

--- a/completions/rpcdebug
+++ b/completions/rpcdebug
@@ -32,7 +32,7 @@ _comp_cmd_rpcdebug()
             return
             ;;
         -*m)
-            COMPREPLY=($(compgen -W 'rpc nfs nfsd nlm' -- "$cur"))
+            _comp_compgen -- -W 'rpc nfs nfsd nlm'
             return
             ;;
     esac

--- a/completions/rpm
+++ b/completions/rpm
@@ -61,7 +61,7 @@ _comp_cmd_rpm()
                     -- "$cur"))
                 ;;
             *)
-                COMPREPLY=($(compgen -W '-e -E -F -i -q -t -U -V' -- "$cur"))
+                _comp_compgen -- -W '-e -E -F -i -q -t -U -V'
                 ;;
         esac
         return
@@ -80,7 +80,7 @@ _comp_cmd_rpm()
             ;;
         --pipe)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --rcfile)

--- a/completions/rpm2tgz
+++ b/completions/rpm2tgz
@@ -6,7 +6,7 @@ _comp_cmd_rpm2tgz()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-s -S -n -r -d -c' -- "$cur"))
+        _comp_compgen -- -W '-s -S -n -r -d -c'
         return
     fi
 

--- a/completions/rsync
+++ b/completions/rsync
@@ -23,12 +23,12 @@ _comp_cmd_rsync()
             ;;
         --rsh | -${noargopts}e)
             compopt +o nospace
-            COMPREPLY=($(compgen -W 'rsh ssh' -- "$cur"))
+            _comp_compgen -- -W 'rsh ssh'
             return
             ;;
         --compress-level)
             compopt +o nospace
-            COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+            _comp_compgen -- -W '{1..9}'
             return
             ;;
         --info)

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -12,7 +12,7 @@ _comp_cmd_sbopkg()
 
     case "$prev" in
         -e)
-            COMPREPLY=($(compgen -W 'ask continue stop' -- "$cur"))
+            _comp_compgen -- -W 'ask continue stop'
             return
             ;;
         -f)

--- a/completions/screen
+++ b/completions/screen
@@ -7,7 +7,7 @@ _comp_cmd_screen__sessions()
     ((${#sessions[@]} == 0)) && return
     if [[ $cur == +([0-9])?(.*) ]]; then
         # Complete sessions including pid prefixes
-        COMPREPLY=($(compgen -W '"${sessions[@]}"' -- "$cur"))
+        _comp_compgen -- -W '"${sessions[@]}"'
     else
         # Create unique completions, dropping pids where possible
         local -A res
@@ -18,7 +18,7 @@ _comp_cmd_screen__sessions()
         for i in "${!res[@]}"; do
             [[ ${res[i]} == \ *\ * ]] && tmp+=" ${res[i]}" || tmp+=" $i"
         done
-        COMPREPLY=($(compgen -W '$tmp' -- "$cur"))
+        _comp_compgen -- -W '$tmp'
     fi
 } &&
     _comp_cmd_screen()
@@ -30,11 +30,11 @@ _comp_cmd_screen__sessions()
             if [[ $cur == /dev* ]]; then
                 _comp_expand_glob COMPREPLY '/dev/serial/*/* /dev/ttyUSB* /dev/ttyACM*'
                 ((${#COMPREPLY[@]})) &&
-                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${COMPREPLY[@]}"'
                 return
             fi
             if [[ $cur == //* ]]; then
-                COMPREPLY=($(compgen -W '//telnet' -- "$cur"))
+                _comp_compgen -- -W '//telnet'
                 return
             fi
         fi

--- a/completions/secret-tool
+++ b/completions/secret-tool
@@ -26,14 +26,14 @@ _comp_cmd_secret_tool()
                 fi
             done))
         ((${#modes[@]})) &&
-            COMPREPLY=($(compgen -W '"${modes[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${modes[@]}"'
         return
     fi
 
     case $mode in
         store)
             if [[ ${words[*]} != *\ --label[\ =]* ]]; then
-                COMPREPLY=($(compgen -W "--label=" -- "$cur"))
+                _comp_compgen -- -W "--label="
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             fi
             ;;
@@ -43,7 +43,7 @@ _comp_cmd_secret_tool()
                 [[ $word ]] && unset -v 'opts[$word]'
             done
             ((${#opts[@]})) &&
-                COMPREPLY=($(compgen -W '"${!opts[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${!opts[@]}"'
             ;;
     esac
 } &&

--- a/completions/sh
+++ b/completions/sh
@@ -19,10 +19,10 @@ _comp_cmd_sh()
 
     local opts="-a -b -C -e -f -h -i -m -n -o -u -v -x"
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W "$opts -c -s" -- "$cur"))
+        _comp_compgen -- -W "$opts -c -s"
         return
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W "${opts//-/+}" -- "$cur"))
+        _comp_compgen -- -W "${opts//-/+}"
         return
     fi
 

--- a/completions/sha256sum
+++ b/completions/sha256sum
@@ -31,7 +31,7 @@ _comp_cmd_sha256sum()
 
     _comp_compgen_filedir
     ((${#COMPREPLY[@]})) &&
-        COMPREPLY=($(compgen -X "*.$sumtype" -W '"${COMPREPLY[@]}"' -- "$cur"))
+        _comp_compgen -- -X "*.$sumtype" -W '"${COMPREPLY[@]}"'
 } &&
     complete -F _comp_cmd_sha256sum md5sum sha{,1,224,256,384,512}sum
 

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -4,7 +4,7 @@ _comp_cmd_shellcheck__optarg()
 {
     local args=$("$1" --help 2>&1 |
         command sed -e 's/,/ /g' -ne 's/^.*'"$2"'\>.*(\([^)]*\)).*/\1/p')
-    COMPREPLY+=($(compgen -W '$args' -- "$cur"))
+    _comp_compgen -a -- -W '$args'
 }
 
 _comp_cmd_shellcheck()
@@ -42,7 +42,7 @@ _comp_cmd_shellcheck()
             ;;
         --source-path | -${noargopts}P)
             _comp_compgen_filedir -d
-            COMPREPLY+=($(compgen -W 'SCRIPTDIR' -- "$cur"))
+            _comp_compgen -a -- -W 'SCRIPTDIR'
             return
             ;;
         --wiki-link-count | -${noargopts}W)

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -25,7 +25,7 @@ _comp_cmd_shellcheck()
             local args=$("$1" --format=nonexistent-format /dev/null 2>&1 |
                 command sed -ne '/^Supported formats/,//p' |
                 command sed -ne '/^[[:space:]]/p')
-            COMPREPLY=($(compgen -W '$args' -- "$cur"))
+            _comp_compgen -- -W '$args'
             return
             ;;
         --color | -${noargopts}C)
@@ -37,7 +37,7 @@ _comp_cmd_shellcheck()
             return
             ;;
         --enable | -${noargopts}o)
-            COMPREPLY=($(compgen -W 'all' -- "$cur")) # TODO others?
+            _comp_compgen -- -W 'all' # TODO others?
             return
             ;;
         --source-path | -${noargopts}P)

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -5,12 +5,12 @@ _comp_cmd_smartctl__device()
     case $cur in
         areca* | 3ware* | megaraid* | cciss*)
             # shellcheck disable=SC2054
-            COMPREPLY+=(${cur%%,*},{0..31})
+            COMPREPLY=(${cur%%,*},{0..31})
             _comp_compgen -- -W '"${COMPREPLY[@]}"'
             ;;
         hpt*)
             # shellcheck disable=SC2054
-            COMPREPLY+=(hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5})
+            COMPREPLY=(hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5})
             _comp_compgen -- -W '"${COMPREPLY[@]}"'
             ;;
         *)

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -6,12 +6,12 @@ _comp_cmd_smartctl__device()
         areca* | 3ware* | megaraid* | cciss*)
             # shellcheck disable=SC2054
             COMPREPLY+=(${cur%%,*},{0..31})
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]}"'
             ;;
         hpt*)
             # shellcheck disable=SC2054
             COMPREPLY+=(hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5})
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]}"'
             ;;
         *)
             COMPREPLY=($(compgen -W "ata scsi sat usbcypress usbjmicron
@@ -53,7 +53,7 @@ _comp_cmd_smartctl()
     # shellcheck disable=SC2254
     case $prev in
         --quietmode | -${noargopts}q)
-            COMPREPLY=($(compgen -W 'errorsonly silent noserial' -- "$cur"))
+            _comp_compgen -- -W 'errorsonly silent noserial'
             return
             ;;
         --device | -${noargopts}d)
@@ -68,19 +68,19 @@ _comp_cmd_smartctl()
             return
             ;;
         --badsum | -${noargopts}b)
-            COMPREPLY=($(compgen -W 'warn exit ignore' -- "$cur"))
+            _comp_compgen -- -W 'warn exit ignore'
             return
             ;;
         --report | -${noargopts}r)
-            COMPREPLY=($(compgen -W 'ioctl ataioctl scsiioctl' -- "$cur"))
+            _comp_compgen -- -W 'ioctl ataioctl scsiioctl'
             return
             ;;
         --nocheck | -${noargopts}n)
-            COMPREPLY=($(compgen -W 'never sleep standby idle' -- "$cur"))
+            _comp_compgen -- -W 'never sleep standby idle'
             return
             ;;
         --smart | --offlineauto | --saveauto | -${noargopts}[soS])
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --log | -${noargopts}l)
@@ -105,7 +105,7 @@ _comp_cmd_smartctl()
             return
             ;;
         --presets | -${noargopts}P)
-            COMPREPLY=($(compgen -W 'use ignore show showall' -- "$cur"))
+            _comp_compgen -- -W 'use ignore show showall'
             return
             ;;
         --drivedb | -${noargopts}B)

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -4,14 +4,10 @@ _comp_cmd_smartctl__device()
 {
     case $cur in
         areca* | 3ware* | megaraid* | cciss*)
-            # shellcheck disable=SC2054
-            COMPREPLY=(${cur%%,*},{0..31})
-            _comp_compgen -- -W '"${COMPREPLY[@]}"'
+            _comp_compgen -- -W '${cur%%,*},{0..31}'
             ;;
         hpt*)
-            # shellcheck disable=SC2054
-            COMPREPLY=(hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5})
-            _comp_compgen -- -W '"${COMPREPLY[@]}"'
+            _comp_compgen -- -W 'hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5}'
             ;;
         *)
             COMPREPLY=($(compgen -W "ata scsi sat usbcypress usbjmicron

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -2,7 +2,7 @@
 
 _comp_cmd_smbclient__resolve_order()
 {
-    COMPREPLY=($(compgen -W 'lmhosts host wins bcast' -- "$cur"))
+    _comp_compgen -- -W 'lmhosts host wins bcast'
 }
 
 _comp_cmd_smbclient__domains()
@@ -24,7 +24,7 @@ _comp_cmd_smbclient__hosts()
 
 _comp_cmd_smbclient__debuglevel()
 {
-    COMPREPLY=($(compgen -W '{0..10}' -- "$cur"))
+    _comp_compgen -- -W '{0..10}'
 }
 
 _comp_cmd_smbclient__sockopts()
@@ -36,7 +36,7 @@ _comp_cmd_smbclient__sockopts()
 
 _comp_cmd_smbclient__signing()
 {
-    COMPREPLY=($(compgen -W 'on off required' -- "$cur"))
+    _comp_compgen -- -W 'on off required'
 }
 
 _comp_cmd_smbclient()
@@ -69,7 +69,7 @@ _comp_cmd_smbclient()
             return
             ;;
         -${noargopts}T)
-            COMPREPLY=($(compgen -W 'c x I X F b g q r N a' -- "$cur"))
+            _comp_compgen -- -W 'c x I X F b g q r N a'
             return
             ;;
         --workgroup | -${noargopts}W)

--- a/completions/sqlite3
+++ b/completions/sqlite3
@@ -18,7 +18,7 @@ _comp_cmd_sqlite3()
             ;;
         -cmd)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac

--- a/completions/ssh
+++ b/completions/ssh
@@ -110,19 +110,19 @@ _comp_cmd_ssh__suboption()
             pubkeyauthentication | rhostsrsaauthentication | \
             rsaauthentication | streamlocalbindunlink | \
             tcpkeepalive | useprivilegedport | visualhostkey)
-            COMPREPLY=($(compgen -W 'yes no' -- "$cur"))
+            _comp_compgen -- -W 'yes no'
             ;;
         addkeystoagent)
-            COMPREPLY=($(compgen -W 'yes ask confirm no' -- "$cur"))
+            _comp_compgen -- -W 'yes ask confirm no'
             ;;
         addressfamily)
-            COMPREPLY=($(compgen -W 'any inet inet6' -- "$cur"))
+            _comp_compgen -- -W 'any inet inet6'
             ;;
         bindaddress)
             _ip_addresses
             ;;
         canonicalizehostname)
-            COMPREPLY=($(compgen -W 'yes no always' -- "$cur"))
+            _comp_compgen -- -W 'yes no always'
             ;;
         identityfile)
             _comp_xfunc_ssh_identityfile
@@ -135,19 +135,19 @@ _comp_cmd_ssh__suboption()
             COMPREPLY=($(compgen -W '$(_comp_xfunc_ssh_query "$2" sig)' -- "$cur"))
             ;;
         cipher)
-            COMPREPLY=($(compgen -W 'blowfish des 3des' -- "$cur"))
+            _comp_compgen -- -W 'blowfish des 3des'
             ;;
         ciphers)
             _comp_cmd_ssh__ciphers "$2"
             ;;
         controlmaster)
-            COMPREPLY=($(compgen -W 'yes ask auto autoask no' -- "$cur"))
+            _comp_compgen -- -W 'yes ask auto autoask no'
             ;;
         compressionlevel)
-            COMPREPLY=($(compgen -W '{1..9}' -- "$cur"))
+            _comp_compgen -- -W '{1..9}'
             ;;
         fingerprinthash)
-            COMPREPLY=($(compgen -W 'md5 sha256' -- "$cur"))
+            _comp_compgen -- -W 'md5 sha256'
             ;;
         ipqos)
             COMPREPLY=($(compgen -W 'af1{1..4} af2{2..3} af3{1..3} af4{1..3}
@@ -179,33 +179,33 @@ _comp_cmd_ssh__suboption()
             local protocols=($(_comp_xfunc_ssh_query "$2" protocol-version))
             [[ $protocols ]] || protocols=(1 2)
             if ((${#protocols[@]} > 1)); then
-                COMPREPLY=($(compgen -W '"${protocols[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${protocols[@]}"'
             fi
             ;;
         proxyjump)
             _known_hosts_real -a ${configfile:+-F "$configfile"} -- "$cur"
             ;;
         proxycommand | remotecommand | localcommand)
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             ;;
         pubkeyacceptedalgorithms | pubkeyacceptedkeytypes)
             COMPREPLY=($(compgen -W '$(_comp_xfunc_ssh_query "$2" key)' -- "$cur"))
             ;;
         requesttty)
-            COMPREPLY=($(compgen -W 'no yes force auto' -- "$cur"))
+            _comp_compgen -- -W 'no yes force auto'
             ;;
         stricthostkeychecking)
-            COMPREPLY=($(compgen -W 'accept-new ask no off' -- "$cur"))
+            _comp_compgen -- -W 'accept-new ask no off'
             ;;
         syslogfacility)
-            COMPREPLY=($(compgen -W 'DAEMON USER AUTH LOCAL{0..7}' -- "$cur"))
+            _comp_compgen -- -W 'DAEMON USER AUTH LOCAL{0..7}'
             ;;
         tunnel)
             COMPREPLY=($(compgen -W 'yes no point-to-point ethernet' \
                 -- "$cur"))
             ;;
         updatehostkeys | verifyhostkeydns)
-            COMPREPLY=($(compgen -W 'yes no ask' -- "$cur"))
+            _comp_compgen -- -W 'yes no ask'
             ;;
     esac
     return 0
@@ -309,7 +309,7 @@ _comp_cmd_ssh()
             return
             ;;
         -*l)
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         -*m)
@@ -317,7 +317,7 @@ _comp_cmd_ssh()
             return
             ;;
         -*O)
-            COMPREPLY=($(compgen -W 'check forward cancel exit stop' -- "$cur"))
+            _comp_compgen -- -W 'check forward cancel exit stop'
             return
             ;;
         -*o)
@@ -402,7 +402,7 @@ _comp_cmd_sftp()
             ;;
         -*S)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         -*4*)
@@ -546,7 +546,7 @@ _comp_cmd_scp()
             ;;
         -*S)
             compopt +o nospace -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         -*4*)

--- a/completions/ssh
+++ b/completions/ssh
@@ -7,7 +7,7 @@ _comp_cmd_ssh__queries()
          key-plain key-sig protocol-version compression sig ciphers macs
          kexalgorithms pubkeyacceptedkeytypes hostkeyalgorithms
          hostbasedkeytypes hostbasedacceptedkeytypes"
-    COMPREPLY+=($(compgen -W "$queries help" -- "${cur,,}"))
+    _comp_compgen -ac "${cur,,}" -- -W "$queries help"
 }
 
 _comp_xfunc_ssh_query()

--- a/completions/ssh
+++ b/completions/ssh
@@ -23,7 +23,7 @@ _comp_cmd_ssh__ciphers()
     [[ $ciphers ]] || ciphers="3des-cbc aes128-cbc aes192-cbc aes256-cbc
         aes128-ctr aes192-ctr aes256-ctr arcfour128 arcfour256 arcfour
         blowfish-cbc cast128-cbc"
-    COMPREPLY+=($(compgen -W "$ciphers" -- "$cur"))
+    _comp_compgen -a -- -W "$ciphers"
 }
 
 _comp_cmd_ssh__macs()
@@ -31,7 +31,7 @@ _comp_cmd_ssh__macs()
     local macs=$(_comp_xfunc_ssh_query "$1" mac)
     [[ $macs ]] || macs="hmac-md5 hmac-sha1 umac-64@openssh.com hmac-ripemd160
         hmac-sha1-96 hmac-md5-96"
-    COMPREPLY+=($(compgen -W "$macs" -- "$cur"))
+    _comp_compgen -a -- -W "$macs"
 }
 
 _comp_xfunc_ssh_options()
@@ -352,7 +352,7 @@ _comp_cmd_ssh()
         _count_args "=" "-*[BbcDeLpRWEFSIiJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
-            COMPREPLY+=($(compgen -c -- "$cur"))
+            _comp_compgen -a -- -c
         else
             _known_hosts_real ${ipvx-} -a ${configfile:+-F "$configfile"} \
                 -- "$cur"

--- a/completions/ssh-add
+++ b/completions/ssh-add
@@ -7,7 +7,7 @@ _comp_cmd_ssh_add()
 
     case $prev in
         -*E)
-            COMPREPLY=($(compgen -W 'md5 sha256' -- "$cur"))
+            _comp_compgen -- -W 'md5 sha256'
             return
             ;;
         -*t)

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -79,17 +79,17 @@ _comp_cmd_ssh_keygen()
                 case $cur in
                     force-command=*)
                         compopt -o filenames
-                        COMPREPLY=($(compgen -c -- "${cur#*=}"))
+                        _comp_compgen -c "${cur#*=}" -- -c
                         ;;
                     checkpoint=* | challenge=* | write-attestation=*)
                         _comp_compgen -c "${cur#*=}" filedir
                         ;;
                     application=*([^:=]))
-                        COMPREPLY=($(compgen -W "ssh:" -- "${cur#*=}"))
+                        _comp_compgen -c "${cur#*=}" -- -W "ssh:"
                         compopt -o nospace
                         ;;
                     user=*)
-                        COMPREPLY=($(compgen -u -- "${cur#*=}"))
+                        _comp_compgen -c "${cur#*=}" -- -u
                         ;;
                 esac
             fi

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -23,11 +23,11 @@ _comp_cmd_ssh_keygen()
                     ;;
             esac
             ((${#sizes[@]})) &&
-                COMPREPLY=($(compgen -W '"${sizes[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${sizes[@]}"'
             return
             ;;
         -*E)
-            COMPREPLY=($(compgen -W 'md5 sha256' -- "$cur"))
+            _comp_compgen -- -W 'md5 sha256'
             return
             ;;
         -*[FR])
@@ -44,7 +44,7 @@ _comp_cmd_ssh_keygen()
             return
             ;;
         -*m)
-            COMPREPLY=($(compgen -W 'PEM PKCS8 RFC4716' -- "$cur"))
+            _comp_compgen -- -W 'PEM PKCS8 RFC4716'
             return
             ;;
         -*n)
@@ -105,7 +105,7 @@ _comp_cmd_ssh_keygen()
             if [[ $protocols == *1* ]]; then
                 types+=' rsa1'
             fi
-            COMPREPLY=($(compgen -W "$types" -- "$cur"))
+            _comp_compgen -- -W "$types"
             return
             ;;
         -*Y)
@@ -119,7 +119,7 @@ _comp_cmd_ssh_keygen()
     if [[ $cur == -* ]]; then
         local opts=$(_parse_usage "$1" "-?")
         [[ ! $opts ]] && opts=$(_parse_help "$1" "-?") # OpenSSH < 7
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+        _comp_compgen -- -W "$opts"
     fi
 
     if [[ ${words[*]} == *\ -*s\ * ]]; then

--- a/completions/strace
+++ b/completions/strace
@@ -78,7 +78,7 @@ _comp_cmd_strace()
                 return
                 ;;
             -*S)
-                COMPREPLY=($(compgen -W 'time calls name nothing' -- "$cur"))
+                _comp_compgen -- -W 'time calls name nothing'
                 return
                 ;;
             -*u)
@@ -90,7 +90,7 @@ _comp_cmd_strace()
         if [[ $cur == -* ]]; then
             COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
         else
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
         fi
     fi
 } &&

--- a/completions/strings
+++ b/completions/strings
@@ -47,8 +47,7 @@ _comp_cmd_strings()
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     elif [[ $cur == @* ]]; then
-        cur=${cur:1}
-        _comp_compgen_filedir
+        _comp_compgen -c "${cur:1}" filedir
         COMPREPLY=("${COMPREPLY[@]/#/@}")
         return
     fi

--- a/completions/strings
+++ b/completions/strings
@@ -13,7 +13,7 @@ _comp_cmd_strings()
             return
             ;;
         --radix | -${noargopts}t)
-            COMPREPLY=($(compgen -W 'o d x' -- "$cur"))
+            _comp_compgen -- -W 'o d x'
             return
             ;;
         --target | -${noargopts}T)

--- a/completions/sudo
+++ b/completions/sudo
@@ -30,11 +30,11 @@ _comp_cmd_sudo()
     # shellcheck disable=SC2254
     case "$prev" in
         --user | --other-user | -${noargopts}[uU])
-            COMPREPLY=($(compgen -u -- "$cur"))
+            _comp_compgen -- -u
             return
             ;;
         --group | -${noargopts}g)
-            COMPREPLY=($(compgen -g -- "$cur"))
+            _comp_compgen -- -g
             return
             ;;
         --close-from | --prompt | -${noargopts}[Cp])

--- a/completions/svcadm
+++ b/completions/svcadm
@@ -113,29 +113,29 @@ _comp_cmd_svcadm()
 
     if [[ ! $command ]]; then
         if [[ ${cur} == -* ]]; then
-            COMPREPLY=($(compgen -W "-v" -- "${cur}"))
+            _comp_compgen -- -W "-v"
         else
-            COMPREPLY=($(compgen -W "$command_list" -- "${cur}"))
+            _comp_compgen -- -W "$command_list"
         fi
     else
         if [[ ${cur} == -* ]]; then
             case "$command" in
                 enable)
-                    COMPREPLY=($(compgen -W "-r -s -t" -- "${cur}"))
+                    _comp_compgen -- -W "-r -s -t"
                     ;;
                 disable)
-                    COMPREPLY=($(compgen -W "-s -t" -- "${cur}"))
+                    _comp_compgen -- -W "-s -t"
                     ;;
                 mark)
-                    COMPREPLY=($(compgen -W "-I -t" -- "${cur}"))
+                    _comp_compgen -- -W "-I -t"
                     ;;
                 milestone)
-                    COMPREPLY=($(compgen -W "-d" -- "${cur}"))
+                    _comp_compgen -- -W "-d"
                     ;;
             esac
         else
             if [[ $command == "mark" && $prev != @(degraded|maintenance) ]]; then
-                COMPREPLY=($(compgen -W "degraded maintenance" -- "${cur}"))
+                _comp_compgen -- -W "degraded maintenance"
             elif [[ $command == "milestone" ]]; then
                 _comp_cmd_svcadm__fmri "${cur}" "svc:/milestone"
             else

--- a/completions/svk
+++ b/completions/svk
@@ -16,9 +16,9 @@ _comp_cmd_svk()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--version' -- "$cur"))
+            _comp_compgen -- -W '--version'
         else
-            COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+            _comp_compgen -- -W "$commands"
         fi
     else
         case $prev in
@@ -172,7 +172,7 @@ _comp_cmd_svk()
             esac
             options+=" --help -h"
 
-            COMPREPLY=($(compgen -W "$options" -- "$cur"))
+            _comp_compgen -- -W "$options"
         else
             case $command in
                 help | h | \?)

--- a/completions/sync_members
+++ b/completions/sync_members
@@ -7,7 +7,7 @@ _comp_cmd_sync_members()
 
     case $prev in
         -w | -g | -d | --welcome-msg | --goodbye-msg | --digest)
-            COMPREPLY=($(compgen -W 'y n' -- "$cur"))
+            _comp_compgen -- -W 'y n'
             return
             ;;
         --file)

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -11,7 +11,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --init-rng | --debug | --validate)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --test)
@@ -28,43 +28,43 @@ _comp_cmd_sysbench()
             return
             ;;
         --file-io-mode)
-            COMPREPLY=($(compgen -W 'sync async fastmmap slowmmap' -- "$cur"))
+            _comp_compgen -- -W 'sync async fastmmap slowmmap'
             return
             ;;
         --file-extra-flags)
-            COMPREPLY=($(compgen -W 'sync dsync direct' -- "$cur"))
+            _comp_compgen -- -W 'sync dsync direct'
             return
             ;;
         --file-fsync-all | --file-fsync-end)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --file-fsync-mode)
-            COMPREPLY=($(compgen -W 'fsync fdatasync' -- "$cur"))
+            _comp_compgen -- -W 'fsync fdatasync'
             return
             ;;
         --memory-scope)
-            COMPREPLY=($(compgen -W 'global local' -- "$cur"))
+            _comp_compgen -- -W 'global local'
             return
             ;;
         --memory-hugetlb)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --memory-oper)
-            COMPREPLY=($(compgen -W 'read write none' -- "$cur"))
+            _comp_compgen -- -W 'read write none'
             return
             ;;
         --memory-access-mode)
-            COMPREPLY=($(compgen -W 'seq rnd' -- "$cur"))
+            _comp_compgen -- -W 'seq rnd'
             return
             ;;
         --oltp-test-mode)
-            COMPREPLY=($(compgen -W 'simple complex nontrx sp' -- "$cur"))
+            _comp_compgen -- -W 'simple complex nontrx sp'
             return
             ;;
         --oltp-read-only | --oltp-skip-trx | --oltp-quto-inc | --mysql-ssl)
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
         --oltp-nontrx-mode)
@@ -73,7 +73,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --oltp-dist-type)
-            COMPREPLY=($(compgen -W 'uniform gaussian special' -- "$cur"))
+            _comp_compgen -- -W 'uniform gaussian special'
             return
             ;;
         --db-driver)
@@ -83,7 +83,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --db-ps-mode)
-            COMPREPLY=($(compgen -W 'auto disable' -- "$cur"))
+            _comp_compgen -- -W 'auto disable'
             return
             ;;
         --mysql-socket)
@@ -96,7 +96,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --mysql-engine-trx)
-            COMPREPLY=($(compgen -W 'yes no auto' -- "$cur"))
+            _comp_compgen -- -W 'yes no auto'
             return
             ;;
         --*)
@@ -122,10 +122,10 @@ _comp_cmd_sysbench()
     fi
 
     if [[ $cur == -* || ! $has_test ]]; then
-        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
+        _comp_compgen -- -W "$opts"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W "prepare run cleanup help version" -- "$cur"))
+        _comp_compgen -- -W "prepare run cleanup help version"
     fi
 } &&
     complete -F _comp_cmd_sysbench sysbench

--- a/completions/tar
+++ b/completions/tar
@@ -339,7 +339,7 @@ _comp_cmd_tar__mode()
 _comp_cmd_tar__gnu_long_options()
 {
     local rv
-    COMPREPLY=($(compgen -W "$long_opts" -- "$cur"))
+    _comp_compgen -- -W "$long_opts"
     rv=$?
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     return $rv
@@ -357,7 +357,7 @@ _comp_cmd_tar__gnu_short_options()
         generated+=" $cur$c"
     done
 
-    COMPREPLY=($(compgen -W "$generated" -- "$cur"))
+    _comp_compgen -- -W "$generated"
 }
 
 # TODO: rename per API conventions
@@ -555,30 +555,30 @@ _comp_cmd_tar__gnu()
                 break
                 ;;
             --hole-detection)
-                COMPREPLY=($(compgen -W 'raw seek' -- "$cur"))
+                _comp_compgen -- -W 'raw seek'
                 break
                 ;;
             --to-command | --info-script | --new-volume-script | \
                 --rmt-command | --rsh-command | --use-compress-program | \
                 -${noargopts}[FI])
                 compopt -o filenames
-                COMPREPLY=($(compgen -c -- "$cur"))
+                _comp_compgen -- -c
                 break
                 ;;
             --atime-preserve)
-                COMPREPLY=($(compgen -W 'replace system' -- "$cur"))
+                _comp_compgen -- -W 'replace system'
                 break
                 ;;
             --group)
-                COMPREPLY=($(compgen -g -- "$cur"))
+                _comp_compgen -- -g
                 break
                 ;;
             --owner)
-                COMPREPLY=($(compgen -u -- "$cur"))
+                _comp_compgen -- -u
                 break
                 ;;
             --sort)
-                COMPREPLY=($(compgen -W 'none name inode' -- "$cur"))
+                _comp_compgen -- -W 'none name inode'
                 break
                 ;;
             --file | -${noargopts}f)

--- a/completions/tar
+++ b/completions/tar
@@ -308,7 +308,7 @@ _comp_cmd_tar__mode()
             generated+=" $filler$cur$c"
         done
 
-        COMPREPLY=($(compgen -W "$generated"))
+        _comp_compgen -R -- -W "$generated"
         return 0
     fi
 
@@ -331,7 +331,7 @@ _comp_cmd_tar__mode()
         generated+=" $cur$c"
     done
 
-    COMPREPLY=($(compgen -W "$generated"))
+    _comp_compgen -R -- -W "$generated"
 
     return 0
 }

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -28,7 +28,7 @@ _comp_cmd_tcpdump()
             ;;
         -${noargopts}z)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
         --relinquish-privileges | -${noargopts}Z)
@@ -44,11 +44,11 @@ _comp_cmd_tcpdump()
             return
             ;;
         --direction | -${noargopts}Q)
-            COMPREPLY=($(compgen -W 'in out inout' -- "$cur"))
+            _comp_compgen -- -W 'in out inout'
             return
             ;;
         --time-stamp-precision)
-            COMPREPLY=($(compgen -W 'micro nano' -- "$cur"))
+            _comp_compgen -- -W 'micro nano'
             return
             ;;
     esac

--- a/completions/tcpkill
+++ b/completions/tcpkill
@@ -13,7 +13,7 @@ _comp_cmd_tcpkill()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-i -1 -2 -3 -4 -5 -6 -7 -8 -9' -- "$cur"))
+        _comp_compgen -- -W '-i -1 -2 -3 -4 -5 -6 -7 -8 -9'
     fi
 
 } &&

--- a/completions/tipc
+++ b/completions/tipc
@@ -5,10 +5,10 @@ _comp_cmd_tipc__media()
     local optind=$1
 
     if ((cword == optind)); then
-        COMPREPLY=($(compgen -W 'media' -- "$cur"))
+        _comp_compgen -- -W 'media'
         return 0
     elif ((cword == optind + 1)); then
-        COMPREPLY=($(compgen -W 'udp eth ib' -- "$cur"))
+        _comp_compgen -- -W 'udp eth ib'
         return 0
     fi
 
@@ -33,10 +33,10 @@ _comp_cmd_tipc__bearer()
     if ((cword == optind + 2)); then
         case "$media" in
             "udp")
-                COMPREPLY=($(compgen -W 'name' -- "$cur"))
+                _comp_compgen -- -W 'name'
                 ;;
             "eth" | "ib")
-                COMPREPLY=($(compgen -W 'device' -- "$cur"))
+                _comp_compgen -- -W 'device'
                 ;;
         esac
     elif ((cword == optind + 3)); then
@@ -45,11 +45,11 @@ _comp_cmd_tipc__bearer()
                 local names=$(
                     tipc bearer list 2>/dev/null | awk -F: '/^udp:/ {print $2}'
                 )
-                COMPREPLY=($(compgen -W '$names' -- "$cur"))
+                _comp_compgen -- -W '$names'
                 ;;
             "eth")
                 local interfaces=$(command ls /sys/class/net/)
-                COMPREPLY=($(compgen -W '$interfaces' -- "$cur"))
+                _comp_compgen -- -W '$interfaces'
                 ;;
         esac
     fi
@@ -57,7 +57,7 @@ _comp_cmd_tipc__bearer()
 
 _comp_cmd_tipc__link_opts()
 {
-    COMPREPLY=($(compgen -W 'priority tolerance window' -- "$cur"))
+    _comp_compgen -- -W 'priority tolerance window'
 }
 
 _comp_cmd_tipc__link()
@@ -66,14 +66,14 @@ _comp_cmd_tipc__link()
     local filter=$2
 
     if ((cword == optind)); then
-        COMPREPLY=($(compgen -W 'link' -- "$cur"))
+        _comp_compgen -- -W 'link'
     elif ((cword == optind + 1)); then
         # awk drops link state and last trailing :
         local links=$(tipc link list 2>/dev/null |
             awk '{print substr($1, 0, length($1))}')
         local -a exclude
         [[ $filter == peers ]] && exclude=(-X broadcast-link)
-        COMPREPLY=($(compgen "${exclude[@]}" -W '$links' -- "$cur"))
+        _comp_compgen -- "${exclude[@]}" -W '$links'
     fi
 }
 
@@ -88,7 +88,7 @@ _comp_cmd_tipc()
     # Flags can be placed anywhere in the commandline
     case "$cur" in
         -*)
-            COMPREPLY=($(compgen -W '-h --help' -- "$cur"))
+            _comp_compgen -- -W '-h --help'
             return
             ;;
     esac
@@ -157,7 +157,7 @@ _comp_cmd_tipc()
                         done
                     done
 
-                    COMPREPLY=($(compgen -W '"${params[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${params[@]}"'
                     ;;
                 disable)
                     ((optind++))
@@ -188,7 +188,7 @@ _comp_cmd_tipc()
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=($(compgen -W 'get set list statistics' -- "$cur"))
+                _comp_compgen -- -W 'get set list statistics'
                 return
             fi
 
@@ -215,7 +215,7 @@ _comp_cmd_tipc()
                     ((optind++))
 
                     if ((cword == optind)); then
-                        COMPREPLY=($(compgen -W 'show reset' -- "$cur"))
+                        _comp_compgen -- -W 'show reset'
                         return
                     fi
 
@@ -231,7 +231,7 @@ _comp_cmd_tipc()
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=($(compgen -W 'get set list' -- "$cur"))
+                _comp_compgen -- -W 'get set list'
                 return
             fi
 
@@ -260,14 +260,14 @@ _comp_cmd_tipc()
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=($(compgen -W 'show' -- "$cur"))
+                _comp_compgen -- -W 'show'
             fi
             ;;
         node)
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=($(compgen -W 'list get set' -- "$cur"))
+                _comp_compgen -- -W 'list get set'
                 return
             fi
 
@@ -276,7 +276,7 @@ _comp_cmd_tipc()
                     ((optind++))
 
                     if ((cword == optind)); then
-                        COMPREPLY=($(compgen -W 'address netid' -- "$cur"))
+                        _comp_compgen -- -W 'address netid'
                     fi
                     ;;
             esac
@@ -285,7 +285,7 @@ _comp_cmd_tipc()
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=($(compgen -W 'list' -- "$cur"))
+                _comp_compgen -- -W 'list'
             fi
             ;;
     esac

--- a/completions/tree
+++ b/completions/tree
@@ -20,7 +20,7 @@ _comp_cmd_tree()
             return
             ;;
         --sort)
-            COMPREPLY=($(compgen -W "name version size mtime ctime" -- "$cur"))
+            _comp_compgen -- -W "name version size mtime ctime"
             return
             ;;
     esac

--- a/completions/tshark
+++ b/completions/tshark
@@ -20,8 +20,7 @@ _comp_cmd_tshark()
             ;;
         -o*)
             if [[ $cur == *:* ]]; then
-                cur=${cur#*:}
-                _comp_compgen_filedir
+                _comp_compgen -c "${cur#*:}" filedir
             else
                 [[ -v _comp_cmd_tshark__prefs ]] ||
                     _comp_cmd_tshark__prefs="$("$1" -G defaultprefs 2>/dev/null | command sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
@@ -104,8 +103,7 @@ _comp_cmd_tshark()
             ;;
         -*X)
             if [[ ${cur:${#prefix}} == lua_script:* ]]; then
-                cur=${cur#*:}
-                _comp_compgen_filedir lua
+                _comp_compgen -c "${cur#*:}" filedir lua
             else
                 COMPREPLY=($(compgen -P "$prefix" -W 'lua_script:' -- \
                     "${cur:${#prefix}}"))

--- a/completions/tshark
+++ b/completions/tshark
@@ -54,7 +54,7 @@ _comp_cmd_tshark()
             return
             ;;
         -*[ab])
-            COMPREPLY=($(compgen -W 'duration: filesize: files:' -- "$cur"))
+            _comp_compgen -- -W 'duration: filesize: files:'
             [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             return
             ;;
@@ -94,11 +94,11 @@ _comp_cmd_tshark()
             ;;
         -*u)
             # TODO: could be parsed from "-u ." output
-            COMPREPLY=($(compgen -W 's hms' -- "$cur"))
+            _comp_compgen -- -W 's hms'
             return
             ;;
         -*W)
-            COMPREPLY=($(compgen -W 'n' -- "$cur"))
+            _comp_compgen -- -W 'n'
             return
             ;;
         -*X)

--- a/completions/tsig-keygen
+++ b/completions/tsig-keygen
@@ -16,7 +16,7 @@ _comp_cmd_tsig_keygen()
             return
             ;;
         -r)
-            COMPREPLY=($(compgen -W keyboard -- "$cur"))
+            _comp_compgen -- -W keyboard
             _comp_compgen -a filedir
             return
             ;;

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -15,8 +15,7 @@ _comp_cmd_tune2fs()
             ;;
         -*g)
             _gids
-            ((${#COMPREPLY[@]})) &&
-                _comp_compgen -- -g -W '"${COMPREPLY[@]}"'
+            _comp_compgen -a -- -g
             return
             ;;
         -*M)
@@ -40,8 +39,7 @@ _comp_cmd_tune2fs()
             ;;
         -*u)
             _uids
-            ((${#COMPREPLY[@]})) &&
-                _comp_compgen -- -u -W '"${COMPREPLY[@]}"'
+            _comp_compgen -a -- -u
             return
             ;;
         -*U)

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -10,13 +10,13 @@ _comp_cmd_tune2fs()
             return
             ;;
         -*e)
-            COMPREPLY=($(compgen -W 'continue remount-ro panic' -- "$cur"))
+            _comp_compgen -- -W 'continue remount-ro panic'
             return
             ;;
         -*g)
             _gids
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -g -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -g -W '"${COMPREPLY[@]}"'
             return
             ;;
         -*M)
@@ -27,7 +27,7 @@ _comp_cmd_tune2fs()
             local -a opts=(^debug ^bsdgroups ^user_xattr ^acl ^uid16
                 ^journal_data ^journal_data_ordered ^journal_data_writeback
                 ^nobarrier ^block_validity ^discard ^nodelalloc)
-            COMPREPLY=($(compgen -W '"${opts[@]}" "${opts[@]#^}"' -- "$cur"))
+            _comp_compgen -- -W '"${opts[@]}" "${opts[@]#^}"'
             return
             ;;
         -*O)
@@ -35,17 +35,17 @@ _comp_cmd_tune2fs()
                 ^filetype ^flex_bg ^has_journal ^huge_file ^large_file
                 ^metadata_csum ^mmp ^project ^quota ^read-only ^resize_inode
                 ^sparse_super ^uninit_bg)
-            COMPREPLY=($(compgen -W '"${opts[@]}" "${opts[@]#^}"' -- "$cur"))
+            _comp_compgen -- -W '"${opts[@]}" "${opts[@]#^}"'
             return
             ;;
         -*u)
             _uids
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -u -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -u -W '"${COMPREPLY[@]}"'
             return
             ;;
         -*U)
-            COMPREPLY=($(compgen -W 'clear random time' -- "$cur"))
+            _comp_compgen -- -W 'clear random time'
             return
             ;;
     esac

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -55,8 +55,7 @@ _comp_cmd_tune2fs()
         return
     fi
 
-    : "${cur:=/dev/}"
-    _comp_compgen_filedir
+    _comp_compgen -c "${cur:-/dev/}" filedir
 } &&
     complete -F _comp_cmd_tune2fs tune2fs
 

--- a/completions/ulimit
+++ b/completions/ulimit
@@ -10,7 +10,7 @@ _comp_cmd_ulimit()
     local mode=
     case $prev in
         -a)
-            COMPREPLY=($(compgen -W "-S -H" -- "$cur"))
+            _comp_compgen -- -W "-S -H"
             return
             ;;
         -[SH]) ;;
@@ -32,7 +32,7 @@ _comp_cmd_ulimit()
         fi
     fi
 
-    [[ ${mode-} ]] && COMPREPLY=($(compgen -W "soft hard unlimited" -- "$cur"))
+    [[ ${mode-} ]] && _comp_compgen -- -W "soft hard unlimited"
 } &&
     complete -F _comp_cmd_ulimit ulimit
 

--- a/completions/unace
+++ b/completions/unace
@@ -6,10 +6,10 @@ _comp_cmd_unace()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-c -c- -f -f- -o -o- -p -y -y-' -- "$cur"))
+        _comp_compgen -- -W '-c -c- -f -f- -o -o- -p -y -y-'
     else
         if ((cword == 1)); then
-            COMPREPLY=($(compgen -W 'e l t v x' -- "$cur"))
+            _comp_compgen -- -W 'e l t v x'
         else
             _comp_compgen_filedir '@(ace|cba)'
         fi

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -12,11 +12,11 @@ _comp_cmd_unpack200()
             return
             ;;
         --deflate-hint | -${noargopts}H)
-            COMPREPLY=($(compgen -W 'true false keep' -- "$cur"))
+            _comp_compgen -- -W 'true false keep'
             return
             ;;
         --log-file | -${noargopts}l)
-            COMPREPLY=($(compgen -W '-' -- "$cur"))
+            _comp_compgen -- -W '-'
             _comp_compgen -a filedir log
             return
             ;;

--- a/completions/unrar
+++ b/completions/unrar
@@ -11,7 +11,7 @@ _comp_cmd_unrar()
             -ver -vp -x -x@ -y' -- "$cur"))
     else
         if ((cword == 1)); then
-            COMPREPLY=($(compgen -W 'e l lb lt p t v vb vt x' -- "$cur"))
+            _comp_compgen -- -W 'e l lb lt p t v vb vt x'
         else
             _comp_compgen_filedir '@(rar|exe|cbr)'
         fi

--- a/completions/update-alternatives
+++ b/completions/update-alternatives
@@ -60,7 +60,7 @@ _comp_cmd_update_alternatives()
                             _comp_compgen_filedir
                             ;;
                         1)
-                            COMPREPLY=($(compgen -W '--slave' -- "$cur"))
+                            _comp_compgen -- -W '--slave'
                             ;;
                         3)
                             _comp_cmd_update_alternatives__installed

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -20,7 +20,7 @@ _comp_cmd_update_rc_d()
         COMPREPLY=($(compgen -W '"${options[@]}" ${services[@]+"${services[@]}"}' \
             -X '$(tr " " "|" <<<${words[@]})' -- "$cur"))
     elif ((${#services[@]})) && [[ $prev == ?($(tr " " "|" <<<"${services[*]}")) ]]; then
-        COMPREPLY=($(compgen -W 'remove defaults start stop' -- "$cur"))
+        _comp_compgen -- -W 'remove defaults start stop'
     elif [[ $prev == defaults && $cur == [0-9] ]]; then
         COMPREPLY=(0 1 2 3 4 5 6 7 8 9)
     elif [[ $prev == defaults && $cur == [sk]?([0-9]) ]]; then
@@ -48,7 +48,7 @@ _comp_cmd_update_rc_d()
             COMPREPLY=()
         fi
     elif [[ $prev == "." ]]; then
-        COMPREPLY=($(compgen -W "start stop" -- "$cur"))
+        _comp_compgen -- -W "start stop"
     else
         COMPREPLY=()
     fi

--- a/completions/upgradepkg
+++ b/completions/upgradepkg
@@ -18,7 +18,7 @@ _comp_cmd_upgradepkg()
         compopt -o filenames
         COMPREPLY=($(compgen -P "$prev%" -f -X "!*.@(t[bgxl]z)" -- "$cur"))
         [[ ${COMPREPLY-} ]] || nofiles=set
-        COMPREPLY+=($(compgen -P "$prev%" -S '/' -d -- "$cur"))
+        _comp_compgen -a -- -P "$prev%" -S '/' -d
         [[ $nofiles ]] && compopt -o nospace
         return
     fi

--- a/completions/useradd
+++ b/completions/useradd
@@ -30,7 +30,7 @@ _comp_cmd_useradd()
             ;;
         --gid | -${noargopts}g)
             _gids
-            COMPREPLY+=($(compgen -g))
+            _comp_compgen -aR -- -g
             ((${#COMPREPLY[@]})) &&
                 _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return

--- a/completions/useradd
+++ b/completions/useradd
@@ -30,9 +30,7 @@ _comp_cmd_useradd()
             ;;
         --gid | -${noargopts}g)
             _gids
-            _comp_compgen -aR -- -g
-            ((${#COMPREPLY[@]})) &&
-                _comp_compgen -- -W '"${COMPREPLY[@]}"'
+            _comp_compgen -a -- -g
             return
             ;;
         --groups | -${noargopts}G)

--- a/completions/useradd
+++ b/completions/useradd
@@ -32,7 +32,7 @@ _comp_cmd_useradd()
             _gids
             COMPREPLY+=($(compgen -g))
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return
             ;;
         --groups | -${noargopts}G)

--- a/completions/userdel
+++ b/completions/userdel
@@ -22,7 +22,7 @@ _comp_cmd_userdel()
         return
     fi
 
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_userdel userdel
 

--- a/completions/usermod
+++ b/completions/usermod
@@ -28,7 +28,7 @@ _comp_cmd_usermod()
             _gids
             COMPREPLY+=($(compgen -g))
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return
             ;;
         --groups | -${noargopts}G)
@@ -57,7 +57,7 @@ _comp_cmd_usermod()
         return
     fi
 
-    COMPREPLY=($(compgen -u -- "$cur"))
+    _comp_compgen -- -u
 } &&
     complete -F _comp_cmd_usermod usermod
 

--- a/completions/usermod
+++ b/completions/usermod
@@ -26,7 +26,7 @@ _comp_cmd_usermod()
             ;;
         --gid | -${noargopts}g)
             _gids
-            COMPREPLY+=($(compgen -g))
+            _comp_compgen -aR -- -g
             ((${#COMPREPLY[@]})) &&
                 _comp_compgen -- -W '"${COMPREPLY[@]}"'
             return

--- a/completions/usermod
+++ b/completions/usermod
@@ -26,9 +26,7 @@ _comp_cmd_usermod()
             ;;
         --gid | -${noargopts}g)
             _gids
-            _comp_compgen -aR -- -g
-            ((${#COMPREPLY[@]})) &&
-                _comp_compgen -- -W '"${COMPREPLY[@]}"'
+            _comp_compgen -a -- -g
             return
             ;;
         --groups | -${noargopts}G)

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -39,16 +39,16 @@ _comp_cmd_valgrind()
             return
             ;;
         --sim-hints)
-            COMPREPLY=($(compgen -W 'lax-ioctls enable-outer' -- "$cur"))
+            _comp_compgen -- -W 'lax-ioctls enable-outer'
             return
             ;;
         --soname-synonyms)
-            COMPREPLY=($(compgen -W 'somalloc' -S = -- "$cur"))
+            _comp_compgen -- -W 'somalloc' -S =
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
             ;;
         --kernel-variant)
-            COMPREPLY=($(compgen -W 'bproc' -- "$cur"))
+            _comp_compgen -- -W 'bproc'
             return
             ;;
         # callgrind:
@@ -64,7 +64,7 @@ _comp_cmd_valgrind()
             ;;
         # massif:
         --time-unit)
-            COMPREPLY=($(compgen -W 'i ms B' -- "$cur"))
+            _comp_compgen -- -W 'i ms B'
             return
             ;;
             # generic cases parsed from --help output
@@ -80,7 +80,7 @@ _comp_cmd_valgrind()
                     ;;
                 \<command\>)
                     compopt -o filenames
-                    COMPREPLY=($(compgen -c -- "$cur"))
+                    _comp_compgen -- -c
                     return
                     ;;
                 \<+([0-9])..+([0-9])\>)

--- a/completions/vmstat
+++ b/completions/vmstat
@@ -13,7 +13,7 @@ _comp_cmd_vmstat()
             ;;
         --unit | -${noargopts}S)
             [[ $OSTYPE == *linux* ]] &&
-                COMPREPLY=($(compgen -W 'k K m M' -- "$cur"))
+                _comp_compgen -- -W 'k K m M'
             return
             ;;
     esac

--- a/completions/vncviewer
+++ b/completions/vncviewer
@@ -65,7 +65,7 @@ _comp_cmd_xvnc4viewer()
             return
             ;;
         -preferredencoding)
-            COMPREPLY=($(compgen -W 'zrle hextile raw' -- "$cur"))
+            _comp_compgen -- -W 'zrle hextile raw'
             return
             ;;
         -via)

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -17,7 +17,7 @@ _vpnc()
             return
             ;;
         --vendor)
-            COMPREPLY=($(compgen -W 'cisco netscreen' -- "$cur"))
+            _comp_compgen -- -W 'cisco netscreen'
             return
             ;;
         --natt-mode)
@@ -30,23 +30,23 @@ _vpnc()
             return
             ;;
         --dh)
-            COMPREPLY=($(compgen -W 'dh1 dh2 dh5' -- "$cur"))
+            _comp_compgen -- -W 'dh1 dh2 dh5'
             return
             ;;
         --pfs)
-            COMPREPLY=($(compgen -W 'nopfs dh1 dh2 dh5 server' -- "$cur"))
+            _comp_compgen -- -W 'nopfs dh1 dh2 dh5 server'
             return
             ;;
         --ifmode)
-            COMPREPLY=($(compgen -W 'tun tap' -- "$cur"))
+            _comp_compgen -- -W 'tun tap'
             return
             ;;
         --debug)
-            COMPREPLY=($(compgen -W '0 1 2 3 99' -- "$cur"))
+            _comp_compgen -- -W '0 1 2 3 99'
             return
             ;;
         --auth-mode)
-            COMPREPLY=($(compgen -W 'psk cert hybrid' -- "$cur"))
+            _comp_compgen -- -W 'psk cert hybrid'
             return
             ;;
         --ca-dir)
@@ -55,7 +55,7 @@ _vpnc()
             ;;
         --password-helper)
             compopt -o filenames
-            COMPREPLY=($(compgen -c -- "$cur"))
+            _comp_compgen -- -c
             return
             ;;
     esac
@@ -74,7 +74,7 @@ _vpnc()
             configs=("${configs[@]%.conf}")
             local IFS=$'\n'
             compopt -o filenames
-            COMPREPLY=($(compgen -W '"${configs[@]}"' -- "$cur"))
+            _comp_compgen -- -W '"${configs[@]}"'
         fi
     fi
 } &&

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -72,7 +72,6 @@ _vpnc()
         if ((${#configs[@]})); then
             configs=("${configs[@]##*/}")
             configs=("${configs[@]%.conf}")
-            local IFS=$'\n'
             compopt -o filenames
             _comp_compgen -- -W '"${configs[@]}"'
         fi

--- a/completions/watch
+++ b/completions/watch
@@ -36,7 +36,7 @@ _comp_cmd_watch()
     case $prev in
         --differences | -${noargopts}d)
             [[ $cur != -* ]] &&
-                COMPREPLY=($(compgen -W 'cumulative' -- "$cur"))
+                _comp_compgen -- -W 'cumulative'
             return
             ;;
         --interval | -${noargopts}n)

--- a/completions/wget
+++ b/completions/wget
@@ -12,7 +12,7 @@ _comp_cmd_wget()
             return
             ;;
         --progress)
-            COMPREPLY=($(compgen -W 'bar dot' -- "$cur"))
+            _comp_compgen -- -W 'bar dot'
             return
             ;;
         --bind-address)
@@ -59,7 +59,7 @@ _comp_cmd_wget()
             return
             ;;
         --prefer-family)
-            COMPREPLY=($(compgen -W 'IPv4 IPv6 none' -- "$cur"))
+            _comp_compgen -- -W 'IPv4 IPv6 none'
             return
             ;;
         --directory-prefix | --ca-directory | --warc-tempdir | -${noargopts}P)
@@ -78,11 +78,11 @@ _comp_cmd_wget()
             return
             ;;
         --secure-protocol)
-            COMPREPLY=($(compgen -W 'auto SSLv2 SSLv3 TLSv1' -- "$cur"))
+            _comp_compgen -- -W 'auto SSLv2 SSLv3 TLSv1'
             return
             ;;
         --certificate-type | --private-key-type)
-            COMPREPLY=($(compgen -W 'PEM DER' -- "$cur"))
+            _comp_compgen -- -W 'PEM DER'
             return
             ;;
         --follow-tags | --ignore-tags)
@@ -149,11 +149,11 @@ _comp_cmd_wget()
             return # TODO base=STR
             ;;
         --report-speed)
-            COMPREPLY=($(compgen -W 'bits' -- "$cur"))
+            _comp_compgen -- -W 'bits'
             return
             ;;
         --regex-type)
-            COMPREPLY=($(compgen -W 'posix' -- "$cur"))
+            _comp_compgen -- -W 'posix'
             return
             ;;
         --base | --password | --ftp-password | --http-password | \

--- a/completions/wget
+++ b/completions/wget
@@ -104,7 +104,7 @@ _comp_cmd_wget()
             --read-timeout | --wait | --waitretry | --cut-dirs | \
             --max-redirect | --level | -${noargopts}[tTwl])
             # expect integer number
-            COMPREPLY+=($(compgen -P "$cur" -W "{0..9}"))
+            _comp_compgen -aR -- -P "$cur" -W "{0..9}"
             compopt -o nospace
             return
             ;;

--- a/completions/wget
+++ b/completions/wget
@@ -111,12 +111,12 @@ _comp_cmd_wget()
         --quota | --limit-rate | --warc-max-size | -${noargopts}Q)
             # expect size
             if [[ $cur == *[km] ]]; then
-                COMPREPLY=($(compgen -W "$cur"))
+                _comp_compgen -R -- -W "$cur"
             elif [[ $cur ]]; then
-                COMPREPLY=($(compgen -P "$cur" -W "{0..9} k m"))
+                _comp_compgen -R -- -P "$cur" -W "{0..9} k m"
                 compopt -o nospace
             else
-                COMPREPLY=($(compgen -W "{0..9}"))
+                _comp_compgen -R -- -W "{0..9}"
                 compopt -o nospace
             fi
             return

--- a/completions/wine
+++ b/completions/wine
@@ -13,7 +13,7 @@ _comp_cmd_wine()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
+            _comp_compgen -- -W '--help --version'
             [[ ${COMPREPLY-} ]] && return
         fi
         _comp_compgen_filedir '@([eE][xX][eE]?(.[sS][oO])|[cC][oO][mM]|[sS][cC][rR]|[mM][sS][iI])'

--- a/completions/wodim
+++ b/completions/wodim
@@ -84,10 +84,10 @@ _comp_cmd_wodim()
     # files are always eligible completion
     _comp_compgen_filedir
     # track options are always available
-    COMPREPLY+=($(compgen -W '"${track_options[@]}"' -- "$cur"))
+    _comp_compgen -a -- -W '"${track_options[@]}"'
     # general options are no more available after file or track option
     if [[ ! $track_mode ]]; then
-        COMPREPLY+=($(compgen -W '"${generic_options[@]}"' -- "$cur"))
+        _comp_compgen -a -- -W '"${generic_options[@]}"'
     fi
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&

--- a/completions/wodim
+++ b/completions/wodim
@@ -25,7 +25,7 @@ _comp_cmd_wodim()
                     cur=${cur#*=}
                     case $prev in
                         varirec)
-                            COMPREPLY=($(compgen -W "-2 -1 0 1 2" -- "$cur"))
+                            _comp_compgen -- -W "-2 -1 0 1 2"
                             ;;
                         gigarec)
                             COMPREPLY=($(compgen -W "0.6 0.7 0.8 1.0 1.2 1.3
@@ -48,7 +48,7 @@ _comp_cmd_wodim()
                     awk 'NR > 1 { print $1 }') help" -- "$cur"))
                 ;;
             minbuf)
-                COMPREPLY=($(compgen -W '{25..95}' -- "$cur"))
+                _comp_compgen -- -W '{25..95}'
                 ;;
         esac
         return

--- a/completions/wsimport
+++ b/completions/wsimport
@@ -22,7 +22,7 @@ _comp_cmd_wsimport()
             return
             ;;
         -target)
-            COMPREPLY=($(compgen -W '2.0 2.1 2.2' -- "$cur"))
+            _comp_compgen -- -W '2.0 2.1 2.2'
             return
             ;;
         -clientjar)

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -59,7 +59,6 @@ _comp_cmd_xdg_mime()
                 _comp_expand_glob desktops '/usr/share/applications/*.desktop'
                 if ((${#desktops[@]})); then
                     desktops=("${desktops[@]##*/}")
-                    local IFS=$'\n'
                     _comp_compgen -- -W '"${desktops[@]}"'
                 fi
             else

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -33,7 +33,7 @@ _comp_cmd_xdg_mime()
 
     if ((args == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--help --manual --version' -- "$cur"))
+            _comp_compgen -- -W '--help --manual --version'
             return
         fi
         COMPREPLY=($(compgen -W \
@@ -44,7 +44,7 @@ _comp_cmd_xdg_mime()
     case ${words[1]} in
         query)
             if ((args == 2)); then
-                COMPREPLY=($(compgen -W 'filetype default' -- "$cur"))
+                _comp_compgen -- -W 'filetype default'
                 return
             fi
             ((args == 3)) || return
@@ -60,7 +60,7 @@ _comp_cmd_xdg_mime()
                 if ((${#desktops[@]})); then
                     desktops=("${desktops[@]##*/}")
                     local IFS=$'\n'
-                    COMPREPLY=($(compgen -W '"${desktops[@]}"' -- "$cur"))
+                    _comp_compgen -- -W '"${desktops[@]}"'
                 fi
             else
                 _comp_cmd_xdg_mime__mimetype
@@ -68,18 +68,18 @@ _comp_cmd_xdg_mime()
             ;;
         install)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '--mode --novendor' -- "$cur"))
+                _comp_compgen -- -W '--mode --novendor'
             elif [[ $prev == --mode ]]; then
-                COMPREPLY=($(compgen -W 'user system' -- "$cur"))
+                _comp_compgen -- -W 'user system'
             else
                 _comp_compgen_filedir xml
             fi
             ;;
         uninstall)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '--mode' -- "$cur"))
+                _comp_compgen -- -W '--mode'
             elif [[ $prev == --mode ]]; then
-                COMPREPLY=($(compgen -W 'user system' -- "$cur"))
+                _comp_compgen -- -W 'user system'
             else
                 _comp_compgen_filedir xml
             fi

--- a/completions/xdg-settings
+++ b/completions/xdg-settings
@@ -20,7 +20,7 @@ _comp_cmd_xdg_settings()
     local args
     _count_args
     if ((args == 1)); then
-        COMPREPLY=($(compgen -W "get check set" -- "$cur"))
+        _comp_compgen -- -W "get check set"
     elif ((args == 2)); then
         COMPREPLY=($(compgen -W \
             '$("$1" --list | awk "!/^Known/ { print \$1 }")' -- "$cur"))

--- a/completions/xev
+++ b/completions/xev
@@ -10,7 +10,7 @@ _comp_cmd_xev()
             return
             ;;
         -bs)
-            COMPREPLY=($(compgen -W 'NotUseful WhenMapped Always' -- "$cur"))
+            _comp_compgen -- -W 'NotUseful WhenMapped Always'
             return
             ;;
         -event)

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -35,7 +35,7 @@ _comp_cmd_xfreerdp()
             return
             ;;
         /bpp:*)
-            COMPREPLY=($(compgen -W '8 15 16 24 32' -- "${cur#/bpp:}"))
+            _comp_compgen -c "${cur#/bpp:}" -- -W '8 15 16 24 32'
             return
             ;;
         /*:*)

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -12,15 +12,15 @@ _comp_cmd_xfreerdp()
             return
             ;;
         -a)
-            COMPREPLY=($(compgen -W '8 15 16 24 32' -- "$cur"))
+            _comp_compgen -- -W '8 15 16 24 32'
             return
             ;;
         -x)
-            COMPREPLY=($(compgen -W 'broadband modem lan' -- "$cur"))
+            _comp_compgen -- -W 'broadband modem lan'
             return
             ;;
         --plugin)
-            COMPREPLY=($(compgen -W 'cliprdr rdpsnd rdpdr' -- "$cur"))
+            _comp_compgen -- -W 'cliprdr rdpsnd rdpdr'
             return
             ;;
         /help | /version | -h | --help | --version)
@@ -59,7 +59,7 @@ _comp_cmd_xfreerdp()
         else # old/dash syntax
             COMPREPLY=($(_parse_help - <<<"$help"))
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]%:}"' -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]%:}"'
         fi
     else
         _comp_compgen_filedir rdp

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -17,7 +17,7 @@ _comp_cmd_xgamma()
             if [[ $cur && $cur != *.* ]]; then
                 COMPREPLY=(.)
             fi
-            COMPREPLY+=($(compgen -W "{0..9}"))
+            _comp_compgen -aR -- -W "{0..9}"
             compopt -o nospace
             return
             ;;

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -9,7 +9,7 @@ _comp_cmd_xgamma()
         -screen)
             local screens=$(xrandr --query 2>/dev/null | command sed -n \
                 '/^Screen /s|^Screen \{1,\}\(.*\):.*$|\1|p' 2>/dev/null)
-            COMPREPLY=($(compgen -W "$screens" -- "$cur"))
+            _comp_compgen -- -W "$screens"
             return
             ;;
         -gamma | -rgamma | -ggamma | -bgamma)

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -26,7 +26,7 @@ _comp_cmd_xgamma()
             if [[ $cur == :* && $cur != :*.* ]]; then
                 # FIXME: where to get local display numbers?
                 local display=${cur#:}
-                COMPREPLY=($(compgen -W "${display:-0}."))
+                _comp_compgen -R -- -W "${display:-0}."
                 compopt -o nospace
             elif [[ $cur == :*.* ]]; then
                 # local screen numbers

--- a/completions/xmllint
+++ b/completions/xmllint
@@ -35,7 +35,7 @@ _comp_cmd_xmllint()
             return
             ;;
         --pretty)
-            COMPREPLY=($(compgen -W '{0..2}' -- "$cur"))
+            _comp_compgen -- -W '{0..2}'
             return
             ;;
     esac

--- a/completions/xmms
+++ b/completions/xmms
@@ -12,7 +12,7 @@ _comp_cmd_xmms()
             return
             ;;
         --toggle-shuffle | --toggle-repeat | --toggle-advance | -${noargopts}[SRA])
-            COMPREPLY=($(compgen -W 'on off' -- "$cur"))
+            _comp_compgen -- -W 'on off'
             return
             ;;
     esac

--- a/completions/xrandr
+++ b/completions/xrandr
@@ -69,20 +69,20 @@ _comp_cmd_xrandr()
             ;;
         --output | --addmode | --delmode | --dpi)
             local outputs=$(_comp_cmd_xrandr_outputs "$1")
-            COMPREPLY=($(compgen -W "$outputs" -- "$cur"))
+            _comp_compgen -- -W "$outputs"
             return
             ;;
         --left-of | --right-of | --above | --below | --same-as)
             if [[ $has_output ]]; then
                 local outputs=$(_comp_cmd_xrandr_outputs "$1")
-                COMPREPLY=($(compgen -W "$outputs" -- "$cur"))
+                _comp_compgen -- -W "$outputs"
             fi
             return
             ;;
         --mode)
             if [[ $has_output ]]; then
                 local modes=$(_comp_cmd_xrandr_modes "$1" "$output")
-                COMPREPLY=($(compgen -W "$modes" -- "$cur"))
+                _comp_compgen -- -W "$modes"
             fi
             return
             ;;
@@ -94,35 +94,35 @@ _comp_cmd_xrandr()
             ;;
         --reflect)
             if [[ $has_output ]]; then
-                COMPREPLY=($(compgen -W 'normal x y xy' -- "$cur"))
+                _comp_compgen -- -W 'normal x y xy'
             fi
             return
             ;;
         --rotate)
             if [[ $has_output ]]; then
-                COMPREPLY=($(compgen -W 'normal inverted left right' -- "$cur"))
+                _comp_compgen -- -W 'normal inverted left right'
             fi
             return
             ;;
         --filter)
             if [[ $has_output ]]; then
-                COMPREPLY=($(compgen -W 'bilinear nearest' -- "$cur"))
+                _comp_compgen -- -W 'bilinear nearest'
             fi
             return
             ;;
         --setprovideroutputsource)
             local providers=$(_comp_cmd_xrandr_providers "$1" "Sink Output")
-            COMPREPLY=($(compgen -W "$providers" -- "$cur"))
+            _comp_compgen -- -W "$providers"
             return
             ;;
         --setprovideroffloadsink)
             local providers=$(_comp_cmd_xrandr_providers "$1" "Source Offload")
-            COMPREPLY=($(compgen -W "$providers" -- "$cur"))
+            _comp_compgen -- -W "$providers"
             return
             ;;
         --delmonitor)
             local monitors=$(_comp_cmd_xrandr_monitors "$1")
-            COMPREPLY=($(compgen -W "$monitors" -- "$cur"))
+            _comp_compgen -- -W "$monitors"
             return
             ;;
     esac
@@ -135,30 +135,30 @@ _comp_cmd_xrandr()
                 ;;
             --addmode)
                 local modes=$(_comp_cmd_xrandr_all_modes "$1")
-                COMPREPLY=($(compgen -W "$modes" -- "$cur"))
+                _comp_compgen -- -W "$modes"
                 return
                 ;;
             --delmode)
                 local modes=$(_comp_cmd_xrandr_modes "$1" "${words[cword - 1]}")
-                COMPREPLY=($(compgen -W "$modes" -- "$cur"))
+                _comp_compgen -- -W "$modes"
                 return
                 ;;
             --setmonitor)
-                COMPREPLY=($(compgen -W 'auto' -- "$cur"))
+                _comp_compgen -- -W 'auto'
                 return
                 ;;
             --setprovideroutputsource)
                 local providers=$(
                     _comp_cmd_xrandr_providers "$1" "Source Output"
                 )
-                COMPREPLY=($(compgen -W "0x0 $providers" -- "$cur"))
+                _comp_compgen -- -W "0x0 $providers"
                 return
                 ;;
             --setprovideroffloadsink)
                 local providers=$(
                     _comp_cmd_xrandr_providers "$1" "Sink Offload"
                 )
-                COMPREPLY=($(compgen -W "0x0 $providers" -- "$cur"))
+                _comp_compgen -- -W "0x0 $providers"
                 return
                 ;;
         esac
@@ -169,7 +169,7 @@ _comp_cmd_xrandr()
         case "${words[cword - 3]}" in
             --setmonitor)
                 local outputs=$(_comp_cmd_xrandr_outputs "$1")
-                COMPREPLY=($(compgen -W "none $outputs" -- "$cur"))
+                _comp_compgen -- -W "none $outputs"
                 # TODO: the third argument is actually a comma-separated list
                 return
                 ;;
@@ -192,7 +192,7 @@ _comp_cmd_xrandr()
         )
     fi
 
-    COMPREPLY=($(compgen -W "$options" -- "$cur"))
+    _comp_compgen -- -W "$options"
 } &&
     complete -F _comp_cmd_xrandr xrandr
 

--- a/completions/xz
+++ b/completions/xz
@@ -18,11 +18,11 @@ _comp_cmd_xz()
             return
             ;;
         --check | -${noargopts}C)
-            COMPREPLY=($(compgen -W 'crc32 crc64 sha256 none' -- "$cur"))
+            _comp_compgen -- -W 'crc32 crc64 sha256 none'
             return
             ;;
         --format | -${noargopts}F)
-            COMPREPLY=($(compgen -W 'auto xz lzma raw' -- "$cur"))
+            _comp_compgen -- -W 'auto xz lzma raw'
             return
             ;;
         --threads | -${noargopts}T)

--- a/completions/yum-arch
+++ b/completions/yum-arch
@@ -6,7 +6,7 @@ _comp_cmd_yum_arch()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-d -v -vv -n -c -z -s -l -q' -- "$cur"))
+        _comp_compgen -- -W '-d -v -vv -n -c -z -s -l -q'
     else
         _comp_compgen_filedir -d
     fi

--- a/completions/zopflipng
+++ b/completions/zopflipng
@@ -10,7 +10,7 @@ _comp_cmd_zopflipng()
             return
             ;;
         --splitting)
-            COMPREPLY=($(compgen -W '{0..3}' -- "$cur"))
+            _comp_compgen -- -W '{0..3}'
             return
             ;;
     esac
@@ -20,7 +20,7 @@ _comp_cmd_zopflipng()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(_parse_help "$1" -h))
         ((${#COMPREPLY[@]})) &&
-            COMPREPLY=($(compgen -W '"${COMPREPLY[@]%:}"' -- "$cur"))
+            _comp_compgen -- -W '"${COMPREPLY[@]%:}"'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi


### PR DESCRIPTION
These are relatively trivial ones for the `_comp_compgen` rewriting.

~~**edit**: #952 is blocking more, so could you see #952 before this?~~ Merged

Note: The commits "fix: use _comp_compgen for COMPREPLY=(...)" are essentially generated by `sed`:

```
sed -E "s/$path/$rep/g"

with

pat='(COMPREPLY)=\(\$\(compgen ([^()]*) -- "\$(cur|\{cur-?\})"[[:space:]]*\)\)'   rep='_comp_compgen -- \2'
pat='(COMPREPLY)\+=\(\$\(compgen ([^()]*) -- "\$(cur|\{cur-?\})"[[:space:]]*\)\)' rep='_comp_compgen -a -- \2'
pat='(COMPREPLY)=\(\$\(compgen ([^()]*) -- ("[^"()]+")[[:space:]]*\)\)'           rep='_comp_compgen -c \3 -- \2'
pat='(COMPREPLY)\+=\(\$\(compgen ([^()]*) -- ("[^"()]+")[[:space:]]*\)\)'         rep='_comp_compgen -ac \3 -- \2'
pat='(COMPREPLY)=\(\$\(compgen ([^()]*)\)\)'                                      rep='_comp_compgen -R -- \2'
pat='(COMPREPLY)\+=\(\$\(compgen ([^()]*)\)\)'                                    rep='_comp_compgen -aR -- \2'

```
