### PR TITLE
feat: add some clap_complete based 3rd party loaders

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -47,6 +47,7 @@
 /createuser
 /_datree
 /dcop
+/_deno
 /dfutool
 /_diesel
 /display

--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -48,6 +48,7 @@
 /_datree
 /dcop
 /dfutool
+/_diesel
 /display
 /_docker
 /dpkg-deb

--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -308,6 +308,7 @@
 /vgsplit
 /vigr
 /_virtctl
+/_watchexec
 /whatis
 /wine-development
 /wine-stable

--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -274,6 +274,7 @@
 /spovray
 /_sshi
 /star
+/_starship
 /stream
 /sudoedit
 /_tanzu

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -118,6 +118,7 @@ bashcomp_DATA = 2to3 \
 		fio \
 		firefox \
 		flake8 \
+		_flamegraph \
 		freebsd-update \
 		freeciv \
 		freeciv-server \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -828,6 +828,7 @@ CLEANFILES = \
 	spovray \
 	_sshi \
 	star \
+	_starship \
 	stream \
 	sudoedit \
 	_tanzu \
@@ -1053,6 +1054,8 @@ symlinks: $(DATA)
 		apropos whatis
 	$(ss) mcrypt \
 		mdecrypt
+	$(ss) _mdbook \
+		_starship
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2
 	$(ss) mutt \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -557,6 +557,7 @@ CLEANFILES = \
 	createuser \
 	_datree \
 	dcop \
+	_deno \
 	dfutool \
 	_diesel \
 	display \
@@ -1061,7 +1062,7 @@ symlinks: $(DATA)
 	$(ss) mcrypt \
 		mdecrypt
 	$(ss) _mdbook \
-		_diesel _starship
+		_deno _diesel _starship
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2
 	$(ss) mutt \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -253,6 +253,7 @@ bashcomp_DATA = 2to3 \
 		mc \
 		mcrypt \
 		mdadm \
+		_mdbook \
 		mdtool \
 		medusa \
 		mii-diag \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -556,6 +556,7 @@ CLEANFILES = \
 	_datree \
 	dcop \
 	dfutool \
+	_diesel \
 	display \
 	_docker \
 	dpkg-deb \
@@ -1055,7 +1056,7 @@ symlinks: $(DATA)
 	$(ss) mcrypt \
 		mdecrypt
 	$(ss) _mdbook \
-		_starship
+		_diesel _starship
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2
 	$(ss) mutt \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -864,6 +864,7 @@ CLEANFILES = \
 	vgsplit \
 	vigr \
 	_virtctl \
+	_watchexec \
 	whatis \
 	wine-development \
 	wine-stable \
@@ -930,6 +931,8 @@ symlinks: $(DATA)
 		mailsnarf msgsnarf
 	$(ss) firefox \
 		firefox-esr iceweasel mozilla-firefox
+	$(ss) _flamegraph \
+		_watchexec
 	$(ss) freeciv \
 		civclient freeciv-gtk2 freeciv-gtk3 freeciv-sdl freeciv-xaw
 	$(ss) freeciv-server \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -428,6 +428,7 @@ bashcomp_DATA = 2to3 \
 		tcpnice \
 		timeout \
 		tipc \
+		_tokio-console \
 		tox \
 		tracepath \
 		tree \

--- a/completions/_flamegraph
+++ b/completions/_flamegraph
@@ -1,0 +1,8 @@
+# 3rd party completion loader for commands emitting        -*- shell-script -*-
+# their completion using "$cmd --completions bash".
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+eval -- "$("$1" --completions bash 2>/dev/null)"
+
+# ex: filetype=sh

--- a/completions/_mdbook
+++ b/completions/_mdbook
@@ -1,0 +1,8 @@
+# 3rd party completion loader for commands emitting        -*- shell-script -*-
+# their completion using "$cmd completions bash".
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+eval -- "$("$1" completions bash 2>/dev/null)"
+
+# ex: filetype=sh

--- a/completions/_tokio-console
+++ b/completions/_tokio-console
@@ -1,0 +1,8 @@
+# 3rd party completion loader for commands emitting        -*- shell-script -*-
+# their completion using "$cmd gen-completion bash".
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+eval -- "$("$1" gen-completion bash 2>/dev/null)"
+
+# ex: filetype=sh

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = \
 	hwclock \
 	ionice \
 	look \
+	mdbook \
 	mock \
 	modules \
 	mount \

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -6,6 +6,7 @@ EXTRA_DIST = \
 	chsh \
 	dmesg \
 	eject \
+	flamegraph \
 	gaiacli \
 	gh \
 	golangci-lint \

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -36,6 +36,7 @@ EXTRA_DIST = \
 	svn \
 	svnadmin \
 	svnlook \
+	tokio-console \
 	udevadm \
 	umount \
 	umount.linux \

--- a/test/fallback/completions/flamegraph
+++ b/test/fallback/completions/flamegraph
@@ -1,0 +1,1 @@
+../../../completions/_flamegraph

--- a/test/fallback/completions/mdbook
+++ b/test/fallback/completions/mdbook
@@ -1,0 +1,1 @@
+../../../completions/_mdbook

--- a/test/fallback/completions/tokio-console
+++ b/test/fallback/completions/tokio-console
@@ -1,0 +1,1 @@
+../../../completions/_tokio-console


### PR DESCRIPTION
See the `clap_complete` entry at https://github.com/scop/bash-completion/wiki/Externally-available-completions#fallback-3rd-party-completions -- this adds loaders for a handful of the most downloaded ones. Quite a few of them seem to provide completions as build time generated snippets only, that's why the "gaps".