### PR TITLE
style(_comp_compgen): call `_comp_compgen_filedir` directly

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -437,6 +437,11 @@ _comp_split()
 #   [-alR|-v arr|-c cur] to the child calls of `_comp_compgen` in
 #   `_comp_compgen_NAME`.
 #
+# @remarks When no options are supplied to _comp_compgen, `_comp_compgen NAME
+# args` is equivalent to the direct call `_comp_compgen_NAME args`.  As the
+# direct call is slightly more efficient, the direct call is preferred over
+# calling it through `_comp_compgen`.
+#
 # @remarks Design `_comp_compgen_NAME`: a function that produce completions can
 # be defined with the name _comp_compgen_NAME.  The function is supposed to
 # generate completions by calling `_comp_compgen`.  To reflect the options

--- a/bash_completion
+++ b/bash_completion
@@ -1154,7 +1154,7 @@ _comp_initialize()
                 ;;
         esac
         cur=${cur##"$redir"}
-        _comp_compgen filedir "$xspec"
+        _comp_compgen_filedir "$xspec"
         return 1
     fi
 

--- a/bash_completion
+++ b/bash_completion
@@ -853,47 +853,52 @@ _comp_compgen_filedir()
     _comp_compgen_tilde && return
 
     local -a toks
-    local arg=${1-}
+    local _arg=${1-}
 
-    if [[ $arg == -d ]]; then
+    if [[ $_arg == -d ]]; then
         _comp_compgen -v toks -- -d
     else
         local ret
         _comp_quote_compgen "${cur-}"
-        local quoted=$ret
+        local _quoted=$ret
+        _comp_unlocal ret
 
         # Munge xspec to contain uppercase version too
         # https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00036.html
         # news://news.gmane.io/4C940E1C.1010304@case.edu
-        local xspec=${arg:+"!*.@($arg|${arg^^})"} plusdirs=()
+        local _xspec=${_arg:+"!*.@($_arg|${_arg^^})"} _plusdirs=()
 
         # Use plusdirs to get dir completions if we have a xspec; if we don't,
         # there's no need, dirs come along with other completions. Don't use
         # plusdirs quite yet if fallback is in use though, in order to not ruin
         # the fallback condition with the "plus" dirs.
-        local opts=(-f -X "$xspec")
-        [[ $xspec ]] && plusdirs=(-o plusdirs)
+        local _opts=(-f -X "$_xspec")
+        [[ $_xspec ]] && _plusdirs=(-o plusdirs)
         [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} ||
-            ! ${plusdirs-} ]] ||
-            opts+=("${plusdirs[@]}")
+            ! ${_plusdirs-} ]] ||
+            _opts+=("${_plusdirs[@]}")
 
-        _comp_compgen -v toks -c "$quoted" -- "${opts[@]}"
+        _comp_compgen -v toks -c "$_quoted" -- "${_opts[@]}"
 
         # Try without filter if it failed to produce anything and configured to
         [[ ${BASH_COMPLETION_FILEDIR_FALLBACK-${COMP_FILEDIR_FALLBACK-}} &&
-            $arg && ${#toks[@]} -lt 1 ]] &&
-            _comp_compgen -av toks -c "$quoted" -- -f ${plusdirs+"${plusdirs[@]}"}
+            $_arg && ${#toks[@]} -lt 1 ]] &&
+            _comp_compgen -av toks -c "$_quoted" -- \
+                -f ${_plusdirs+"${_plusdirs[@]}"}
     fi
 
     if ((${#toks[@]} != 0)); then
-        # 2>/dev/null for direct invocation, e.g. in the _comp_compgen_filedir unit test
+        # 2>/dev/null for direct invocation, e.g. in the _comp_compgen_filedir
+        # unit test
         compopt -o filenames 2>/dev/null
     fi
 
     # Note: bash < 4.4 has a bug that all the elements are connected with
     # ${v-"${a[@]}"} when IFS does not contain whitespace.
     local IFS=$' \t\n'
-    _comp_compgen_set ${toks[@]+"${toks[@]}"}
+    local -a _tmp=(${toks[@]+"${toks[@]}"})
+    _comp_unlocal toks
+    _comp_compgen_set ${_tmp[@]+"${_tmp[@]}"}
 } # _comp_compgen_filedir()
 
 # This function splits $cur=--foo=bar into $prev=--foo, $cur=bar, making it

--- a/completions/2to3
+++ b/completions/2to3
@@ -19,7 +19,7 @@ _comp_cmd_2to3()
             return
             ;;
         -o | --output-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -32,7 +32,7 @@ _comp_cmd_2to3()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_2to3 2to3
 

--- a/completions/7z
+++ b/completions/7z
@@ -119,7 +119,7 @@ _comp_cmd_7z()
                 2>/dev/null | tail -n+2)")" -- "$cur"))
             compopt -o filenames
         else
-            _comp_compgen filedir
+            _comp_compgen_filedir
         fi
     fi
 } &&

--- a/completions/_adb
+++ b/completions/_adb
@@ -20,7 +20,7 @@ _comp_cmd_adb()
             return
             ;;
         -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/_chsh
+++ b/completions/_chsh
@@ -22,7 +22,7 @@ _comp_cmd_chsh()
             return
             ;;
         -R | --root)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -s | --shell)

--- a/completions/_hexdump
+++ b/completions/_hexdump
@@ -13,7 +13,7 @@ _comp_cmd_hexdump()
             return
             ;;
         -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -25,7 +25,7 @@ _comp_cmd_hexdump()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_hexdump hexdump hd
 

--- a/completions/_hwclock
+++ b/completions/_hwclock
@@ -13,7 +13,7 @@ _comp_cmd_hwclock()
             return
             ;;
         -f | --rtc | --adjfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/_mock
+++ b/completions/_mock
@@ -32,11 +32,11 @@ _comp_cmd_mock()
             return
             ;;
         --configdir | --resultdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --spec)
-            _comp_compgen filedir spec
+            _comp_compgen_filedir spec
             return
             ;;
         --target)
@@ -61,7 +61,7 @@ _comp_cmd_mock()
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir '@(?(no)src.r|s)pm'
+        _comp_compgen_filedir '@(?(no)src.r|s)pm'
     fi
 } &&
     complete -F _comp_cmd_mock mock

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -28,7 +28,7 @@ _comp_cmd_mount()
             return
             ;;
         --bind | -B | --rbind | -R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -p | --pass-fd)

--- a/completions/_repomanage
+++ b/completions/_repomanage
@@ -16,7 +16,7 @@ _comp_cmd_repomanage()
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_repomanage repomanage

--- a/completions/_slackpkg
+++ b/completions/_slackpkg
@@ -74,7 +74,7 @@ _comp_cmd_slackpkg()
             return
             ;;
         remove)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             COMPREPLY+=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
                 xap xfce y' -- "$cur"))
             COMPREPLY+=($(
@@ -84,7 +84,7 @@ _comp_cmd_slackpkg()
             return
             ;;
         install | reinstall | upgrade | blacklist | download)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             COMPREPLY+=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
                 xap xfce y' -- "$cur"))
             COMPREPLY+=($(cut -f 6 -d\  "${WORKDIR}/pkglist" 2>/dev/null |

--- a/completions/_svn
+++ b/completions/_svn
@@ -26,11 +26,11 @@ _comp_cmd_svn()
 
         case $prev in
             --config-dir)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
                 ;;
             -F | --file | --targets)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             --encoding)
@@ -199,7 +199,7 @@ _comp_cmd_svn()
             if [[ $command == @(help|[h?]) ]]; then
                 COMPREPLY=($(compgen -W "$commands" -- "$cur"))
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
             fi
         fi
     fi

--- a/completions/_svnadmin
+++ b/completions/_svnadmin
@@ -21,7 +21,7 @@ _comp_cmd_svnadmin()
     else
         case $prev in
             --config-dir)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
                 ;;
             --fs-type)
@@ -67,7 +67,7 @@ _comp_cmd_svnadmin()
             if [[ $command == @(help|[h?]) ]]; then
                 COMPREPLY=($(compgen -W "$commands" -- "$cur"))
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
             fi
         fi
     fi

--- a/completions/_svnlook
+++ b/completions/_svnlook
@@ -52,7 +52,7 @@ _comp_cmd_svnlook()
             if [[ $command == @(help|[h?]) ]]; then
                 COMPREPLY=($(compgen -W "$commands" -- "$cur"))
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
             fi
         fi
     fi

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -38,7 +38,7 @@ _comp_cmd_udevadm()
             return
             ;;
         --device-id-of-file | --exit-if-exists)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --action)

--- a/completions/_xm
+++ b/completions/_xm
@@ -98,7 +98,7 @@ _comp_cmd_xm()
                     esac
                     ;;
                 restore | dry-run | vnet-create)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
                 save)
                     _count_args
@@ -107,7 +107,7 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         3)
-                            _comp_compgen filedir
+                            _comp_compgen_filedir
                             ;;
                     esac
                     ;;
@@ -186,7 +186,7 @@ _comp_cmd_xm()
                     esac
                     ;;
                 create)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     COMPREPLY+=(
                         $(compgen -W '$(command ls /etc/xen 2>/dev/null)' \
                             -- "$cur"))
@@ -194,11 +194,11 @@ _comp_cmd_xm()
                 new)
                     case $prev in
                         -f | -F | --defconfig | --config)
-                            _comp_compgen filedir
+                            _comp_compgen_filedir
                             return
                             ;;
                         --path)
-                            _comp_compgen filedir -d
+                            _comp_compgen_filedir -d
                             return
                             ;;
                     esac

--- a/completions/_yum
+++ b/completions/_yum
@@ -56,7 +56,7 @@ _comp_cmd_yum()
         # TODO: install|update|upgrade should not match *src.rpm
         if [[ $cur == @(*/|[.~])* &&
             $special == @(deplist|install|update|upgrade) ]]; then
-            _comp_compgen filedir rpm
+            _comp_compgen_filedir rpm
             return
         fi
         case $special in
@@ -94,16 +94,16 @@ _comp_cmd_yum()
             ;;
         localinstall | localupdate)
             # TODO: should not match *src.rpm
-            _comp_compgen filedir rpm
+            _comp_compgen_filedir rpm
             ;;
         -d | -e)
             COMPREPLY=($(compgen -W '{0..10}' -- "$cur"))
             ;;
         -c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         --installroot)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             ;;
         --enablerepo)
             COMPREPLY=($(compgen -W '$(_yum_repolist disabled)' -- "$cur"))

--- a/completions/a2x
+++ b/completions/a2x
@@ -13,7 +13,7 @@ _comp_cmd_a2x()
             return
             ;;
         --destination-dir | --icons-dir | -${noargopts}D)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --doctype | -${noargopts}d)
@@ -21,7 +21,7 @@ _comp_cmd_a2x()
             return
             ;;
         --stylesheet)
-            _comp_compgen filedir css
+            _comp_compgen_filedir css
             return
             ;;
     esac
@@ -34,7 +34,7 @@ _comp_cmd_a2x()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_a2x a2x
 

--- a/completions/abook
+++ b/completions/abook
@@ -33,14 +33,14 @@ _comp_cmd_abook()
             ;;
         --infile)
             COMPREPLY=($(compgen -W stdin -- "$cur"))
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         --outfile)
             COMPREPLY=($(compgen -W stdout -- "$cur"))
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         --config | --datafile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
     esac
 } &&

--- a/completions/aclocal
+++ b/completions/aclocal
@@ -10,11 +10,11 @@ _comp_cmd_aclocal()
             return
             ;;
         --acdir | -I)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --output)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --warnings | -W)

--- a/completions/acpi
+++ b/completions/acpi
@@ -12,7 +12,7 @@ _comp_cmd_acpi()
             return
             ;;
         --directory | -${noargopts}d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/add_members
+++ b/completions/add_members
@@ -7,7 +7,7 @@ _comp_cmd_add_members()
 
     case $prev in
         -r | -d | --regular-members-file | --digest-members-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -w | -a | --welcome-msg | --admin-notify)

--- a/completions/ant
+++ b/completions/ant
@@ -35,15 +35,15 @@ _comp_cmd_ant()
             return
             ;;
         -buildfile | -file | -f)
-            _comp_compgen filedir 'xml'
+            _comp_compgen_filedir 'xml'
             return
             ;;
         -logfile | -l)
-            [[ $1 != *phing || $prev != -l ]] && _comp_compgen filedir
+            [[ $1 != *phing || $prev != -l ]] && _comp_compgen_filedir
             return
             ;;
         -propertyfile)
-            _comp_compgen filedir properties
+            _comp_compgen_filedir properties
             return
             ;;
         -nice)
@@ -51,7 +51,7 @@ _comp_cmd_ant()
             return
             ;;
         -lib)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -logger | -listener | -inputhandler | -main | -find | -s)

--- a/completions/appdata-validate
+++ b/completions/appdata-validate
@@ -25,7 +25,7 @@ _comp_cmd_appdata_validate()
         return
     fi
 
-    _comp_compgen filedir appdata.xml
+    _comp_compgen_filedir appdata.xml
 } &&
     complete -F _comp_cmd_appdata_validate appdata-validate
 

--- a/completions/apt-build
+++ b/completions/apt-build
@@ -28,7 +28,7 @@ _comp_cmd_apt_build()
 
     case $prev in
         --patch | --build-dir | --repository-dir)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -h | --help)

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -41,7 +41,7 @@ _comp_cmd_apt_cache()
     if [[ $special && $ispecial -lt $cword ]]; then
         case $special in
             add)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 ;;
 
             showsrc)
@@ -60,11 +60,11 @@ _comp_cmd_apt_cache()
     # shellcheck disable=SC2254
     case $prev in
         --config-file | --pkg-cache | --src-cache | -${noargopts}[cps])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --with-source)
-            _comp_compgen filedir '@(deb|dsc|changes)'
+            _comp_compgen_filedir '@(deb|dsc|changes)'
             COMPREPLY+=($(
                 compgen -f -o plusdirs -X '!?(*/)@(Sources|Packages)' -- "$cur"
             ))

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -40,7 +40,7 @@ _comp_cmd_apt_get()
                 ;;
             install | reinstall)
                 if _comp_looks_like_path "$cur"; then
-                    _comp_compgen filedir deb
+                    _comp_compgen_filedir deb
                     return
                 elif [[ $cur == *=* ]]; then
                     package="${cur%%=*}"
@@ -57,7 +57,7 @@ _comp_cmd_apt_get()
                 fi
                 ;;&
             build-dep)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 _comp_looks_like_path "$cur" && return
                 ;;&
             *)
@@ -74,7 +74,7 @@ _comp_cmd_apt_get()
             return
             ;;
         --config-file | -${noargopts}c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --target-release | --default-release | -${noargopts}t)

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -40,11 +40,11 @@ _comp_cmd_apt_mark()
             return
             ;;
         --config-file | -${noargopts}c)
-            _comp_compgen filedir conf
+            _comp_compgen_filedir conf
             return
             ;;
         --file | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -55,7 +55,7 @@ _comp_cmd_aptitude()
             return
             ;;
         -${noargopts}S)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --display-format | --width | -${noargopts}[wFo])

--- a/completions/arch
+++ b/completions/arch
@@ -14,7 +14,7 @@ _comp_have_command mailmanctl &&
                 return
                 ;;
             --file)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
         esac
@@ -35,7 +35,7 @@ _comp_have_command mailmanctl &&
                     _comp_xfunc list_lists mailman_lists
                     ;;
                 2)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
             esac
         fi

--- a/completions/arp
+++ b/completions/arp
@@ -17,7 +17,7 @@ _comp_cmd_arp()
             return
             ;;
         --file | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --hw-type | -${noargopts}[Ht])

--- a/completions/asciidoc
+++ b/completions/asciidoc
@@ -23,7 +23,7 @@ _comp_cmd_asciidoc()
             return
             ;;
         --conf-file | -${noargopts}f)
-            _comp_compgen filedir conf
+            _comp_compgen_filedir conf
             return
             ;;
         --doctype | -${noargopts}d)
@@ -35,7 +35,7 @@ _comp_cmd_asciidoc()
             return
             ;;
         --out-file | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -49,7 +49,7 @@ _comp_cmd_asciidoc()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_asciidoc asciidoc asciidoc.py
 

--- a/completions/aspell
+++ b/completions/aspell
@@ -23,11 +23,11 @@ _comp_cmd_aspell()
 
     case $prev in
         -c | -p | check | --conf | --personal | --repl | --per-conf)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --conf-dir | --data-dir | --dict-dir | --home-dir | --local-data-dir | --prefix)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         dump | create | merge)

--- a/completions/autoconf
+++ b/completions/autoconf
@@ -10,7 +10,7 @@ _comp_cmd_autoconf()
             return
             ;;
         --output | -o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --warnings | -W)
@@ -20,7 +20,7 @@ _comp_cmd_autoconf()
             return
             ;;
         --prepend-include | -B | --include | -I)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -33,7 +33,7 @@ _comp_cmd_autoconf()
         return
     fi
 
-    _comp_compgen filedir '@(ac|in)'
+    _comp_compgen_filedir '@(ac|in)'
 } &&
     complete -F _comp_cmd_autoconf autoconf
 

--- a/completions/automake
+++ b/completions/automake
@@ -16,7 +16,7 @@ _comp_cmd_automake()
             return
             ;;
         --libdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -29,7 +29,7 @@ _comp_cmd_automake()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_automake automake automake-1.1{0..6}
 

--- a/completions/autoreconf
+++ b/completions/autoreconf
@@ -17,7 +17,7 @@ _comp_cmd_autoreconf()
             return
             ;;
         --prepend-include | -B | --include | -I)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -31,9 +31,9 @@ _comp_cmd_autoreconf()
     fi
 
     if [[ $1 == *autoheader ]]; then
-        _comp_compgen filedir '@(ac|in)'
+        _comp_compgen_filedir '@(ac|in)'
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_autoreconf autoreconf autoheader

--- a/completions/autoscan
+++ b/completions/autoscan
@@ -12,7 +12,7 @@ _comp_cmd_autoscan()
             return
             ;;
         --prepend-include | --include | -${noargopts}[BI])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -26,9 +26,9 @@ _comp_cmd_autoscan()
     fi
 
     if [[ $1 == *autoupdate ]]; then
-        _comp_compgen filedir '@(ac|in)'
+        _comp_compgen_filedir '@(ac|in)'
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_autoscan autoscan autoupdate

--- a/completions/badblocks
+++ b/completions/badblocks
@@ -10,7 +10,7 @@ _comp_cmd_badblocks()
             return
             ;;
         -*[io])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/bind
+++ b/completions/bind
@@ -15,7 +15,7 @@ _comp_cmd_bind()
             return
             ;;
         -*f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*[qu])

--- a/completions/btdownloadheadless.py
+++ b/completions/btdownloadheadless.py
@@ -7,7 +7,7 @@ _comp_cmd_btdownload()
 
     case $prev in
         --responsefile | --saveas)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -23,7 +23,7 @@ _comp_cmd_btdownload()
             --rarest_first_cutoff --min_uploads --report_hash_failures' \
             -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_btdownload btdownloadheadless.py btdownloadcurses.py \

--- a/completions/carton
+++ b/completions/carton
@@ -45,13 +45,13 @@ _comp_cmd_carton()
             ;;
         --cpanfile)
             if [[ $command == install ]]; then
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
             fi
             ;;
         --path)
             if [[ $command == install ]]; then
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
             fi
             ;;

--- a/completions/ccze
+++ b/completions/ccze
@@ -16,7 +16,7 @@ _comp_cmd_ccze()
             return
             ;;
         --rcfile | -${noargopts}F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --mode | -${noargopts}m)

--- a/completions/cd
+++ b/completions/cd
@@ -21,7 +21,7 @@ _comp_cmd_cd()
     # Use standard dir completion if no CDPATH or parameter starts with /,
     # ./ or ../
     if [[ ! ${CDPATH-} || $cur == ?(.)?(.)/* ]]; then
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
         return
     fi
 

--- a/completions/cfagent
+++ b/completions/cfagent
@@ -7,7 +7,7 @@ _comp_cmd_cfagent()
 
     case $prev in
         -f | --file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/cfrun
+++ b/completions/cfrun
@@ -16,7 +16,7 @@ _comp_cmd_cfrun()
         1)
             case $prev in
                 -f)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     return
                     ;;
             esac

--- a/completions/chage
+++ b/completions/chage
@@ -13,7 +13,7 @@ _comp_cmd_chage()
             return
             ;;
         --root | -${noargopts}R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/checksec
+++ b/completions/checksec
@@ -10,11 +10,11 @@ _comp_cmd_checksec()
             return
             ;;
         --file | --fortify-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --proc)

--- a/completions/chgrp
+++ b/completions/chgrp
@@ -8,7 +8,7 @@ _comp_cmd_chgrp()
     cur=${cur//\\\\/}
 
     if [[ $prev == --reference ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
         return
     fi
 

--- a/completions/chmod
+++ b/completions/chmod
@@ -10,7 +10,7 @@ _comp_cmd_chmod()
             return
             ;;
         --reference)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -34,7 +34,7 @@ _comp_cmd_chmod()
 
     case $args in
         1) ;; # mode
-        *) _comp_compgen filedir ;;
+        *) _comp_compgen_filedir ;;
     esac
 } &&
     complete -F _comp_cmd_chmod chmod

--- a/completions/chown
+++ b/completions/chown
@@ -12,7 +12,7 @@ _comp_cmd_chown()
             return
             ;;
         --reference)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -37,7 +37,7 @@ _comp_cmd_chown()
         if ((args == 1)); then
             _usergroup -u
         else
-            _comp_compgen filedir
+            _comp_compgen_filedir
         fi
     fi
 } &&

--- a/completions/chpasswd
+++ b/completions/chpasswd
@@ -17,7 +17,7 @@ _comp_cmd_chpasswd()
             return
             ;;
         --root | -${noargopts}R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/chromium-browser
+++ b/completions/chromium-browser
@@ -10,7 +10,7 @@ _comp_cmd_chromium_browser()
             return
             ;;
         --user-data-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --proxy-server)
@@ -42,7 +42,7 @@ _comp_cmd_chromium_browser()
         return
     fi
 
-    _comp_compgen filedir "@(?([mxs])htm?(l)|pdf|txt)"
+    _comp_compgen_filedir "@(?([mxs])htm?(l)|pdf|txt)"
 } &&
     complete -F _comp_cmd_chromium_browser chromium-browser google-chrome \
         google-chrome-stable chromium chrome

--- a/completions/chrpath
+++ b/completions/chrpath
@@ -12,7 +12,7 @@ _comp_cmd_chrpath()
             return
             ;;
         --replace | -${noargopts}r)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -22,7 +22,7 @@ _comp_cmd_chrpath()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_chrpath chrpath
 

--- a/completions/cksfv
+++ b/completions/cksfv
@@ -12,16 +12,16 @@ _comp_cmd_cksfv()
 
     case "$prev" in
         -*C | -*g)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -*f)
-            _comp_compgen filedir 'sfv'
+            _comp_compgen_filedir 'sfv'
             return
             ;;
     esac
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 
 } &&
     complete -F _comp_cmd_cksfv cksfv

--- a/completions/clisp
+++ b/completions/clisp
@@ -13,7 +13,7 @@ _comp_cmd_clisp()
             -N -E -q --quiet --silent -w -I -ansi -traditional -p -C -norc -i
             -c -l -o -x ' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/config_list
+++ b/completions/config_list
@@ -7,7 +7,7 @@ _comp_cmd_config_list()
 
     case $prev in
         -i | -o | --inputfile | --outputfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/configure
+++ b/completions/configure
@@ -11,17 +11,17 @@ _comp_cmd_configure()
             return
             ;;
         --*file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --*prefix | --*dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
 
     if [[ $was_split || $cur != -* ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
         return
     fi
 

--- a/completions/convert
+++ b/completions/convert
@@ -98,7 +98,7 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -mask | -profile | -texture | -tile | -write)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -type)
@@ -141,7 +141,7 @@ _comp_cmd_convert()
             +dither +endian +gamma +label +map +mask +matte +negate +noise
             +page +raise +render +write' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_convert convert
@@ -159,7 +159,7 @@ _comp_cmd_mogrify()
         COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
             +gamma +label +map +mask +matte +negate +page +raise' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_mogrify mogrify
@@ -177,7 +177,7 @@ _comp_cmd_display()
         COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
             +gamma +label +map +matte +negate +page +raise +write' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_display display
@@ -195,7 +195,7 @@ _comp_cmd_animate()
         COMPREPLY=($(compgen -W '+debug +dither +gamma +map +matte' \
             -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_animate animate
@@ -212,7 +212,7 @@ _comp_cmd_identify()
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_identify identify
@@ -230,7 +230,7 @@ _comp_cmd_montage()
         COMPREPLY=($(compgen -W '+adjoin +compress +debug +dither +endian
             +gamma +label +matte +page' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_montage montage
@@ -248,7 +248,7 @@ _comp_cmd_composite()
         COMPREPLY=($(compgen -W '+compress +debug +dither +endian +label
             +matte +negate +page +write' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_composite composite
@@ -265,7 +265,7 @@ _comp_cmd_compare()
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_compare compare
@@ -282,7 +282,7 @@ _comp_cmd_conjure()
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_conjure conjure
@@ -299,7 +299,7 @@ _comp_cmd_import()
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_import import
@@ -316,7 +316,7 @@ _comp_cmd_stream()
     elif [[ $cur == +* ]]; then
         COMPREPLY=($(compgen -W '+debug' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_stream stream

--- a/completions/cpan2dist
+++ b/completions/cpan2dist
@@ -14,7 +14,7 @@ _comp_cmd_cpan2dist()
             return
             ;;
         --banlist | --ignorelist | --modulelist | --logfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/cpio
+++ b/completions/cpio
@@ -15,7 +15,7 @@ _comp_cmd_cpio()
             return
             ;;
         --file | --pattern-file | -${noargopts}[EFI])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --owner | -${noargopts}R)
@@ -69,7 +69,7 @@ _comp_cmd_cpio()
                         --no-preserve-owner --sparse --help --version' \
                         -- "$cur"))
                 else
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                 fi
                 ;;
         esac

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -8,7 +8,7 @@ _comp_cmd_cppcheck()
     case $prev in
         --append | --exitcode-suppressions | --rule-file | --config-excludes-file | \
             --suppressions-list | --includes-file | --include | -i)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -D | -U | --rule | --suppress | --template | --max-configs | -h | --help | --version | \
@@ -34,12 +34,12 @@ _comp_cmd_cppcheck()
             return
             ;;
         --file-list)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             [[ ! $cur || $cur == - ]] && COMPREPLY+=(-)
             return
             ;;
         -I)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -j)
@@ -56,19 +56,19 @@ _comp_cmd_cppcheck()
             return
             ;;
         --platform)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             COMPREPLY+=($(compgen -W 'unix32 unix64 win32A win32W win64
                 native' -- "$cur"))
             return
             ;;
         -rp | --relative-paths)
             if [[ $was_split ]]; then # -rp without argument is allowed
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
             fi
             ;;
         --library)
-            _comp_compgen filedir cfg
+            _comp_compgen_filedir cfg
             return
             ;;
         --xml-version)
@@ -83,7 +83,7 @@ _comp_cmd_cppcheck()
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir '@([cht]pp|[cht]xx|cc|[ch]++|[ch])'
+        _comp_compgen_filedir '@([cht]pp|[cht]xx|cc|[ch]++|[ch])'
     fi
 } &&
     complete -F _comp_cmd_cppcheck cppcheck

--- a/completions/crontab
+++ b/completions/crontab
@@ -41,7 +41,7 @@ _comp_cmd_crontab()
     fi
 
     # do filenames only if we did not have -l, -r, or -e
-    [[ ${words[*]} == *\ -[lre]* ]] || _comp_compgen filedir
+    [[ ${words[*]} == *\ -[lre]* ]] || _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_crontab crontab
 

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -23,7 +23,7 @@ _comp_cmd_cryptsetup()
             return
             ;;
         --key-file | --master-key-file | --header-backup-file | -${noargopts}d)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --type | -${noargopts}M)
@@ -74,7 +74,7 @@ _comp_cmd_cryptsetup()
                         _comp_cmd_cryptsetup__device
                         ;;
                     3)
-                        _comp_compgen filedir
+                        _comp_compgen_filedir
                         ;;
                 esac
                 ;;

--- a/completions/curl
+++ b/completions/curl
@@ -13,7 +13,7 @@ _comp_cmd_curl()
             --etag-save | --hsts | --key | --libcurl | --netrc-file | \
             --output | --proxy-key | --random-file | --trace | --trace-ascii | \
             --unix-socket | --upload-file | -${noargopts}[KbcDoT])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --ciphers | --connect-timeout | --connect-to | --continue-at | \
@@ -35,11 +35,11 @@ _comp_cmd_curl()
             return
             ;;
         --cacert | --cert | --proxy-cacert | --proxy-cert | -${noargopts}E)
-            _comp_compgen filedir '@(c?(e)rt|cer|pem|der)'
+            _comp_compgen_filedir '@(c?(e)rt|cer|pem|der)'
             return
             ;;
         --capath | --output-dir | --proxy-capath)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --cert-type | --key-type | --proxy-cert-type | --proxy-key-type)
@@ -47,7 +47,7 @@ _comp_cmd_curl()
             return
             ;;
         --crlfile | --proxy-crlfile)
-            _comp_compgen filedir crl
+            _comp_compgen_filedir crl
             return
             ;;
         --data | --data-ascii | --data-binary | --data-urlencode | --header | \
@@ -121,7 +121,7 @@ _comp_cmd_curl()
             return
             ;;
         --pinnedpubkey | --proxy-pinnedpubkey)
-            _comp_compgen filedir '@(pem|der|key)'
+            _comp_compgen_filedir '@(pem|der|key)'
             return
             ;;
         --preproxy | --proxy | --socks4 | --socks4a | --socks5 | \
@@ -144,7 +144,7 @@ _comp_cmd_curl()
             ;;
         --stderr)
             COMPREPLY=($(compgen -W '-' -- "$cur"))
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --tls-max)

--- a/completions/cvs
+++ b/completions/cvs
@@ -189,7 +189,7 @@ _comp_cmd_cvs()
                     return
                     ;;
                 -*t)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     return
                     ;;
                 -*k)
@@ -224,7 +224,7 @@ _comp_cmd_cvs()
                     return
                     ;;
                 -*d)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     return
                     ;;
                 -*k)
@@ -250,7 +250,7 @@ _comp_cmd_cvs()
                     return
                     ;;
                 -*F)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     return
                     ;;
             esac
@@ -309,7 +309,7 @@ _comp_cmd_cvs()
                     return
                     ;;
                 -*d)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     return
                     ;;
                 -*k)
@@ -396,7 +396,7 @@ _comp_cmd_cvs()
             case $prev in
                 --*) ;;
                 -*T)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     return
                     ;;
                 -*[es])

--- a/completions/cvsps
+++ b/completions/cvsps
@@ -30,11 +30,11 @@ _comp_cmd_cvsps()
             return
             ;;
         -p)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --test-log)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -Z)

--- a/completions/deja-dup
+++ b/completions/deja-dup
@@ -10,11 +10,11 @@ _comp_cmd_deja_dup()
             return
             ;;
         --restore)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --restore-missing)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/desktop-file-validate
+++ b/completions/desktop-file-validate
@@ -16,7 +16,7 @@ _comp_cmd_desktop_file_validate()
         return
     fi
 
-    _comp_compgen filedir desktop
+    _comp_compgen_filedir desktop
 } &&
     complete -F _comp_cmd_desktop_file_validate desktop-file-validate
 

--- a/completions/dhclient
+++ b/completions/dhclient
@@ -14,7 +14,7 @@ _comp_cmd_dhclient()
             return
             ;;
         -*f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -s)

--- a/completions/dmypy
+++ b/completions/dmypy
@@ -10,7 +10,7 @@ _comp_cmd_dmypy()
             return
             ;;
         --status-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -26,7 +26,7 @@ _comp_cmd_dmypy()
 
     case ${cmd-} in
         check | run)
-            _comp_compgen filedir '@(py|pyi)'
+            _comp_compgen_filedir '@(py|pyi)'
             return
             ;;
     esac

--- a/completions/dnssec-keygen
+++ b/completions/dnssec-keygen
@@ -19,7 +19,7 @@ _comp_cmd_dnssec_keygen()
             return
             ;;
         -K)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -[ancdfTtm])

--- a/completions/dnsspoof
+++ b/completions/dnsspoof
@@ -11,7 +11,7 @@ _comp_cmd_dnsspoof()
             return
             ;;
         -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/dot
+++ b/completions/dot
@@ -39,7 +39,7 @@ _comp_cmd_dot()
         return
     fi
 
-    _comp_compgen filedir dot
+    _comp_compgen_filedir dot
 } &&
     complete -F _comp_cmd_dot dot
 

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -54,11 +54,11 @@ _comp_cmd_dpkg()
     case $prev in
         --install | --unpack | --record-avail | --contents | --info | --fsys-tarfile | \
             --field | --control | --extract | --vextract | --raw-extract | -${noargopts}[ciAIfexX])
-            _comp_compgen filedir '?(u|d)deb'
+            _comp_compgen_filedir '?(u|d)deb'
             return
             ;;
         --build | --admindir | --instdir | --root | -${noargopts}b)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --status | --print-avail | --list | -${noargopts}[spl])
@@ -69,12 +69,12 @@ _comp_cmd_dpkg()
             if [[ $1 == *dpkg-query ]]; then
                 COMPREPLY=($(_comp_xfunc apt-cache packages))
             else
-                _comp_compgen filedir '?(u|d)deb'
+                _comp_compgen_filedir '?(u|d)deb'
             fi
             return
             ;;
         --search | -${noargopts}S)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --remove | --verify | -${noargopts}[rV])
@@ -97,7 +97,7 @@ _comp_cmd_dpkg()
             return
             ;;
         --log)
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         --path-exclude | --path-include)

--- a/completions/dpkg-source
+++ b/completions/dpkg-source
@@ -29,7 +29,7 @@ _comp_cmd_dpkg_source()
         unpack)
             case $prev in
                 -x)
-                    _comp_compgen filedir 'dsc'
+                    _comp_compgen_filedir 'dsc'
                     ;;
                 *)
                     COMPREPLY=($(compgen -W "$unpackopts" -- "$cur"))
@@ -41,7 +41,7 @@ _comp_cmd_dpkg_source()
         pack)
             case $prev in
                 -b)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     ;;
                 -c | -l | -T | -i | -I)
                     # -c: get controlfile
@@ -50,7 +50,7 @@ _comp_cmd_dpkg_source()
                     # -i: <regexp> filter out files to ignore diffs of.
                     # -I: filter out files when building tarballs.
                     # return directory names and file names
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
                 -F)
                     # -F: force change log format

--- a/completions/dselect
+++ b/completions/dselect
@@ -7,11 +7,11 @@ _comp_cmd_dselect()
 
     case $prev in
         --admindir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -D | -debug)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/dsniff
+++ b/completions/dsniff
@@ -7,7 +7,7 @@ _comp_cmd_dsniff()
 
     case $prev in
         -r | -w | -f | -p)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -i)

--- a/completions/dumpdb
+++ b/completions/dumpdb
@@ -9,7 +9,7 @@ _comp_cmd_dumpdb()
         COMPREPLY=($(compgen -W '--marshal --pickle --noprint --help' \
             -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/dumpe2fs
+++ b/completions/dumpe2fs
@@ -10,7 +10,7 @@ _comp_cmd_dumpe2fs()
             return
             ;;
         -*i)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/eog
+++ b/completions/eog
@@ -19,7 +19,7 @@ _comp_cmd_eog()
         return
     fi
 
-    _comp_compgen filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[gp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m)'
+    _comp_compgen_filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[gp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m)'
 } &&
     complete -F _comp_cmd_eog eog
 

--- a/completions/evince
+++ b/completions/evince
@@ -14,7 +14,7 @@ _comp_cmd_evince()
             return
             ;;
         --sm-client-state-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -27,7 +27,7 @@ _comp_cmd_evince()
         return
     fi
 
-    _comp_compgen filedir '@(@(?(e)ps|?(E)PS|[pf]df|[PF]DF|dvi|DVI)?(.gz|.GZ|.bz2|.BZ2|.xz|.XZ)|cb[7rtz]|djv?(u)|tif?(f)|?(o)xps)'
+    _comp_compgen_filedir '@(@(?(e)ps|?(E)PS|[pf]df|[PF]DF|dvi|DVI)?(.gz|.GZ|.bz2|.BZ2|.xz|.XZ)|cb[7rtz]|djv?(u)|tif?(f)|?(o)xps)'
 } &&
     complete -F _comp_cmd_evince evince
 

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -43,7 +43,7 @@ _comp_cmd_fbgs()
         [[ ${COMPREPLY-} ]] && return
     fi
 
-    _comp_compgen filedir '?(e)ps|pdf'
+    _comp_compgen_filedir '?(e)ps|pdf'
 } &&
     complete -F _comp_cmd_fbgs fbgs
 

--- a/completions/fbi
+++ b/completions/fbi
@@ -7,7 +7,7 @@ _comp_cmd_fbi()
 
     case "$prev" in
         -l | --list)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -r | --resolution)
@@ -47,7 +47,7 @@ _comp_cmd_fbi()
 
     # FIXME: It is hard to determine correct supported extensions.
     # fbi can handle any format that imagemagick can plus some others
-    _comp_compgen filedir 'bmp|gif|jp?(e)g|pcd|png|p[pgb]m|tif?(f)|webp|xpm|xwd|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf'
+    _comp_compgen_filedir 'bmp|gif|jp?(e)g|pcd|png|p[pgb]m|tif?(f)|webp|xpm|xwd|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf'
 } &&
     complete -F _comp_cmd_fbi fbi
 

--- a/completions/feh
+++ b/completions/feh
@@ -13,11 +13,11 @@ _comp_cmd_feh()
             return
             ;;
         --filelist | --output | --output-only | --start-at | -${noargopts}[foO\|])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --caption-path | --fontpath | --output-dir | -${noargopts}[KCj])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --font | --menu-font | --title-font | -${noargopts}[eM@])
@@ -82,7 +82,7 @@ _comp_cmd_feh()
             return
             ;;
         --bg | -${noargopts}b)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             COMPREPLY+=($(compgen -W 'trans' -- "$cur"))
             return
             ;;
@@ -115,7 +115,7 @@ _comp_cmd_feh()
 
     # FIXME: It is hard to determine correct supported extensions.
     # feh can handle any format that imagemagick can plus some others
-    _comp_compgen filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp'
+    _comp_compgen_filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp'
 } &&
     complete -F _comp_cmd_feh feh
 

--- a/completions/file
+++ b/completions/file
@@ -12,7 +12,7 @@ _comp_cmd_file()
             return
             ;;
         --magic-file | --files-from | -${noargopts}[mf])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --exclude | -${noargopts}e)
@@ -27,7 +27,7 @@ _comp_cmd_file()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_file file
 

--- a/completions/file-roller
+++ b/completions/file-roller
@@ -14,7 +14,7 @@ _comp_cmd_file_roller()
             return
             ;;
         --sm-client-state-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --add-to | -${noargopts}a)
@@ -23,7 +23,7 @@ _comp_cmd_file_roller()
             return
             ;;
         --extract-to | --default-dir | -${noargopts}e)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/filefrag
+++ b/completions/filefrag
@@ -10,7 +10,7 @@ _comp_cmd_filefrag()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_filefrag filefrag
 

--- a/completions/find
+++ b/completions/find
@@ -22,7 +22,7 @@ _comp_cmd_find()
             ;;
         -newer | -anewer | -cnewer | -fls | -fprint | -fprint0 | -fprintf | -name | -[il]name | \
             -ilname | -wholename | -[il]wholename | -samefile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -fstype)
@@ -71,7 +71,7 @@ _comp_cmd_find()
 
     # handle case where first parameter is not a dash option
     if [[ ! $exprfound && $cur != [-\(\),\!]* ]]; then
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
         return
     fi
 

--- a/completions/fio
+++ b/completions/fio
@@ -50,7 +50,7 @@ _comp_cmd_fio()
             return
             ;;
         --daemonize)
-            _comp_compgen filedir pid
+            _comp_compgen_filedir pid
             return
             ;;
         --client)
@@ -58,7 +58,7 @@ _comp_cmd_fio()
             return
             ;;
         --remote-config)
-            _comp_compgen filedir '@(fio|job)'
+            _comp_compgen_filedir '@(fio|job)'
             return
             ;;
         --idle-prof)
@@ -66,11 +66,11 @@ _comp_cmd_fio()
             return
             ;;
         --inflate-log)
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         --trigger-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --trigger | --trigger-remote)
@@ -79,7 +79,7 @@ _comp_cmd_fio()
             return
             ;;
         --aux-path)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --ioengine)
@@ -151,7 +151,7 @@ _comp_cmd_fio()
         return
     fi
 
-    _comp_compgen filedir '@(fio|job)'
+    _comp_compgen_filedir '@(fio|job)'
 } &&
     complete -F _comp_cmd_fio fio
 

--- a/completions/firefox
+++ b/completions/firefox
@@ -21,15 +21,15 @@ _comp_cmd_firefox()
             return
             ;;
         --profile | --screenshot)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -MOZ_LOG_FILE)
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         --recording-output | --recording-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --debugger | -d)
@@ -46,7 +46,7 @@ _comp_cmd_firefox()
         return
     fi
 
-    _comp_compgen filedir "@(?([xs])htm?(l)|pdf|txt|svg)"
+    _comp_compgen_filedir "@(?([xs])htm?(l)|pdf|txt|svg)"
 } &&
     complete -F _comp_cmd_firefox firefox firefox-esr iceweasel mozilla-firefox
 

--- a/completions/flake8
+++ b/completions/flake8
@@ -20,11 +20,11 @@ _comp_cmd_flake8()
             return
             ;;
         --output-file | --append-config | --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --include-in-doctest | --exclude-from-doctest)
-            _comp_compgen filedir py
+            _comp_compgen_filedir py
             return
             ;;
     esac
@@ -37,7 +37,7 @@ _comp_cmd_flake8()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_flake8 flake8
 

--- a/completions/freebsd-update
+++ b/completions/freebsd-update
@@ -9,11 +9,11 @@ _comp_cmd_freebsd_update()
 
     case $prev in
         -b | -d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -k | -r | -s | -t)

--- a/completions/freeciv
+++ b/completions/freeciv
@@ -10,7 +10,7 @@ _comp_cmd_freeciv()
             return
             ;;
         --file | --log | --music | --read | --Sound | --tiles | -[flmrSt])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --Announce | -A)

--- a/completions/freeciv-server
+++ b/completions/freeciv-server
@@ -7,7 +7,7 @@ _comp_cmd_civserver()
 
     case $prev in
         -f | -g | -l | -r | --file | --log | --gamelog | --read)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/fusermount
+++ b/completions/fusermount
@@ -20,7 +20,7 @@ _comp_cmd_fusermount()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_fusermount fusermount

--- a/completions/gcc
+++ b/completions/gcc
@@ -16,7 +16,7 @@ _comp_cmd_gcc()
                 -- "$cur"))
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            _comp_compgen filedir
+            _comp_compgen_filedir
         fi
         return
     fi
@@ -46,7 +46,7 @@ _comp_cmd_gcc()
     fi
 
     if [[ ! $argument ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
     else
         # In situation like '-fsanitize=add' $cur is equal to last token.
         # Thus we need to strip the beginning of suggested option.

--- a/completions/gcl
+++ b/completions/gcl
@@ -12,7 +12,7 @@ _comp_cmd_gcl()
         COMPREPLY=($(compgen -W '-eval -load -f -batch -dir -libdir -compile
             -o-file -c-file -h-file -data-file -system-p' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/gendiff
+++ b/completions/gendiff
@@ -5,7 +5,7 @@ _comp_cmd_gendiff()
     local cur prev words cword comp_args
     _comp_initialize -o '@(diff|patch)' -- "$@" || return
 
-    ((cword == 1)) && _comp_compgen filedir -d
+    ((cword == 1)) && _comp_compgen_filedir -d
 } &&
     complete -F _comp_cmd_gendiff gendiff
 

--- a/completions/genisoimage
+++ b/completions/genisoimage
@@ -8,7 +8,7 @@ _comp_cmd_mkisofs()
     case $prev in
         -o | -abstract | -biblio | -check-session | -copyright | -log-file | \
             -root-info | -prep-boot | -*-list)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*-charset)
@@ -29,7 +29,7 @@ _comp_cmd_mkisofs()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/geoiplookup
+++ b/completions/geoiplookup
@@ -10,11 +10,11 @@ _comp_cmd_geoiplookup()
             return
             ;;
         -d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -f)
-            _comp_compgen filedir dat
+            _comp_compgen_filedir dat
             return
             ;;
     esac

--- a/completions/getconf
+++ b/completions/getconf
@@ -7,7 +7,7 @@ _comp_cmd_getconf()
 
     case $prev in
         -a)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -v)
@@ -19,7 +19,7 @@ _comp_cmd_getconf()
     esac
 
     if [[ $prev == PATH_MAX ]]; then # TODO more path vars, better handling
-        _comp_compgen filedir
+        _comp_compgen_filedir
     elif [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '-a -v' -- "$cur"))
     else

--- a/completions/gkrellm
+++ b/completions/gkrellm
@@ -7,11 +7,11 @@ _comp_cmd_gkrellm()
 
     case $prev in
         -t | --theme)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -p | --plugin)
-            _comp_compgen filedir so
+            _comp_compgen_filedir so
             return
             ;;
         -s | --server)
@@ -19,7 +19,7 @@ _comp_cmd_gkrellm()
             return
             ;;
         -l | --logfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -g | --geometry | -c | --config | -P | --port | -d | --debug-level)

--- a/completions/gnatmake
+++ b/completions/gnatmake
@@ -18,7 +18,7 @@ _comp_cmd_gnatmake()
             -gnatz -gnatZ -gnat83' -- "$cur"))
     else
         # source file completion
-        _comp_compgen filedir '@(adb|ads)'
+        _comp_compgen_filedir '@(adb|ads)'
     fi
 } &&
     complete -F _comp_cmd_gnatmake gnatmake

--- a/completions/gnokii
+++ b/completions/gnokii
@@ -13,7 +13,7 @@ _comp_cmd_gnokii()
 
     case $prev in
         --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --phone)
@@ -87,7 +87,7 @@ _comp_cmd_gnokii()
             return
             ;;
         --writecalendarnote | --writetodo)
-            _comp_compgen filedir vcf
+            _comp_compgen_filedir vcf
             return
             ;;
 

--- a/completions/gnome-mplayer
+++ b/completions/gnome-mplayer
@@ -14,7 +14,7 @@ _comp_cmd_gnome_mplayer()
             return
             ;;
         --subtitle)
-            _comp_compgen filedir '@(srt|sub|txt|utf|rar|mpsub|smi|js|ssa|ass)'
+            _comp_compgen_filedir '@(srt|sub|txt|utf|rar|mpsub|smi|js|ssa|ass)'
             return
             ;;
         --tvdriver)
@@ -31,7 +31,7 @@ _comp_cmd_gnome_mplayer()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_gnome_mplayer gnome-mplayer
 

--- a/completions/gnome-screenshot
+++ b/completions/gnome-screenshot
@@ -16,7 +16,7 @@ _comp_cmd_gnome_screenshot()
             return
             ;;
         --file | -${noargopts}f)
-            _comp_compgen filedir '@(jp?(e)|pn)g'
+            _comp_compgen_filedir '@(jp?(e)|pn)g'
             return
             ;;
     esac

--- a/completions/gpg
+++ b/completions/gpg
@@ -10,7 +10,7 @@ _comp_cmd_gpg()
     case $prev in
         --sign | --clear-sign | --clearsign | --decrypt-files | \
             --load-extension | -${noargopts}s)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --list-keys | --list-public-keys | --locate-keys | \

--- a/completions/gpg2
+++ b/completions/gpg2
@@ -9,11 +9,11 @@ _comp_cmd_gpg2()
     # shellcheck disable=SC2254
     case $prev in
         --homedir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --sign | --clearsign | --options | --decrypt | -${noargopts}s)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --export | --sign-key | --lsign-key | --nrsign-key | --nrlsign-key | \

--- a/completions/gpgv
+++ b/completions/gpgv
@@ -10,11 +10,11 @@ _comp_cmd_gpgv()
             return
             ;;
         --keyring)
-            _comp_compgen filedir "@(gpg|kbx)"
+            _comp_compgen_filedir "@(gpg|kbx)"
             return
             ;;
         --homedir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -35,10 +35,10 @@ _comp_cmd_gpgv()
                 _comp_compgen -a filedir
             fi
         else
-            _comp_compgen filedir gpg
+            _comp_compgen_filedir gpg
         fi
     else
-        _comp_compgen filedir "@(asc|gpg|sig|sign)"
+        _comp_compgen_filedir "@(asc|gpg|sig|sign)"
     fi
 } &&
     complete -F _comp_cmd_gpgv gpgv gpgv2

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -7,19 +7,19 @@ _comp_cmd_gphoto2()
 
     case $prev in
         --debug-logfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --hook-script)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --filename)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -u | --upload-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --port)

--- a/completions/gprof
+++ b/completions/gprof
@@ -24,11 +24,11 @@ _comp_cmd_gprof()
 
     case $prev in
         -I | --directory-path)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -R | --file-ordering | --external-symbol-table)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -w | --width | -k | -m | --min-count | -h | --help | -e | -E | -f | -F)
@@ -48,7 +48,7 @@ _comp_cmd_gprof()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_gprof gprof
 

--- a/completions/groupdel
+++ b/completions/groupdel
@@ -10,7 +10,7 @@ _comp_cmd_groupdel()
             return
             ;;
         -R | --root)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/groupmems
+++ b/completions/groupmems
@@ -15,7 +15,7 @@ _comp_cmd_groupmems()
             return
             ;;
         -R | --root)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/growisofs
+++ b/completions/growisofs
@@ -31,7 +31,7 @@ _comp_cmd_growisofs()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_growisofs growisofs
 

--- a/completions/grpck
+++ b/completions/grpck
@@ -9,7 +9,7 @@ _comp_cmd_grpck()
     # shellcheck disable=SC2254
     case $prev in
         --root | -${noargopts}R)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -21,7 +21,7 @@ _comp_cmd_grpck()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_grpck grpck
 

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -195,7 +195,7 @@ _comp_cmd_rfcomm()
 
     case $prev in
         -f | --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -i)
@@ -291,7 +291,7 @@ _comp_cmd_dfutool()
                     -- "$cur"))
                 ;;
             2)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 ;;
         esac
     fi

--- a/completions/hddtemp
+++ b/completions/hddtemp
@@ -9,7 +9,7 @@ _comp_cmd_hddtemp()
     # shellcheck disable=SC2254
     case $prev in
         --file | -${noargopts}f)
-            _comp_compgen filedir db
+            _comp_compgen_filedir db
             return
             ;;
         --listen | -${noargopts}l)

--- a/completions/hostname
+++ b/completions/hostname
@@ -12,7 +12,7 @@ _comp_cmd_hostname()
             return
             ;;
         --file | -${noargopts}F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/hping2
+++ b/completions/hping2
@@ -21,7 +21,7 @@ _comp_cmd_hping2()
             return
             ;;
         --file | -${noargopts}E)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/htpasswd
+++ b/completions/htpasswd
@@ -23,7 +23,7 @@ _comp_cmd_htpasswd()
             return
         fi
         # Password file (first non-option argument)
-        _comp_compgen filedir
+        _comp_compgen_filedir
 
     elif ((o == cword - 1)); then
         # Username (second non-option argument)

--- a/completions/hunspell
+++ b/completions/hunspell
@@ -25,7 +25,7 @@ _comp_cmd_hunspell()
             return
             ;;
         -p)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -35,7 +35,7 @@ _comp_cmd_hunspell()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_hunspell hunspell
 

--- a/completions/iconv
+++ b/completions/iconv
@@ -25,7 +25,7 @@ _comp_cmd_iconv()
             return
             ;;
         --output | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/iftop
+++ b/completions/iftop
@@ -14,7 +14,7 @@ _comp_cmd_iftop()
             return
             ;;
         -c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/ifup
+++ b/completions/ifup
@@ -14,11 +14,11 @@ _comp_cmd_ifupdown()
             return
             ;;
         --interfaces | -${noargopts}i)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --state-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/influx
+++ b/completions/influx
@@ -22,7 +22,7 @@ _comp_cmd_influx()
             return
             ;;
         -import | -path)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/info
+++ b/completions/info
@@ -7,7 +7,7 @@ _comp_cmd_info()
 
     # default completion if parameter looks like a path
     if [[ $cur == @(*/|[.~])* ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
         return
     fi
 
@@ -19,16 +19,16 @@ _comp_cmd_info()
             ;;
         -${noargopts}d)
             if [[ ${1##*/} == info ]]; then
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
             fi
             ;;
         --directory)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --dribble | --file | --output | --restore | --raw-filename | --rcfile | -${noargopts}[for])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/inject
+++ b/completions/inject
@@ -17,7 +17,7 @@ _comp_cmd_inject()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '--listname --queue --help' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/inotifywait
+++ b/completions/inotifywait
@@ -23,7 +23,7 @@ _comp_cmd_inotifywait()
             return
             ;;
         --fromfile | --outfile | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --event | -${noargopts}e)
@@ -42,7 +42,7 @@ _comp_cmd_inotifywait()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_inotifywait inotifywait inotifywatch
 

--- a/completions/insmod
+++ b/completions/insmod
@@ -7,7 +7,7 @@ _comp_cmd_insmod()
 
     # do filename completion for first argument
     if ((cword == 1)); then
-        _comp_compgen filedir '@(?(k)o?(.[gx]z|.zst))'
+        _comp_compgen_filedir '@(?(k)o?(.[gx]z|.zst))'
     else # do module parameter completion
         COMPREPLY=($(compgen -W "$(PATH="$PATH:/sbin" modinfo \
             -p "${words[1]}" 2>/dev/null | cut -d: -f1)" -- "$cur"))

--- a/completions/installpkg
+++ b/completions/installpkg
@@ -7,7 +7,7 @@ _comp_cmd_installpkg()
 
     case "$prev" in
         --root)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --priority)
@@ -15,7 +15,7 @@ _comp_cmd_installpkg()
             return
             ;;
         --tagfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -26,7 +26,7 @@ _comp_cmd_installpkg()
         return
     fi
 
-    _comp_compgen filedir 't[bglx]z'
+    _comp_compgen_filedir 't[bglx]z'
 } &&
     complete -F _comp_cmd_installpkg installpkg
 

--- a/completions/interdiff
+++ b/completions/interdiff
@@ -28,7 +28,7 @@ _comp_cmd_interdiff()
             break
         fi
     done
-    _comp_compgen filedir "$exts"
+    _comp_compgen_filedir "$exts"
 } &&
     complete -F _comp_cmd_interdiff interdiff
 

--- a/completions/ip
+++ b/completions/ip
@@ -30,7 +30,7 @@ _comp_cmd_ip()
             return
             ;;
         -b | -batch)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -n | -netns)

--- a/completions/iperf
+++ b/completions/iperf
@@ -27,11 +27,11 @@ _comp_cmd_iperf()
             return
             ;;
         --pidfile | -${noargopts}I)
-            _comp_compgen filedir pid
+            _comp_compgen_filedir pid
             return
             ;;
         --output | --fileinput | --authorized-users-path | -${noargopts}[oF])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --bind | -${noargopts}B)
@@ -57,11 +57,11 @@ _comp_cmd_iperf()
             return
             ;;
         --logfile)
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         --rsa-private-key-path | --rsa-public-key-path)
-            _comp_compgen filedir pem
+            _comp_compgen_filedir pem
             return
             ;;
     esac

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -34,7 +34,7 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*[fSO])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*C)
@@ -87,7 +87,7 @@ _comp_cmd_ipmitool()
         shell) ;;
 
         exec)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
 
         chassis | power | kontronoem | fwum)
@@ -122,7 +122,7 @@ _comp_cmd_ipmitool()
                         generic' -- "$cur"))
                     ;;
                 dump)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
                 fill)
                     case $prev in
@@ -130,7 +130,7 @@ _comp_cmd_ipmitool()
                             COMPREPLY=($(compgen -W 'sensors file' -- "$cur"))
                             ;;
                         file)
-                            _comp_compgen filedir
+                            _comp_compgen_filedir
                             ;;
                     esac
                     ;;
@@ -156,7 +156,7 @@ _comp_cmd_ipmitool()
                 info | clear | list | elist | delete) ;;
 
                 add | save | writeraw | readraw)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
                 time)
                     [[ $prev == time ]] &&

--- a/completions/ipsec
+++ b/completions/ipsec
@@ -84,7 +84,7 @@ _comp_cmd_ipsec__strongswan()
         pool) ;;
 
         irdumm)
-            _comp_compgen filedir 'rb'
+            _comp_compgen_filedir 'rb'
             ;;
         *) ;;
 

--- a/completions/ipv6calc
+++ b/completions/ipv6calc
@@ -19,7 +19,7 @@ _comp_cmd_ipv6calc()
             return
             ;;
         --db-geoip | --db-ip2location-ipv4 | --db-ip2location-ipv6)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --printstart | --printend)

--- a/completions/isort
+++ b/completions/isort
@@ -34,7 +34,7 @@ _comp_cmd_isort()
         return
     fi
 
-    _comp_compgen filedir '@(py|pyi)'
+    _comp_compgen_filedir '@(py|pyi)'
 } &&
     complete -F _comp_cmd_isort isort
 

--- a/completions/jar
+++ b/completions/jar
@@ -12,13 +12,13 @@ _comp_cmd_jar()
 
     case ${words[1]} in
         *c*f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         *f)
             _filedir_xspec unzip "${@:2}"
             ;;
         *)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
     esac
 } &&

--- a/completions/jarsigner
+++ b/completions/jarsigner
@@ -17,7 +17,7 @@ _comp_cmd_jarsigner()
             return
             ;;
         -certchain | -tsa)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -storetype)
@@ -25,7 +25,7 @@ _comp_cmd_jarsigner()
             return
             ;;
         -signedjar)
-            _comp_compgen filedir '@(jar|apk)'
+            _comp_compgen_filedir '@(jar|apk)'
             return
             ;;
     esac

--- a/completions/java
+++ b/completions/java
@@ -151,7 +151,7 @@ _comp_cmd_java()
                 ;;
             *)
                 # once we've seen a class, just do filename completion
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
         esac
@@ -231,7 +231,7 @@ _comp_cmd_java()
     else
         if [[ $prev == -jar ]]; then
             # jar file completion
-            _comp_compgen filedir '[jw]ar'
+            _comp_compgen_filedir '[jw]ar'
         else
             # classes completion
             _comp_cmd_java__classes
@@ -251,7 +251,7 @@ _comp_cmd_javadoc()
 
     case $prev in
         -overview | -helpfile)
-            _comp_compgen filedir '?(x)htm?(l)'
+            _comp_compgen_filedir '?(x)htm?(l)'
             return
             ;;
         -doclet | -exclude | -subpackages | -source | -locale | -encoding | -windowtitle | \
@@ -260,11 +260,11 @@ _comp_cmd_javadoc()
             return
             ;;
         -stylesheetfile)
-            _comp_compgen filedir css
+            _comp_compgen_filedir css
             return
             ;;
         -d | -link | -linkoffline)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -classpath | -cp | -bootclasspath | -docletpath | -sourcepath | -extdirs | \
@@ -276,7 +276,7 @@ _comp_cmd_javadoc()
 
     # -linkoffline takes two arguments
     if [[ $cword -gt 2 && ${words[cword - 2]} == -linkoffline ]]; then
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
         return
     fi
 
@@ -284,7 +284,7 @@ _comp_cmd_javadoc()
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help)' -- "$cur"))
     else
         # source files completion
-        _comp_compgen filedir java
+        _comp_compgen_filedir java
         # packages completion
         _comp_cmd_java__packages
     fi
@@ -298,7 +298,7 @@ _comp_cmd_javac()
 
     case $prev in
         -d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -cp | -classpath | -bootclasspath | -sourcepath | -extdirs)
@@ -326,7 +326,7 @@ _comp_cmd_javac()
             COMPREPLY+=($(compgen -W '$(_parse_help "$1" -X)' -- "$cur"))
     else
         # source files completion
-        _comp_compgen filedir java
+        _comp_compgen_filedir java
     fi
 
     [[ ${COMPREPLY-} == -*[:=] ]] && compopt -o nospace

--- a/completions/javaws
+++ b/completions/javaws
@@ -10,11 +10,11 @@ _comp_cmd_javaws()
             return
             ;;
         -basedir | -codebase)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -uninstall | -import)
-            _comp_compgen filedir jnlp
+            _comp_compgen_filedir jnlp
             return
             ;;
     esac
@@ -27,7 +27,7 @@ _comp_cmd_javaws()
         return
     fi
 
-    _comp_compgen filedir jnlp
+    _comp_compgen_filedir jnlp
 } &&
     complete -F _comp_cmd_javaws javaws
 

--- a/completions/jpegoptim
+++ b/completions/jpegoptim
@@ -12,7 +12,7 @@ _comp_cmd_jpegoptim()
             return
             ;;
         --dest | -${noargopts}d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --max | --threshold | -${noargopts}[mT])
@@ -33,7 +33,7 @@ _comp_cmd_jpegoptim()
         return
     fi
 
-    _comp_compgen filedir 'jp?(e)g'
+    _comp_compgen_filedir 'jp?(e)g'
 } &&
     complete -F _comp_cmd_jpegoptim jpegoptim
 

--- a/completions/jq
+++ b/completions/jq
@@ -16,11 +16,11 @@ _comp_cmd_jq()
             return
             ;;
         --from-file | --run-tests | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -${noargopts}L)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -31,7 +31,7 @@ _comp_cmd_jq()
                 return
                 ;;
             --slurpfile | --argfile)
-                _comp_compgen filedir 'json?(l)'
+                _comp_compgen_filedir 'json?(l)'
                 return
                 ;;
         esac
@@ -72,7 +72,7 @@ _comp_cmd_jq()
     # 1st arg is filter
     ((args == 1)) && return
     # 2... are input files
-    _comp_compgen filedir 'json?(l)'
+    _comp_compgen_filedir 'json?(l)'
 
 } &&
     complete -F _comp_cmd_jq jq

--- a/completions/jshint
+++ b/completions/jshint
@@ -10,7 +10,7 @@ _comp_cmd_jshint()
             return
             ;;
         -c | --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --reporter)
@@ -31,7 +31,7 @@ _comp_cmd_jshint()
         return
     fi
 
-    _comp_compgen filedir js
+    _comp_compgen_filedir js
 } &&
     complete -F _comp_cmd_jshint jshint
 

--- a/completions/jsonschema
+++ b/completions/jsonschema
@@ -10,7 +10,7 @@ _comp_cmd_jsonschema()
             return
             ;;
         --instance | -i)
-            _comp_compgen filedir json
+            _comp_compgen_filedir json
             return
             ;;
     esac
@@ -23,7 +23,7 @@ _comp_cmd_jsonschema()
     local args
     _count_args "" "-*"
     ((args == 1)) || return
-    _comp_compgen filedir '@(json|schema)'
+    _comp_compgen_filedir '@(json|schema)'
 } &&
     complete -F _comp_cmd_jsonschema jsonschema
 

--- a/completions/k3b
+++ b/completions/k3b
@@ -10,7 +10,7 @@ _comp_cmd_k3b()
             return
             ;;
         --datacd | --audiocd | --videocd | --mixedcd | --emovixcd | --videodvd)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --copydvd | --formatdvd | --videodvdrip)
@@ -23,11 +23,11 @@ _comp_cmd_k3b()
             return
             ;;
         --cdimage | --image)
-            _comp_compgen filedir '@(cue|iso|toc)'
+            _comp_compgen_filedir '@(cue|iso|toc)'
             return
             ;;
         --dvdimage)
-            _comp_compgen filedir iso
+            _comp_compgen_filedir iso
             return
             ;;
         --ao)
@@ -40,7 +40,7 @@ _comp_cmd_k3b()
         COMPREPLY=($(compgen -W "$(_parse_help "$1")" -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_k3b k3b

--- a/completions/kcov
+++ b/completions/kcov
@@ -16,14 +16,14 @@ _comp_cmd_kcov()
             return
             ;;
         --include-path | --exclude-path)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --replace-src-path)
             if [[ $cur == ?*:* ]]; then
                 _comp_compgen -c "${cur##*:}" filedir
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 compopt -o nospace
             fi
             return
@@ -56,7 +56,7 @@ _comp_cmd_kcov()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_kcov kcov
 

--- a/completions/kldload
+++ b/completions/kldload
@@ -8,7 +8,7 @@ _comp_cmd_kldload()
     _comp_initialize -- "$@" || return
 
     if _comp_looks_like_path "$cur"; then
-        _comp_compgen filedir ko
+        _comp_compgen_filedir ko
         return
     fi
 

--- a/completions/koji
+++ b/completions/koji
@@ -53,7 +53,7 @@ _comp_cmd_koji()
             return
             ;;
         --config | --keytab | -${noargopts}[co])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --runas | --user | --editor | --by)
@@ -65,7 +65,7 @@ _comp_cmd_koji()
             return
             ;;
         --topdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --type)
@@ -129,7 +129,7 @@ _comp_cmd_koji()
                         _comp_cmd_koji__target "$1"
                         ;;
                     2)
-                        _comp_compgen filedir src.rpm
+                        _comp_compgen_filedir src.rpm
                         ;;
                 esac
                 ;;
@@ -153,7 +153,7 @@ _comp_cmd_koji()
             import-comps)
                 case $nth in
                     1)
-                        _comp_compgen filedir xml
+                        _comp_compgen_filedir xml
                         ;;
                     2)
                         _comp_cmd_koji__tag "$1"

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -44,7 +44,7 @@ _comp_cmd_ktutil()
             return
             ;;
         -s | -k | --srvtab | --keytab)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -101,7 +101,7 @@ _comp_cmd_ktutil()
     else
         case ${command-} in
             copy)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 ;;
             get)
                 _comp_cmd_ktutil__heimdal_principals

--- a/completions/ldapsearch
+++ b/completions/ldapsearch
@@ -25,11 +25,11 @@ _comp_cmd_ldapsearch()
             return
             ;;
         -*T)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -*[fy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*s)
@@ -67,7 +67,7 @@ _comp_cmd_ldapadd()
             return
             ;;
         -*[Sfy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*P)
@@ -97,7 +97,7 @@ _comp_cmd_ldapdelete()
             return
             ;;
         -*[fy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*P)
@@ -127,7 +127,7 @@ _comp_cmd_ldapcompare()
             return
             ;;
         -*y)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*P)
@@ -157,7 +157,7 @@ _comp_cmd_ldapmodrdn()
             return
             ;;
         -*[fy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*P)
@@ -187,7 +187,7 @@ _comp_cmd_ldapwhoami()
             return
             ;;
         -*[fy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*P)
@@ -217,7 +217,7 @@ _comp_cmd_ldappasswd()
             return
             ;;
         -*[tTy])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/lftp
+++ b/completions/lftp
@@ -9,7 +9,7 @@ _comp_cmd_lftp()
     # shellcheck disable=SC2254
     case $prev in
         -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --help | --version | -${noargopts}[chveups])

--- a/completions/lilo
+++ b/completions/lilo
@@ -14,11 +14,11 @@ _comp_cmd_lilo()
 
     case $prev in
         -C | -i | -m | -s | -S)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -r)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -I | -D | -R)
@@ -45,11 +45,11 @@ _comp_cmd_lilo()
             return
             ;;
         -B)
-            _comp_compgen filedir bmp
+            _comp_compgen_filedir bmp
             return
             ;;
         -E)
-            _comp_compgen filedir '@(bmp|dat)'
+            _comp_compgen_filedir '@(bmp|dat)'
             return
             ;;
     esac

--- a/completions/links
+++ b/completions/links
@@ -38,7 +38,7 @@ _comp_cmd_links()
             return
             ;;
         -download-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -bind-address)
@@ -66,15 +66,15 @@ _comp_cmd_links()
             return
             ;;
         -ssl.client-cert-key)
-            _comp_compgen filedir '@(key|pem)'
+            _comp_compgen_filedir '@(key|pem)'
             return
             ;;
         -ssl.client-cert-crt)
-            _comp_compgen filedir '@(c?(e)rt|cer|pem|der)'
+            _comp_compgen_filedir '@(c?(e)rt|cer|pem|der)'
             return
             ;;
         -bookmarks-file)
-            _comp_compgen filedir html
+            _comp_compgen_filedir html
             return
             ;;
     esac

--- a/completions/lintian
+++ b/completions/lintian
@@ -97,11 +97,11 @@ _comp_cmd_lintian()
                 ;;
             --tags-from-file | --suppress-tags-from-file | --cfg | -p | \
                 --packages-file)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             --lab | --archivedir | --dist | --root)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
                 ;;
             --color)
@@ -145,7 +145,7 @@ _comp_cmd_lintian()
             ;;
         *)
             # in Ubuntu, dbgsym packages end in .ddeb, lintian >= 2.57.0 groks
-            _comp_compgen filedir '@(?(u|d)deb|changes|dsc|buildinfo)'
+            _comp_compgen_filedir '@(?(u|d)deb|changes|dsc|buildinfo)'
             ;;
     esac
     return 0
@@ -166,7 +166,7 @@ _comp_cmd_lintian_info()
             return
             ;;
         --include-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -176,7 +176,7 @@ _comp_cmd_lintian_info()
             COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
             ;;
         *)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
     esac
     return 0

--- a/completions/lisp
+++ b/completions/lisp
@@ -13,7 +13,7 @@ _comp_cmd_lisp()
         -dynamic-space-size -hinit -noinit -nositeinit -load -slave' \
             -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 
 } &&

--- a/completions/list_members
+++ b/completions/list_members
@@ -7,7 +7,7 @@ _comp_cmd_list_members()
 
     case $prev in
         -o | --output)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -d | --digest)

--- a/completions/locale-gen
+++ b/completions/locale-gen
@@ -10,7 +10,7 @@ _comp_cmd_locale_gen()
             return
             ;;
         --aliases)
-            _comp_compgen filedir alias
+            _comp_compgen_filedir alias
             return
             ;;
     esac

--- a/completions/lpq
+++ b/completions/lpq
@@ -21,7 +21,7 @@ _comp_cmd_lpq()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_lpq lpq
 

--- a/completions/lpr
+++ b/completions/lpr
@@ -26,7 +26,7 @@ _comp_cmd_lpr()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_lpr lpr
 

--- a/completions/lrzip
+++ b/completions/lrzip
@@ -18,11 +18,11 @@ _comp_cmd_lrzip()
             xspec="!"$xspec
             ;;
         --outfile | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --outdir | -${noargopts}O)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --level | -${noargopts}L)

--- a/completions/lsof
+++ b/completions/lsof
@@ -10,11 +10,11 @@ _comp_cmd_lsof()
             return
             ;;
         -A | -k | -m | +m | -o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         +d | +D)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -D)
@@ -49,7 +49,7 @@ _comp_cmd_lsof()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_lsof lsof
 

--- a/completions/lspci
+++ b/completions/lspci
@@ -10,11 +10,11 @@ _comp_cmd_lspci()
             return
             ;;
         -*i)
-            _comp_compgen filedir ids
+            _comp_compgen_filedir ids
             return
             ;;
         -*p)
-            _comp_compgen filedir pcimap
+            _comp_compgen_filedir pcimap
             return
             ;;
         -*A)
@@ -27,7 +27,7 @@ _comp_cmd_lspci()
             return
             ;;
         -*F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/lsscsi
+++ b/completions/lsscsi
@@ -12,7 +12,7 @@ _comp_cmd_lsscsi()
             return
             ;;
         --sysfsroot | -${noargopts}y)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/lua
+++ b/completions/lua
@@ -16,7 +16,7 @@ _comp_cmd_lua()
         return
     fi
 
-    _comp_compgen filedir 'l@(ua|?(ua)c)'
+    _comp_compgen_filedir 'l@(ua|?(ua)c)'
 } &&
     complete -F _comp_cmd_lua lua{,5{,.}{0..4}}
 

--- a/completions/luac
+++ b/completions/luac
@@ -10,7 +10,7 @@ _comp_cmd_luac()
             return
             ;;
         -o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -20,7 +20,7 @@ _comp_cmd_luac()
         return
     fi
 
-    _comp_compgen filedir lua
+    _comp_compgen_filedir lua
 } &&
     complete -F _comp_cmd_luac luac{,5{,.}{0..4}}
 

--- a/completions/luseradd
+++ b/completions/luseradd
@@ -14,7 +14,7 @@ _comp_cmd_luseradd()
             return
             ;;
         --directory | --skeleton | -${noargopts}[dk])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --shell | -${noargopts}s)

--- a/completions/lvm
+++ b/completions/lvm
@@ -164,7 +164,7 @@ _comp_cmd_pvcreate()
     # shellcheck disable=SC2254
     case $prev in
         --restorefile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --metadatatype | -${noargopts}M)
@@ -507,7 +507,7 @@ _comp_cmd_vgcfgbackup()
     # shellcheck disable=SC2254
     case $prev in
         --file | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -529,7 +529,7 @@ _comp_cmd_vgcfgrestore()
     # shellcheck disable=SC2254
     case $prev in
         --file | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --metadatatype | -${noargopts}M)

--- a/completions/lz4
+++ b/completions/lz4
@@ -7,7 +7,7 @@ _comp_cmd_lz4()
 
     case $prev in
         -b)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/lzip
+++ b/completions/lzip
@@ -22,7 +22,7 @@ _comp_cmd_lzip()
             return
             ;;
         --output | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -36,7 +36,7 @@ _comp_cmd_lzip()
     fi
 
     if [[ $decompress ]]; then
-        _comp_compgen filedir lz
+        _comp_compgen_filedir lz
         return
     fi
 

--- a/completions/lzop
+++ b/completions/lzop
@@ -9,11 +9,11 @@ _comp_cmd_lzop()
     # shellcheck disable=SC2254
     case $prev in
         --output | -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --path)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --suffix | -${noargopts}S)

--- a/completions/make
+++ b/completions/make
@@ -150,11 +150,11 @@ _comp_cmd_make()
     case $prev in
         --file | --makefile | --old-file | --assume-old | --what-if | --new-file | \
             --assume-new | -${noargopts}[foW])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --include-dir | --directory | -${noargopts}[ICm])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -${noargopts}E)
@@ -182,7 +182,7 @@ _comp_cmd_make()
         cur=${cur#*=}
         local diropt
         [[ ${prev,,} == *dir?(ectory) ]] && diropt=-d
-        _comp_compgen filedir $diropt
+        _comp_compgen_filedir $diropt
     else
         # before we check for makefiles, see if a path was specified
         # with -C/--directory

--- a/completions/makepkg
+++ b/completions/makepkg
@@ -20,7 +20,7 @@ _comp_cmd_makepkg__slackware()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 }
 
 _comp_cmd_makepkg__bootstrap()

--- a/completions/man
+++ b/completions/man
@@ -13,15 +13,15 @@ _comp_cmd_man()
     # shellcheck disable=SC2254
     case $prev in
         --config-file | -${noargopts}C)
-            _comp_compgen filedir conf
+            _comp_compgen_filedir conf
             return
             ;;
         --local-file | -${noargopts}l)
-            _comp_compgen filedir "$manext"
+            _comp_compgen_filedir "$manext"
             return
             ;;
         --manpath | -${noargopts}M)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --sections | -${noargopts}[Ss])
@@ -55,7 +55,7 @@ _comp_cmd_man()
 
     # file based completion if parameter looks like a path
     if _comp_looks_like_path "$cur"; then
-        _comp_compgen filedir "$manext"
+        _comp_compgen_filedir "$manext"
         return
     fi
 

--- a/completions/mc
+++ b/completions/mc
@@ -9,7 +9,7 @@ _comp_cmd_mc()
     # shellcheck disable=SC2254
     case $prev in
         --edit | --view | --ftplog | --printwd | -${noargopts}[evlP])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --help | --help-* | --version | --colors | --debuglevel | -${noargopts}[hVCD])
@@ -23,7 +23,7 @@ _comp_cmd_mc()
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --help-all)' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_mc mc

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -35,11 +35,11 @@ _comp_cmd_mcrypt()
             return
             ;;
         -f | -c | --keyfile | --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --algorithms-directory | --modes-directory)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -47,18 +47,18 @@ _comp_cmd_mcrypt()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     elif [[ ${words[0]} == mdecrypt ]]; then
-        _comp_compgen filedir nc
+        _comp_compgen_filedir nc
     else
         local i decrypt=""
         for ((i = 1; i < ${#words[@]} - 1; i++)); do
             if [[ ${words[i]} == -@(d|-decrypt) ]]; then
-                _comp_compgen filedir nc
+                _comp_compgen_filedir nc
                 decrypt=set
                 break
             fi
         done
         if [[ ! $decrypt ]]; then
-            _comp_compgen filedir
+            _comp_compgen_filedir
         fi
     fi
 } &&

--- a/completions/mdadm
+++ b/completions/mdadm
@@ -78,7 +78,7 @@ _comp_cmd_mdadm()
     # shellcheck disable=SC2254
     case $prev in
         --config | --bitmap | --backup-file | -${noargopts}[cb])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --level | -${noargopts}l)

--- a/completions/medusa
+++ b/completions/medusa
@@ -11,7 +11,7 @@ _comp_cmd_medusa()
             return
             ;;
         -*[HUPCO])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*M)

--- a/completions/minicom
+++ b/completions/minicom
@@ -13,7 +13,7 @@ _comp_cmd_minicom()
             return
             ;;
         --script | --capturefile | -${noargopts}[SC])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --ptty | -${noargopts}p)

--- a/completions/mkinitrd
+++ b/completions/mkinitrd
@@ -11,7 +11,7 @@ _comp_cmd_mkinitrd()
             return
             ;;
         --fstab | --dsdt)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --net-dev)
@@ -36,7 +36,7 @@ _comp_cmd_mkinitrd()
 
         case $args in
             1)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 ;;
             2)
                 _kernel_versions

--- a/completions/mktemp
+++ b/completions/mktemp
@@ -12,7 +12,7 @@ _comp_cmd_mktemp()
             return
             ;;
         --tmpdir | -${noargopts}p)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/modinfo
+++ b/completions/modinfo
@@ -20,7 +20,7 @@ _comp_cmd_modinfo()
             return
             ;;
         --basedir | -${noargopts}b)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -45,7 +45,7 @@ _comp_cmd_modinfo()
 
     # do filename completion if we're giving a path to a module
     if [[ $cur == @(*/|[.~])* ]]; then
-        _comp_compgen filedir '@(?(k)o?(.[gx]z|.zst))'
+        _comp_compgen_filedir '@(?(k)o?(.[gx]z|.zst))'
     else
         _modules "$version"
     fi

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -12,11 +12,11 @@ _comp_cmd_modprobe()
             return
             ;;
         --config | -${noargopts}C)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --dirname | --type | -${noargopts}[dt])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --set-version | -${noargopts}S)
@@ -78,12 +78,12 @@ _comp_cmd_modprobe()
             # no completion available
             ;;
         file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         insert)
             # do filename completion if we're giving a path to a module
             if [[ $cur == @(*/|[.~])* ]]; then
-                _comp_compgen filedir '@(?(k)o?(.[gx]z|.zst))'
+                _comp_compgen_filedir '@(?(k)o?(.[gx]z|.zst))'
             elif [[ $module ]]; then
                 # do module parameter completion
                 if [[ $cur == *=* ]]; then

--- a/completions/monodevelop
+++ b/completions/monodevelop
@@ -11,7 +11,7 @@ _comp_cmd_monodevelop()
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -h)' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_monodevelop monodevelop

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -26,25 +26,25 @@ _comp_cmd_mplayer()
             return
             ;;
         -audiofile | -audio-file)
-            _comp_compgen filedir '@(mp3|mpg|og[ag]|w?(a)v|mid|flac|mka|ac3|ape)'
+            _comp_compgen_filedir '@(mp3|mpg|og[ag]|w?(a)v|mid|flac|mka|ac3|ape)'
             return
             ;;
         -font | -subfont)
             if [[ $prev == -font ]]; then
-                _comp_compgen filedir '@(desc|ttf)'
+                _comp_compgen_filedir '@(desc|ttf)'
             else
-                _comp_compgen filedir ttf
+                _comp_compgen_filedir ttf
             fi
             local IFS=$'\n'
             COMPREPLY+=($(compgen -W '$(fc-list 2>/dev/null)' -- "$cur"))
             return
             ;;
         -sub | -sub-file)
-            _comp_compgen filedir '@(srt|sub|txt|utf|rar|mpsub|smi|js|ssa|ass)'
+            _comp_compgen_filedir '@(srt|sub|txt|utf|rar|mpsub|smi|js|ssa|ass)'
             return
             ;;
         -vobsub)
-            _comp_compgen filedir '@(idx|ifo|sub)'
+            _comp_compgen_filedir '@(idx|ifo|sub)'
             local IFS=$'\n'
             COMPREPLY=($(for i in "${COMPREPLY[@]}"; do
                 if [[ -f $i && -r $i ]]; then
@@ -68,11 +68,11 @@ _comp_cmd_mplayer()
             return
             ;;
         -ifo)
-            _comp_compgen filedir ifo
+            _comp_compgen_filedir ifo
             return
             ;;
         -cuefile)
-            _comp_compgen filedir '@(bin|cue)'
+            _comp_compgen_filedir '@(bin|cue)'
             return
             ;;
         -skin)
@@ -107,7 +107,7 @@ _comp_cmd_mplayer()
             return
             ;;
         -bluray-device)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -mixer | -dvdauth | -fb | -zrdev)
@@ -116,7 +116,7 @@ _comp_cmd_mplayer()
             ;;
         -edl | -edlout | -lircconf | -menu-cfg | -playlist | -csslib | -dumpfile | \
             -subfile | -aofile | -fbmodeconfig | -include | -o | -dvdkey | -passlogfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -autoq | -autosync | -loop | -menu-root | -speed | -sstep | -aid | -alang | \
@@ -279,7 +279,7 @@ _comp_cmd_mplayer()
                     -e "/^-\(Total\|.*\*\)\{0,1\}$/!p")' -- "$cur"))
             ;;
         *)
-            _comp_compgen filedir '@(m?(j)p?(e)g|M?(J)P?(E)G|wm[av]|WM[AV]|avi|AVI|asf|ASF|vob|VOB|bin|BIN|dat|DAT|vcd|VCD|ps|PS|pes|PES|fl[iv]|FL[IV]|fxm|FXM|viv|VIV|rm?(j)|RM?(J)|ra?(m)|RA?(M)|yuv|YUV|mov|MOV|qt|QT|mp[234]|MP[234]|m?(p)4[av]|M?(P)4[AV]|og[gmavx]|OG[GMAVX]|w?(a)v|W?(A)V|dump|DUMP|mk[av]|MK[AV]|aac|AAC|m2v|M2V|dv|DV|rmvb|RMVB|mid|MID|t[ps]|T[PS]|3g[p2]|3gpp?(2)|mpc|MPC|flac|FLAC|vro|VRO|divx|DIVX|aif?(f)|AIF?(F)|m2t?(s)|M2T?(S)|mts|MTS|vdr|VDR|xvid|XVID|ape|APE|gif|GIF|nut|NUT|bik|BIK|web[am]|WEB[AM]|amr|AMR|awb|AWB|iso|ISO|opus|OPUS|m[eo]d|M[EO]D|xm|XM|it|IT|s[t3]m|S[T3]M|mtm|MTM|w64|W64)?(.@(crdownload|part))'
+            _comp_compgen_filedir '@(m?(j)p?(e)g|M?(J)P?(E)G|wm[av]|WM[AV]|avi|AVI|asf|ASF|vob|VOB|bin|BIN|dat|DAT|vcd|VCD|ps|PS|pes|PES|fl[iv]|FL[IV]|fxm|FXM|viv|VIV|rm?(j)|RM?(J)|ra?(m)|RA?(M)|yuv|YUV|mov|MOV|qt|QT|mp[234]|MP[234]|m?(p)4[av]|M?(P)4[AV]|og[gmavx]|OG[GMAVX]|w?(a)v|W?(A)V|dump|DUMP|mk[av]|MK[AV]|aac|AAC|m2v|M2V|dv|DV|rmvb|RMVB|mid|MID|t[ps]|T[PS]|3g[p2]|3gpp?(2)|mpc|MPC|flac|FLAC|vro|VRO|divx|DIVX|aif?(f)|AIF?(F)|m2t?(s)|M2T?(S)|mts|MTS|vdr|VDR|xvid|XVID|ape|APE|gif|GIF|nut|NUT|bik|BIK|web[am]|WEB[AM]|amr|AMR|awb|AWB|iso|ISO|opus|OPUS|m[eo]d|M[EO]D|xm|XM|it|IT|s[t3]m|S[T3]M|mtm|MTM|w64|W64)?(.@(crdownload|part))'
             ;;
     esac
 

--- a/completions/mr
+++ b/completions/mr
@@ -34,7 +34,7 @@ _comp_cmd_mr()
     if [[ $has_cmd ]]; then
         case $cmd in
             bootstrap)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 # Also complete stdin (-) as a potential bootstrap source.
                 if [[ ! ${cur} || $cur == - ]] && [[ $prev != - ]]; then
                     COMPREPLY+=(-)
@@ -69,11 +69,11 @@ _comp_cmd_mr()
     # shellcheck disable=SC2254
     case $prev in
         --config | -${noargopts}c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --directory | -${noargopts}d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/munin-node-configure
+++ b/completions/munin-node-configure
@@ -7,11 +7,11 @@ _comp_cmd_munin_node_configure()
 
     case $prev in
         --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --servicedir | --libdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --snmp)

--- a/completions/munin-run
+++ b/completions/munin-run
@@ -7,11 +7,11 @@ _comp_cmd_munin_run()
 
     case $prev in
         --config | --sconffile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --servicedir | --sconfdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/munin-update
+++ b/completions/munin-update
@@ -7,7 +7,7 @@ _comp_cmd_munin_update()
 
     case $prev in
         --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --host)

--- a/completions/mussh
+++ b/completions/mussh
@@ -18,7 +18,7 @@ _comp_cmd_mussh()
             return
             ;;
         -i | -H | -C)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -o | -po)

--- a/completions/mypy
+++ b/completions/mypy
@@ -17,7 +17,7 @@ _comp_cmd_mypy()
             return
             ;;
         --config-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --follow-imports)
@@ -29,7 +29,7 @@ _comp_cmd_mypy()
             return
             ;;
         --*-dir | --*-report)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --custom-typing-module | --module | -${noargopts}m)
@@ -37,11 +37,11 @@ _comp_cmd_mypy()
             return
             ;;
         --shadow-file)
-            _comp_compgen filedir '@(py|pyi)'
+            _comp_compgen_filedir '@(py|pyi)'
             return
             ;;
         --junit-xml)
-            _comp_compgen filedir xml
+            _comp_compgen_filedir xml
             return
             ;;
     esac
@@ -53,7 +53,7 @@ _comp_cmd_mypy()
         return
     fi
 
-    _comp_compgen filedir '@(py|pyi)'
+    _comp_compgen_filedir '@(py|pyi)'
 } &&
     complete -F _comp_cmd_mypy mypy
 

--- a/completions/mysql
+++ b/completions/mysql
@@ -40,11 +40,11 @@ _comp_cmd_mysql()
             ;;
 
         --character-sets-dir | --ssl-capath)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --socket | -${noargopts}S)
-            _comp_compgen filedir sock
+            _comp_compgen_filedir sock
             return
             ;;
         --protocol)
@@ -52,15 +52,15 @@ _comp_cmd_mysql()
             return
             ;;
         --defaults-file | --defaults-extra-file | --tee)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --ssl-ca | --ssl-cert)
-            _comp_compgen filedir '@(pem|cer|c?(e)rt)'
+            _comp_compgen_filedir '@(pem|cer|c?(e)rt)'
             return
             ;;
         --ssl-key)
-            _comp_compgen filedir '@(pem|key)'
+            _comp_compgen_filedir '@(pem|key)'
             return
             ;;
         --port | --set-variable | --ssl-cipher | --connect_timeout | \

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -17,7 +17,7 @@ _comp_cmd_mysqladmin()
             return
             ;;
         --character-sets-dir | --ssl-capath)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --default-character-set)
@@ -25,19 +25,19 @@ _comp_cmd_mysqladmin()
             return
             ;;
         --socket | -${noargopts}S)
-            _comp_compgen filedir sock
+            _comp_compgen_filedir sock
             return
             ;;
         --defaults-file | --defaults-extra-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --ssl-ca | --ssl-cert)
-            _comp_compgen filedir '@(pem|cer|c?(e)rt)'
+            _comp_compgen_filedir '@(pem|cer|c?(e)rt)'
             return
             ;;
         --ssl-key)
-            _comp_compgen filedir '@(pem|key)'
+            _comp_compgen_filedir '@(pem|key)'
             return
             ;;
         --count | --port | --set-variable | --sleep | --ssl-cipher | --wait | \

--- a/completions/newusers
+++ b/completions/newusers
@@ -23,7 +23,7 @@ _comp_cmd_newusers()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_newusers newusers
 

--- a/completions/ngrep
+++ b/completions/ngrep
@@ -10,7 +10,7 @@ _comp_cmd_ngrep()
             return
             ;;
         -I | -O)
-            _comp_compgen filedir 'pcap?(ng)'
+            _comp_compgen_filedir 'pcap?(ng)'
             return
             ;;
         -d)
@@ -23,7 +23,7 @@ _comp_cmd_ngrep()
             return
             ;;
         -F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/nmap
+++ b/completions/nmap
@@ -7,11 +7,11 @@ _comp_cmd_nmap()
 
     case $prev in
         -iL | -oN | -oX | -oS | -oG | ---excludefile | --resume | --stylesheet)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -oA | --datadir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -e)

--- a/completions/nsupdate
+++ b/completions/nsupdate
@@ -10,7 +10,7 @@ _comp_cmd_nsupdate()
             return
             ;;
         -*k)
-            _comp_compgen filedir key
+            _comp_compgen_filedir key
             return
             ;;
         -*R)
@@ -32,7 +32,7 @@ _comp_cmd_nsupdate()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_nsupdate nsupdate
 

--- a/completions/ntpdate
+++ b/completions/ntpdate
@@ -7,7 +7,7 @@ _comp_cmd_ntpdate()
 
     case $prev in
         -*k)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*U)

--- a/completions/oggdec
+++ b/completions/oggdec
@@ -20,7 +20,7 @@ _comp_cmd_oggdec()
             return
             ;;
         --output | -${noargopts}o)
-            _comp_compgen filedir wav
+            _comp_compgen_filedir wav
             return
             ;;
     esac
@@ -33,7 +33,7 @@ _comp_cmd_oggdec()
         return
     fi
 
-    _comp_compgen filedir ogg
+    _comp_compgen_filedir ogg
 } &&
     complete -F _comp_cmd_oggdec oggdec
 

--- a/completions/openssl
+++ b/completions/openssl
@@ -66,11 +66,11 @@ _comp_cmd_openssl()
                 -out | -oid | -paramfile | -peerkey | -prvrify | -rand | -recip | -revoke | \
                 -sess_in | -sess_out | -spkac | -sigfile | -sign | -signkey | -signer | \
                 -signature | -ss_cert | -untrusted | -verify | -writerand)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             -outdir | -CApath)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 return
                 ;;
             -name | -crlexts | -extensions)
@@ -129,7 +129,7 @@ _comp_cmd_openssl()
                     rsa512 rsa1024 rsa2048 rsa4096 dsa512 dsa1024 dsa2048 idea
                     rc2 des rsa blowfish' -- "$cur"))
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
             fi
         fi
     fi

--- a/completions/opera
+++ b/completions/opera
@@ -8,11 +8,11 @@ _comp_cmd_opera()
     case "$prev" in
         ?(-)-widget | ?(-)-urllist | ?(-)-uiparserlog | ?(-)-uiwidgetsparserlog | \
             ?(-)-profilinglog)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         ?(-)-[psb]d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         ?(-)-remote)
@@ -40,7 +40,7 @@ _comp_cmd_opera()
         return
     fi
 
-    _comp_compgen filedir '@(?([xX]|[sS])[hH][tT][mM]?([lL]))'
+    _comp_compgen_filedir '@(?([xX]|[sS])[hH][tT][mM]?([lL]))'
 } &&
     complete -F _comp_cmd_opera opera
 

--- a/completions/optipng
+++ b/completions/optipng
@@ -14,11 +14,11 @@ _comp_cmd_optipng()
             return
             ;;
         -out | -log)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -i)
@@ -45,7 +45,7 @@ _comp_cmd_optipng()
         return
     fi
 
-    _comp_compgen filedir '@(png|bmp|gif|pnm|tif?(f))'
+    _comp_compgen_filedir '@(png|bmp|gif|pnm|tif?(f))'
 } &&
     complete -F _comp_cmd_optipng optipng
 

--- a/completions/pack200
+++ b/completions/pack200
@@ -28,16 +28,16 @@ _comp_cmd_pack200()
             return
             ;;
         -f | --config-file)
-            _comp_compgen filedir properties
+            _comp_compgen_filedir properties
             return
             ;;
         -l | --log-file)
             COMPREPLY=($(compgen -W '-' -- "$cur"))
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         -r | --repack)
-            _comp_compgen filedir jar
+            _comp_compgen_filedir jar
             return
             ;;
     esac
@@ -63,10 +63,10 @@ _comp_cmd_pack200()
                 --help --version -J --repack' -- "$cur"))
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            _comp_compgen filedir 'pack?(.gz)'
+            _comp_compgen_filedir 'pack?(.gz)'
         fi
     elif [[ ! $jar ]]; then
-        _comp_compgen filedir jar
+        _comp_compgen_filedir jar
     fi
 } &&
     complete -F _comp_cmd_pack200 pack200

--- a/completions/patch
+++ b/completions/patch
@@ -17,12 +17,12 @@ _comp_cmd_patch()
             return
             ;;
         --input | -${noargopts}i)
-            _comp_compgen filedir '@(?(d)patch|dif?(f))'
+            _comp_compgen_filedir '@(?(d)patch|dif?(f))'
             return
             ;;
         --output | --reject-file | -${noargopts}[or])
             [[ ! $cur || $cur == - ]] && COMPREPLY=(-)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --quoting-style)
@@ -35,7 +35,7 @@ _comp_cmd_patch()
             return
             ;;
         --directory | -${noargopts}d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --reject-format)
@@ -60,10 +60,10 @@ _comp_cmd_patch()
     _count_args
     case $args in
         1)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         2)
-            _comp_compgen filedir '@(?(d)patch|dif?(f))'
+            _comp_compgen_filedir '@(?(d)patch|dif?(f))'
             ;;
     esac
 } &&

--- a/completions/pdftoppm
+++ b/completions/pdftoppm
@@ -28,7 +28,7 @@ _comp_cmd_pdftoppm()
         return
     fi
 
-    [[ $prev == *.pdf ]] || _comp_compgen filedir pdf
+    [[ $prev == *.pdf ]] || _comp_compgen_filedir pdf
 } &&
     complete -F _comp_cmd_pdftoppm pdftoppm
 

--- a/completions/pdftotext
+++ b/completions/pdftotext
@@ -32,7 +32,7 @@ _comp_cmd_pdftotext()
             COMPREPLY=($(compgen -W '-' -- "$cur"))
             _comp_compgen -a filedir txt
             ;;
-        *) _comp_compgen filedir pdf ;;
+        *) _comp_compgen_filedir pdf ;;
     esac
 } &&
     complete -F _comp_cmd_pdftotext pdftotext

--- a/completions/perl
+++ b/completions/perl
@@ -88,7 +88,7 @@ _comp_cmd_perl()
         COMPREPLY=($(compgen -W '-C -s -T -u -U -W -X -h -v -V -c -w -d -D -p
             -n -a -F -l -0 -I -m -M -P -S -x -i -e' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_perl perl
@@ -116,7 +116,7 @@ _comp_cmd_perldoc()
             return
             ;;
         -*d)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*f)
@@ -139,7 +139,7 @@ _comp_cmd_perldoc()
                     -- "$cur"))
             fi
         fi
-        _comp_compgen filedir 'p@([lm]|od)'
+        _comp_compgen_filedir 'p@([lm]|od)'
     fi
 } &&
     complete -F _comp_cmd_perldoc -o bashdefault perldoc

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -16,7 +16,7 @@ _comp_cmd_perlcritic()
             return
             ;;
         --profile | -p)
-            _comp_compgen filedir perlcriticrc
+            _comp_compgen_filedir perlcriticrc
             return
             ;;
         --theme)
@@ -44,7 +44,7 @@ _comp_cmd_perlcritic()
         return
     fi
 
-    _comp_compgen filedir 'p[lm]'
+    _comp_compgen_filedir 'p[lm]'
 } &&
     complete -F _comp_cmd_perlcritic perlcritic
 

--- a/completions/perltidy
+++ b/completions/perltidy
@@ -10,7 +10,7 @@ _comp_cmd_perltidy()
             return
             ;;
         -o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -55,7 +55,7 @@ _comp_cmd_perltidy()
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        _comp_compgen filedir 'p[lm]|t'
+        _comp_compgen_filedir 'p[lm]|t'
     fi
 } &&
     complete -F _comp_cmd_perltidy perltidy

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -16,7 +16,7 @@ _comp_cmd_pgrep()
             return
             ;;
         --pidfile | -${noargopts}F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --group | -${noargopts}G)

--- a/completions/pine
+++ b/completions/pine
@@ -11,7 +11,7 @@ _comp_cmd_pine()
             ;;
         -attach | -attachlist | -attach_and_delete | -p | -P | -pinerc | \
             -passfile | -x)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -sort)

--- a/completions/pkgadd
+++ b/completions/pkgadd
@@ -23,13 +23,13 @@ _comp_cmd_pkgadd()
 
     case $prev in
         -d)
-            _comp_compgen filedir pkg
+            _comp_compgen_filedir pkg
             ;;
         -a | -r | -V)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         -k | -s | -R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             ;;
         -P | -x) ;;
 

--- a/completions/pkgrm
+++ b/completions/pkgrm
@@ -24,10 +24,10 @@ _comp_cmd_pkgrm()
 
     case $prev in
         -a | -V)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         -s | -R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             ;;
         -Y) ;;
 

--- a/completions/pkgtool
+++ b/completions/pkgtool
@@ -7,7 +7,7 @@ _comp_cmd_pkgtool()
 
     case "$prev" in
         --source_dir | --target_dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --sets)
@@ -19,7 +19,7 @@ _comp_cmd_pkgtool()
             return
             ;;
         --tagfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -38,12 +38,12 @@ _comp_cmd_pkgutil()
     done
 
     if [[ $prev == -@([WPR]|-workdir|-pkgdir|-rootpath) ]]; then
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
         return
     fi
 
     if [[ $prev == -@(o|-output|-config) ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
         return
     fi
 

--- a/completions/pngfix
+++ b/completions/pngfix
@@ -10,7 +10,7 @@ _comp_cmd_pngfix()
             return
             ;;
         --output)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --strip)
@@ -29,7 +29,7 @@ _comp_cmd_pngfix()
         return
     fi
 
-    _comp_compgen filedir png
+    _comp_compgen_filedir png
 } &&
     complete -F _comp_cmd_pngfix pngfix
 

--- a/completions/portsnap
+++ b/completions/portsnap
@@ -9,11 +9,11 @@ _comp_cmd_portsnap()
 
     case $prev in
         -d | -p)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -l | -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/postcat
+++ b/completions/postcat
@@ -7,7 +7,7 @@ _comp_cmd_postcat()
 
     case $prev in
         -c)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -32,7 +32,7 @@ _comp_cmd_postcat()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_postcat postcat
 

--- a/completions/postconf
+++ b/completions/postconf
@@ -9,11 +9,11 @@ _comp_cmd_postconf()
 
     case $prev in
         -b | -t)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -c)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -e)

--- a/completions/postfix
+++ b/completions/postfix
@@ -7,7 +7,7 @@ _comp_cmd_postfix()
 
     case $prev in
         -c)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -D)

--- a/completions/postmap
+++ b/completions/postmap
@@ -7,7 +7,7 @@ _comp_cmd_postmap()
 
     case $prev in
         -c)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -[dq])

--- a/completions/postsuper
+++ b/completions/postsuper
@@ -9,7 +9,7 @@ _comp_cmd_postsuper()
 
     case $prev in
         -c)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -[dr])

--- a/completions/povray
+++ b/completions/povray
@@ -15,7 +15,7 @@ _comp_cmd_povray()
         [-+]I*)
             cur="${povcur#[-+]I}" # to confuse _comp_compgen_filedir
             pfx="${povcur%"$cur"}"
-            _comp_compgen filedir pov
+            _comp_compgen_filedir pov
             ((${#COMPREPLY[@]})) && COMPREPLY=("${COMPREPLY[@]/#/$pfx}")
             return
             ;;
@@ -56,7 +56,7 @@ _comp_cmd_povray()
             return
             ;;
         *)
-            _comp_compgen filedir '@(ini|pov)'
+            _comp_compgen_filedir '@(ini|pov)'
             return
             ;;
     esac

--- a/completions/prelink
+++ b/completions/prelink
@@ -10,19 +10,19 @@ _comp_cmd_prelink()
             return
             ;;
         -b | --black-list | --dynamic-linker | --undo-output)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -c | --config-file)
-            _comp_compgen filedir conf
+            _comp_compgen_filedir conf
             return
             ;;
         -C | --cache)
-            _comp_compgen filedir cache
+            _comp_compgen_filedir cache
             return
             ;;
         --ld-library-path)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -35,7 +35,7 @@ _comp_cmd_prelink()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_prelink prelink
 

--- a/completions/protoc
+++ b/completions/protoc
@@ -10,7 +10,7 @@ _comp_cmd_protoc()
             return
             ;;
         --descriptor_set_out)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --error_format)
@@ -25,7 +25,7 @@ _comp_cmd_protoc()
             return
             ;;
         --proto_path | --*_out)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -54,7 +54,7 @@ _comp_cmd_protoc()
             ;;
     esac
 
-    _comp_compgen filedir proto
+    _comp_compgen_filedir proto
 } &&
     complete -F _comp_cmd_protoc protoc
 

--- a/completions/psql
+++ b/completions/psql
@@ -174,7 +174,7 @@ _comp_cmd_psql()
             return
             ;;
         --output | --file | --log-file | -${noargopts}[ofL])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --help | --version | --command | --field-separator | --port | --pset | \

--- a/completions/puppet
+++ b/completions/puppet
@@ -173,7 +173,7 @@ _comp_cmd_puppet()
                     if [[ $cur == -* ]]; then
                         _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     else
-                        _comp_compgen filedir
+                        _comp_compgen_filedir
                     fi
                     return
                     ;;
@@ -229,7 +229,7 @@ _comp_cmd_puppet()
         doc)
             case $prev in
                 -o | --outputdir)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     return
                     ;;
                 -m | --mode)
@@ -244,7 +244,7 @@ _comp_cmd_puppet()
                     if [[ $cur == -* ]]; then
                         _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     else
-                        _comp_compgen filedir
+                        _comp_compgen_filedir
                     fi
                     return
                     ;;
@@ -257,7 +257,7 @@ _comp_cmd_puppet()
                     return
                     ;;
                 -b | --bucket)
-                    _comp_compgen filedir -d
+                    _comp_compgen_filedir -d
                     return
                     ;;
                 *)
@@ -312,7 +312,7 @@ _comp_cmd_puppet()
             action=$prev
             case $action in
                 validate)
-                    _comp_compgen filedir pp
+                    _comp_compgen_filedir pp
                     return
                     ;;
                 *)
@@ -331,7 +331,7 @@ _comp_cmd_puppet()
                     if [[ $cur == -* ]]; then
                         _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     else
-                        _comp_compgen filedir
+                        _comp_compgen_filedir
                     fi
                     return
                     ;;

--- a/completions/pv
+++ b/completions/pv
@@ -18,7 +18,7 @@ _comp_cmd_pv()
             return
             ;;
         --pidfile | --watchfd | -${noargopts}[Pd])
-            _comp_compgen filedir pid
+            _comp_compgen_filedir pid
             return
             ;;
     esac
@@ -26,7 +26,7 @@ _comp_cmd_pv()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_pv pv

--- a/completions/pwck
+++ b/completions/pwck
@@ -12,7 +12,7 @@ _comp_cmd_pwck()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_pwck pwck
 

--- a/completions/pwgen
+++ b/completions/pwgen
@@ -12,7 +12,7 @@ _comp_cmd_pwgen()
             return
             ;;
         --sha1 | -${noargopts}H)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/pycodestyle
+++ b/completions/pycodestyle
@@ -14,7 +14,7 @@ _comp_cmd_pycodestyle()
             return
             ;;
         --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -27,7 +27,7 @@ _comp_cmd_pycodestyle()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_pycodestyle pycodestyle
 

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -10,7 +10,7 @@ _comp_cmd_pydoc()
             return
             ;;
         -w)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -35,7 +35,7 @@ _comp_cmd_pydoc()
     COMPREPLY+=($(compgen -W \
         '$("$1" keywords topics | command sed -e /^Here/d)' -- "$cur"))
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_pydoc pydoc pydoc3
 

--- a/completions/pydocstyle
+++ b/completions/pydocstyle
@@ -11,7 +11,7 @@ _comp_cmd_pydocstyle()
             return
             ;;
         --config)
-            _comp_compgen filedir xml
+            _comp_compgen_filedir xml
             return
             ;;
         --convention)
@@ -28,7 +28,7 @@ _comp_cmd_pydocstyle()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_pydocstyle pydocstyle
 

--- a/completions/pyflakes
+++ b/completions/pyflakes
@@ -16,7 +16,7 @@ _comp_cmd_pyflakes()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_pyflakes pyflakes
 

--- a/completions/pylint
+++ b/completions/pylint
@@ -61,7 +61,7 @@ _comp_cmd_pylint()
             return
             ;;
         --rcfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --persistent | --include-ids | --symbols | --files-output | \
@@ -95,7 +95,7 @@ _comp_cmd_pylint()
             return
             ;;
         --import-graph | --ext-import-graph | --int-import-graph)
-            _comp_compgen filedir dot
+            _comp_compgen_filedir dot
             return
             ;;
     esac

--- a/completions/pytest
+++ b/completions/pytest
@@ -50,19 +50,19 @@ _comp_cmd_pytest()
             return
             ;;
         --junit-xml)
-            _comp_compgen filedir xml
+            _comp_compgen_filedir xml
             return
             ;;
         --result-log | --log-file)
-            _comp_compgen filedir log
+            _comp_compgen_filedir log
             return
             ;;
         --ignore | -${noargopts}c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --confcutdir | --basetemp | --rsyncdir | --rootdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --doctest-report)
@@ -76,7 +76,7 @@ _comp_cmd_pytest()
             return
             ;;
         --genscript)
-            _comp_compgen filedir py
+            _comp_compgen_filedir py
             return
             ;;
         --pythonwarnings | -${noargopts}W)
@@ -137,7 +137,7 @@ _comp_cmd_pytest()
         return
     fi
 
-    _comp_compgen filedir py
+    _comp_compgen_filedir py
 } &&
     complete -F _comp_cmd_pytest \
         pytest pytest-2 pytest-3 py.test py.test-2 py.test-3

--- a/completions/python
+++ b/completions/python
@@ -63,7 +63,7 @@ _comp_cmd_python()
             ;;
         !(?(*/)python*([0-9.])|?(*/)pypy*([0-9.])|-?))
             if [[ $cword -lt 2 || ${words[cword - 2]} != -[QWX] ]]; then
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
             fi
             ;;

--- a/completions/pyvenv
+++ b/completions/pyvenv
@@ -18,7 +18,7 @@ _comp_cmd_pyvenv()
         return
     fi
 
-    _comp_compgen filedir -d
+    _comp_compgen_filedir -d
 } &&
     complete -F _comp_cmd_pyvenv pyvenv pyvenv-3.{4..12}
 

--- a/completions/qemu
+++ b/completions/qemu
@@ -8,11 +8,11 @@ _comp_cmd_qemu()
     case $prev in
         -fd[ab] | -hd[abcd] | -cdrom | -option-rom | -kernel | -initrd | \
             -bootp | -pidfile | -loadvm | -mtdblock | -sd | -pflash | -bios)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -tftp | -smb | -L | -chroot)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -boot)
@@ -101,7 +101,7 @@ _comp_cmd_qemu()
         COMPREPLY=($(compgen -W '$(_parse_help "$1" -help) -fd{a,b}
             -hd{a..d}' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_qemu qemu qemu-kvm qemu-system-i386 qemu-system-x86_64

--- a/completions/remove_members
+++ b/completions/remove_members
@@ -7,7 +7,7 @@ _comp_cmd_remove_members()
 
     case $prev in
         -f | --file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/removepkg
+++ b/completions/removepkg
@@ -10,7 +10,7 @@ _comp_cmd_removepkg()
     fi
 
     if _comp_looks_like_path "$cur"; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
         return
     fi
 

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -17,7 +17,7 @@ _comp_cmd_reportbug()
             return
             ;;
         --filename | --include | --mta | --output | --attach | -[fioA])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --keyid | -${noargopts}K)
@@ -52,7 +52,7 @@ _comp_cmd_reportbug()
             return
             ;;
         --draftpath)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/ri
+++ b/completions/ri
@@ -49,11 +49,11 @@ _comp_cmd_ri()
             return
             ;;
         --doc-dir | -${noargopts}d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --dump)
-            _comp_compgen filedir ri
+            _comp_compgen_filedir ri
             return
             ;;
     esac

--- a/completions/rpm
+++ b/completions/rpm
@@ -71,7 +71,7 @@ _comp_cmd_rpm()
     # shellcheck disable=SC2254
     case $prev in
         --dbpath | --excludepath | --prefix | --relocate | --root | -${noargopts}r)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --eval | -${noargopts}E)
@@ -84,18 +84,18 @@ _comp_cmd_rpm()
             return
             ;;
         --rcfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --specfile)
             # complete on .spec files
-            _comp_compgen filedir spec
+            _comp_compgen_filedir spec
             return
             ;;
         --whatenhances | --whatprovides | --whatrecommends | --whatrequires | \
             --whatsuggests | --whatsupplements)
             if _comp_looks_like_path "$cur"; then
-                _comp_compgen filedir
+                _comp_compgen_filedir
             else
                 # complete on capabilities
                 local IFS=$'\n' fmt
@@ -138,7 +138,7 @@ _comp_cmd_rpm()
                 --ignoresize --oldpackage --queryformat --repackage
                 --nosuggests' -- "$cur"))
             else
-                _comp_compgen filedir '[rs]pm'
+                _comp_compgen_filedir '[rs]pm'
             fi
             ;;
         -e | --erase)
@@ -166,7 +166,7 @@ _comp_cmd_rpm()
                     COMPREPLY=($(compgen -W '"${opts[@]}" --dbpath --fscontext
                         --last --root --state' -- "$cur"))
                 else
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                 fi
             elif [[ ${words[*]} == *\ -@(*([^ -])g|-group )* ]]; then
                 # -qg completion
@@ -177,7 +177,7 @@ _comp_cmd_rpm()
                     COMPREPLY=($(compgen -W '"${opts[@]}" --ftpport --ftpproxy
                         --httpport --httpproxy --nomanifest' -- "$cur"))
                 else
-                    _comp_compgen filedir '[rs]pm'
+                    _comp_compgen_filedir '[rs]pm'
                 fi
             else
                 # -q; installed package completion
@@ -198,7 +198,7 @@ _comp_cmd_rpm()
                 COMPREPLY=($(compgen -W '"${opts[@]}" --nopgp --nogpg --nomd5' \
                     -- "$cur"))
             else
-                _comp_compgen filedir '[rs]pm'
+                _comp_compgen_filedir '[rs]pm'
             fi
             ;;
         -[Vy]* | --verify)
@@ -211,17 +211,17 @@ _comp_cmd_rpm()
                     -- "$cur"))
             # check whether we're doing file completion
             elif [[ ${words[*]} == *\ -@(*([^ -])f|-file )* ]]; then
-                _comp_compgen filedir
+                _comp_compgen_filedir
             elif [[ ${words[*]} == *\ -@(*([^ -])g|-group )* ]]; then
                 _comp_cmd_rpm__groups "$1"
             elif [[ ${words[*]} == *\ -@(*([^ -])p|-package )* ]]; then
-                _comp_compgen filedir '[rs]pm'
+                _comp_compgen_filedir '[rs]pm'
             else
                 _comp_xfunc_rpm_installed_packages "$1"
             fi
             ;;
         --resign | --addsign | --delsign)
-            _comp_compgen filedir '[rs]pm'
+            _comp_compgen_filedir '[rs]pm'
             ;;
         --setperms | --setgids)
             _comp_xfunc_rpm_installed_packages "$1"
@@ -231,7 +231,7 @@ _comp_cmd_rpm()
                 COMPREPLY=($(compgen -W '--import --dbpath --root=' \
                     -- "$cur"))
             else
-                _comp_compgen filedir
+                _comp_compgen_filedir
             fi
             ;;
     esac
@@ -251,7 +251,7 @@ _comp_cmd_rpmbuild()
     # shellcheck disable=SC2254
     case $prev in
         --buildroot | --root | --dbpath | -${noargopts}r)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --target)
@@ -263,7 +263,7 @@ _comp_cmd_rpmbuild()
             return
             ;;
         --macros | --rcfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --buildpolicy)
@@ -304,7 +304,7 @@ _comp_cmd_rpmbuild()
                 ;;
         esac
     done
-    [[ $ext ]] && _comp_compgen filedir "$ext"
+    [[ $ext ]] && _comp_compgen_filedir "$ext"
 } &&
     complete -F _comp_cmd_rpmbuild rpmbuild rpmbuild-md5
 

--- a/completions/rpm2tgz
+++ b/completions/rpm2tgz
@@ -10,7 +10,7 @@ _comp_cmd_rpm2tgz()
         return
     fi
 
-    _comp_compgen filedir "rpm"
+    _comp_compgen_filedir "rpm"
 } &&
     complete -F _comp_cmd_rpm2tgz rpm2tgz rpm2txz rpm2targz
 

--- a/completions/rpmcheck
+++ b/completions/rpmcheck
@@ -7,7 +7,7 @@ _comp_cmd_rpmcheck()
 
     case $prev in
         -base)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -16,7 +16,7 @@ _comp_cmd_rpmcheck()
         COMPREPLY=($(compgen -W '-explain -failures -successes -dump
             -dump-all -base -help -compressed-input' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_rpmcheck rpmcheck

--- a/completions/rrdtool
+++ b/completions/rrdtool
@@ -9,7 +9,7 @@ _comp_cmd_rrdtool()
         COMPREPLY=($(compgen -W 'create update updatev graph dump restore
             last lastupdate first info fetch tune resize xport' -- "$cur"))
     else
-        _comp_compgen filedir rrd
+        _comp_compgen_filedir rrd
     fi
 } &&
     complete -F _comp_cmd_rrdtool rrdtool

--- a/completions/rsync
+++ b/completions/rsync
@@ -12,13 +12,13 @@ _comp_cmd_rsync()
             --files-from | --log-file | --write-batch | --only-write-batch | \
             --read-batch)
             compopt +o nospace
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --temp-dir | --compare-dest | --backup-dir | --partial-dir | \
             --copy-dest | --link-dest | -${noargopts}T)
             compopt +o nospace
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --rsh | -${noargopts}e)

--- a/completions/sbcl
+++ b/completions/sbcl
@@ -13,7 +13,7 @@ _comp_cmd_sbcl()
             --sysinit --userinit --eval --noprint --disable-debugger
             --end-runtime-options --end-toplevel-options ' -- "$cur"))
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_sbcl sbcl sbcl-mt

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -16,11 +16,11 @@ _comp_cmd_sbopkg()
             return
             ;;
         -f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -V)

--- a/completions/screen
+++ b/completions/screen
@@ -100,7 +100,7 @@ _comp_cmd_screen__sessions()
                 return
                 ;;
             -*c)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             -T)

--- a/completions/scrub
+++ b/completions/scrub
@@ -19,7 +19,7 @@ _comp_cmd_scrub()
             return
             ;;
         --freespace | -${noargopts}X)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -32,7 +32,7 @@ _comp_cmd_scrub()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_scrub scrub
 

--- a/completions/sh
+++ b/completions/sh
@@ -29,7 +29,7 @@ _comp_cmd_sh()
     local args ext=
     _count_args "" "@(-c|[-+]o)"
     ((args == 1)) && ext="sh"
-    _comp_compgen filedir $ext
+    _comp_compgen_filedir $ext
 } &&
     complete -F _comp_cmd_sh sh
 

--- a/completions/sha256sum
+++ b/completions/sha256sum
@@ -24,12 +24,12 @@ _comp_cmd_sha256sum()
     local opt
     for opt in "${words[@]}"; do
         if [[ $opt == -@(c|-check) ]]; then
-            _comp_compgen filedir "$sumtype"
+            _comp_compgen_filedir "$sumtype"
             return
         fi
     done
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
     ((${#COMPREPLY[@]})) &&
         COMPREPLY=($(compgen -X "*.$sumtype" -W '"${COMPREPLY[@]}"' -- "$cur"))
 } &&

--- a/completions/shellcheck
+++ b/completions/shellcheck
@@ -41,7 +41,7 @@ _comp_cmd_shellcheck()
             return
             ;;
         --source-path | -${noargopts}P)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             COMPREPLY+=($(compgen -W 'SCRIPTDIR' -- "$cur"))
             return
             ;;
@@ -58,7 +58,7 @@ _comp_cmd_shellcheck()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_shellcheck shellcheck
 

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -18,11 +18,11 @@ _comp_cmd_sitecopy()
             return
             ;;
         --logfile | --rcfile | -${noargopts}[gr])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --storepath | -${noargopts}p)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -7,7 +7,7 @@ _comp_cmd_slapt_get()
 
     case "$prev" in
         --config | -c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --retry | --search)

--- a/completions/slapt-src
+++ b/completions/slapt-src
@@ -7,7 +7,7 @@ _comp_cmd_slapt_src()
 
     case "$prev" in
         --config | -c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --search | -s | --postprocess | -p)

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -40,7 +40,7 @@ _comp_cmd_smartctl__drivedb()
         prefix=+
         cur="${cur#+}"
     fi
-    _comp_compgen filedir h
+    _comp_compgen_filedir h
     [[ $prefix ]] && COMPREPLY=("${COMPREPLY[@]/#/$prefix}")
 }
 

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -57,11 +57,11 @@ _comp_cmd_smbclient()
             return
             ;;
         --configfile | --authentication-file | -${noargopts}[sA])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --log-basename | --directory | -${noargopts}[lD])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --socket-options | -${noargopts}O)
@@ -116,7 +116,7 @@ _comp_cmd_smbget()
     # shellcheck disable=SC2254
     case $prev in
         --outputfile | --rcfile | -${noargopts}[of])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --debuglevel | -${noargopts}d)
@@ -150,11 +150,11 @@ _comp_cmd_smbcacls()
     # shellcheck disable=SC2254
     case $prev in
         --configfile | --authentication-file | -${noargopts}[As])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --log-basename | -${noargopts}l)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --debuglevel | -${noargopts}d)
@@ -197,11 +197,11 @@ _comp_cmd_smbcquotas()
     # shellcheck disable=SC2254
     case $prev in
         --configfile | --authentication-file | -${noargopts}[sA])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --log-basename | -${noargopts}l)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --debuglevel | -${noargopts}d)
@@ -241,7 +241,7 @@ _comp_cmd_smbpasswd()
             return
             ;;
         -*c)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*D)
@@ -266,7 +266,7 @@ _comp_cmd_smbtar()
 
     case $prev in
         -*[rt])
-            _comp_compgen filedir tar
+            _comp_compgen_filedir tar
             return
             ;;
         -*s)
@@ -278,7 +278,7 @@ _comp_cmd_smbtar()
             return
             ;;
         -*N)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*[pxbdu])
@@ -301,11 +301,11 @@ _comp_cmd_smbtree()
     # shellcheck disable=SC2254
     case $prev in
         --configfile | --authentication-file | -${noargopts}[sA])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --log-basename | -${noargopts}l)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --debuglevel | -${noargopts}d)

--- a/completions/sqlite3
+++ b/completions/sqlite3
@@ -13,7 +13,7 @@ _comp_cmd_sqlite3()
             return
             ;;
         -init)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -cmd)
@@ -31,7 +31,7 @@ _comp_cmd_sqlite3()
         return
     fi
 
-    _comp_compgen filedir "$dbexts"
+    _comp_compgen_filedir "$dbexts"
 } &&
     complete -F _comp_cmd_sqlite3 sqlite3
 

--- a/completions/ss
+++ b/completions/ss
@@ -22,7 +22,7 @@ _comp_cmd_ss()
             return
             ;;
         --diag | --filter | -${noargopts}[DF])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/ssh
+++ b/completions/ssh
@@ -129,7 +129,7 @@ _comp_cmd_ssh__suboption()
             ;;
         *file | identityagent | include | controlpath | revokedhostkeys | \
             xauthlocation)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             ;;
         casignaturealgorithms)
             COMPREPLY=($(compgen -W '$(_comp_xfunc_ssh_query "$2" sig)' -- "$cur"))
@@ -169,7 +169,7 @@ _comp_cmd_ssh__suboption()
             _comp_cmd_ssh__macs "$2"
             ;;
         pkcs11provider)
-            _comp_compgen filedir so
+            _comp_compgen_filedir so
             ;;
         preferredauthentications)
             COMPREPLY=($(compgen -W 'gssapi-with-mic host-based publickey
@@ -293,11 +293,11 @@ _comp_cmd_ssh()
             return
             ;;
         -*[EFS])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*I)
-            _comp_compgen filedir so
+            _comp_compgen_filedir so
             return
             ;;
         -*i)
@@ -381,7 +381,7 @@ _comp_cmd_sftp()
             return
             ;;
         -*[bF])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*i)
@@ -524,7 +524,7 @@ _comp_cmd_scp()
             return
             ;;
         -*F)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             compopt +o nospace
             return
             ;;

--- a/completions/ssh-add
+++ b/completions/ssh-add
@@ -14,11 +14,11 @@ _comp_cmd_ssh_add()
             return
             ;;
         -*T)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*[se])
-            _comp_compgen filedir so
+            _comp_compgen_filedir so
             return
             ;;
     esac
@@ -28,7 +28,7 @@ _comp_cmd_ssh_add()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_ssh_add ssh-add
 

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -36,11 +36,11 @@ _comp_cmd_ssh_keygen()
             return
             ;;
         -*[Dw])
-            _comp_compgen filedir so
+            _comp_compgen_filedir so
             return
             ;;
         -*[fGKsT])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*m)
@@ -96,7 +96,7 @@ _comp_cmd_ssh_keygen()
             return
             ;;
         -*r)
-            [[ ${words[*]} != *\ -*Y\ * ]] || _comp_compgen filedir
+            [[ ${words[*]} != *\ -*Y\ * ]] || _comp_compgen_filedir
             return
             ;;
         -*t)

--- a/completions/ssh-keyscan
+++ b/completions/ssh-keyscan
@@ -15,7 +15,7 @@ _comp_cmd_ssh_keyscan()
             ipvx=-6
             ;;
         -*f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*p | -*T)

--- a/completions/sshow
+++ b/completions/sshow
@@ -11,7 +11,7 @@ _comp_cmd_sshow()
             return
             ;;
         -*p)
-            _comp_compgen filedir pcap
+            _comp_compgen_filedir pcap
             return
             ;;
     esac

--- a/completions/strace
+++ b/completions/strace
@@ -70,7 +70,7 @@ _comp_cmd_strace()
                 return
                 ;;
             -*o)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             -*p)

--- a/completions/strings
+++ b/completions/strings
@@ -48,12 +48,12 @@ _comp_cmd_strings()
         return
     elif [[ $cur == @* ]]; then
         cur=${cur:1}
-        _comp_compgen filedir
+        _comp_compgen_filedir
         COMPREPLY=("${COMPREPLY[@]/#/@}")
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_strings strings
 

--- a/completions/sudo
+++ b/completions/sudo
@@ -52,7 +52,7 @@ _comp_cmd_sudo()
         return
     fi
     if [[ $mode == edit ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_sudo sudo sudoedit

--- a/completions/svk
+++ b/completions/svk
@@ -23,7 +23,7 @@ _comp_cmd_svk()
     else
         case $prev in
             -F | --file | --targets)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 return
                 ;;
             --encoding)
@@ -203,7 +203,7 @@ _comp_cmd_svk()
                         command sed -e 's|\(.*\)|'"$path"'\1|')" -- "$cur"))
                     ;;
                 *)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
             esac
         fi

--- a/completions/sync_members
+++ b/completions/sync_members
@@ -11,7 +11,7 @@ _comp_cmd_sync_members()
             return
             ;;
         --file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -87,7 +87,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --mysql-socket)
-            _comp_compgen filedir sock
+            _comp_compgen_filedir sock
             return
             ;;
         --mysql-table-engine)

--- a/completions/sysctl
+++ b/completions/sysctl
@@ -12,7 +12,7 @@ _comp_cmd_sysctl()
             return
             ;;
         --load | -${noargopts}[pf])
-            _comp_compgen filedir conf
+            _comp_compgen_filedir conf
             return
             ;;
     esac

--- a/completions/tar
+++ b/completions/tar
@@ -246,10 +246,10 @@ __tar_file_option()
     case "$tar_mode" in
         c)
             # no need to advise user to re-write existing tarball
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             ;;
         *)
-            _comp_compgen filedir "$ext"
+            _comp_compgen_filedir "$ext"
             ;;
     esac
 }
@@ -547,11 +547,11 @@ _comp_cmd_tar__gnu()
                 --exclude-from | --listed-incremental | --group-map | \
                 --mtime | --owner-map | --volno-file | --newer | \
                 --after-date | --index-file | -${noargopts}[TXg])
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 break
                 ;;
             --directory | -${noargopts}C)
-                _comp_compgen filedir -d
+                _comp_compgen_filedir -d
                 break
                 ;;
             --hole-detection)
@@ -661,7 +661,7 @@ _comp_cmd_tar__gnu()
 
         # file completion on relevant files
         if [[ $tar_mode != none ]]; then
-            _comp_compgen filedir
+            _comp_compgen_filedir
         fi
 
         break
@@ -729,7 +729,7 @@ _comp_cmd_tar__posix()
     _comp_cmd_tar__try_list_archive && return
 
     # file completion on relevant files
-    _comp_compgen filedir
+    _comp_compgen_filedir
 }
 
 _comp_cmd_tar()

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -9,7 +9,7 @@ _comp_cmd_tcpdump()
     # shellcheck disable=SC2254
     case $prev in
         -${noargopts}[rwFV])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --interface | -${noargopts}i)
@@ -17,7 +17,7 @@ _comp_cmd_tcpdump()
             return
             ;;
         -${noargopts}m)
-            _comp_compgen filedir mib
+            _comp_compgen_filedir mib
             return
             ;;
         -${noargopts}T)

--- a/completions/tox
+++ b/completions/tox
@@ -19,11 +19,11 @@ _comp_cmd_tox()
             return
             ;;
         -${noargopts}c)
-            _comp_compgen filedir ini
+            _comp_compgen_filedir ini
             return
             ;;
         --installpkg | --result-json | --workdir)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -${noargopts}e)

--- a/completions/tree
+++ b/completions/tree
@@ -16,7 +16,7 @@ _comp_cmd_tree()
             return
             ;;
         -${noargopts}o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --sort)
@@ -36,9 +36,9 @@ _comp_cmd_tree()
     # assign ${words[*]} in a temporary variable "line".
     local line="${words[*]}"
     if [[ $line == *\ --fromfile\ * ]]; then
-        _comp_compgen filedir
+        _comp_compgen_filedir
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_tree tree

--- a/completions/truncate
+++ b/completions/truncate
@@ -12,7 +12,7 @@ _comp_cmd_truncate()
             return
             ;;
         -${noargopts}r | --reference)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -25,7 +25,7 @@ _comp_cmd_truncate()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_truncate truncate
 

--- a/completions/tshark
+++ b/completions/tshark
@@ -21,7 +21,7 @@ _comp_cmd_tshark()
         -o*)
             if [[ $cur == *:* ]]; then
                 cur=${cur#*:}
-                _comp_compgen filedir
+                _comp_compgen_filedir
             else
                 [[ -v _comp_cmd_tshark__prefs ]] ||
                     _comp_cmd_tshark__prefs="$("$1" -G defaultprefs 2>/dev/null | command sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
@@ -61,11 +61,11 @@ _comp_cmd_tshark()
             ;;
         -*[rH])
             # -r accepts a lot of different file types
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -*w)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             [[ $cur == @(|-) ]] && COMPREPLY+=(-)
             return
             ;;
@@ -105,7 +105,7 @@ _comp_cmd_tshark()
         -*X)
             if [[ ${cur:${#prefix}} == lua_script:* ]]; then
                 cur=${cur#*:}
-                _comp_compgen filedir lua
+                _comp_compgen_filedir lua
             else
                 COMPREPLY=($(compgen -P "$prefix" -W 'lua_script:' -- \
                     "${cur:${#prefix}}"))

--- a/completions/tune2fs
+++ b/completions/tune2fs
@@ -20,7 +20,7 @@ _comp_cmd_tune2fs()
             return
             ;;
         -*M)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -*o)
@@ -56,7 +56,7 @@ _comp_cmd_tune2fs()
     fi
 
     : "${cur:=/dev/}"
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_tune2fs tune2fs
 

--- a/completions/unace
+++ b/completions/unace
@@ -11,7 +11,7 @@ _comp_cmd_unace()
         if ((cword == 1)); then
             COMPREPLY=($(compgen -W 'e l t v x' -- "$cur"))
         else
-            _comp_compgen filedir '@(ace|cba)'
+            _comp_compgen_filedir '@(ace|cba)'
         fi
     fi
 } &&

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -39,10 +39,10 @@ _comp_cmd_unpack200()
                 --verbose --quiet --log-file= --help --version' -- "$cur"))
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            _comp_compgen filedir 'pack?(.gz)'
+            _comp_compgen_filedir 'pack?(.gz)'
         fi
     elif [[ ! $jar ]]; then
-        _comp_compgen filedir jar
+        _comp_compgen_filedir jar
     fi
 } &&
     complete -F _comp_cmd_unpack200 unpack200

--- a/completions/unrar
+++ b/completions/unrar
@@ -13,7 +13,7 @@ _comp_cmd_unrar()
         if ((cword == 1)); then
             COMPREPLY=($(compgen -W 'e l lb lt p t v vb vt x' -- "$cur"))
         else
-            _comp_compgen filedir '@(rar|exe|cbr)'
+            _comp_compgen_filedir '@(rar|exe|cbr)'
         fi
     fi
 

--- a/completions/unshunt
+++ b/completions/unshunt
@@ -8,7 +8,7 @@ _comp_cmd_unshunt()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 
 } &&

--- a/completions/update-alternatives
+++ b/completions/update-alternatives
@@ -23,7 +23,7 @@ _comp_cmd_update_alternatives()
 
     case $prev in
         --altdir | --admindir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --help | --usage | --version)
@@ -46,7 +46,7 @@ _comp_cmd_update_alternatives()
         --install)
             case $args in
                 1 | 3)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
                 2)
                     _comp_cmd_update_alternatives__installed
@@ -57,7 +57,7 @@ _comp_cmd_update_alternatives()
                 *)
                     case $((args % 4)) in
                         0 | 2)
-                            _comp_compgen filedir
+                            _comp_compgen_filedir
                             ;;
                         1)
                             COMPREPLY=($(compgen -W '--slave' -- "$cur"))
@@ -75,7 +75,7 @@ _comp_cmd_update_alternatives()
                     _comp_cmd_update_alternatives__installed
                     ;;
                 2)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     ;;
             esac
             ;;

--- a/completions/upgradepkg
+++ b/completions/upgradepkg
@@ -23,7 +23,7 @@ _comp_cmd_upgradepkg()
         return
     fi
 
-    _comp_compgen filedir 't[bglx]z'
+    _comp_compgen_filedir 't[bglx]z'
 } &&
     complete -F _comp_cmd_upgradepkg upgradepkg
 

--- a/completions/urlsnarf
+++ b/completions/urlsnarf
@@ -11,7 +11,7 @@ _comp_cmd_urlsnarf()
             return
             ;;
         -*p)
-            _comp_compgen filedir pcap
+            _comp_compgen_filedir pcap
             return
             ;;
     esac

--- a/completions/uscan
+++ b/completions/uscan
@@ -11,11 +11,11 @@ _comp_cmd_uscan()
             return
             ;;
         --watchfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --destdir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --timeout | --upstream-version | --download-version | \

--- a/completions/useradd
+++ b/completions/useradd
@@ -25,7 +25,7 @@ _comp_cmd_useradd()
             return
             ;;
         --base-dir | --home-dir | --skel | --root | -${noargopts}[bdkR])
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --gid | -${noargopts}g)

--- a/completions/userdel
+++ b/completions/userdel
@@ -12,7 +12,7 @@ _comp_cmd_userdel()
             return
             ;;
         --root | -${noargopts}R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/usermod
+++ b/completions/usermod
@@ -36,7 +36,7 @@ _comp_cmd_usermod()
             return
             ;;
         --root | -${noargopts}R)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --selinux-user | -${noargopts}Z)

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -53,7 +53,7 @@ _comp_cmd_valgrind()
             ;;
         # callgrind:
         --callgrind-out-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         # exp-dhat:
@@ -75,7 +75,7 @@ _comp_cmd_valgrind()
                     -ne "s|^[[:blank:]]*$prev=\([^[:blank:]]\{1,\}\).*|\1|p")
             case $value in
                 \<file*\>)
-                    _comp_compgen filedir
+                    _comp_compgen_filedir
                     return
                     ;;
                 \<command\>)

--- a/completions/vipw
+++ b/completions/vipw
@@ -12,7 +12,7 @@ _comp_cmd_vipw()
             return
             ;;
         --root | -${noargopts}R | -d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac

--- a/completions/vncviewer
+++ b/completions/vncviewer
@@ -24,7 +24,7 @@ _comp_cmd_tightvncviewer()
 
     case $prev in
         -passwd)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -encodings)
@@ -61,7 +61,7 @@ _comp_cmd_xvnc4viewer()
     case ${opt,,} in
         # -passwd, -PasswordFile
         -passwd | -passwordfile)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         -preferredencoding)

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -26,7 +26,7 @@ _vpnc()
             return
             ;;
         --script | --pid-file | --ca-file)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --dh)
@@ -50,7 +50,7 @@ _vpnc()
             return
             ;;
         --ca-dir)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --password-helper)
@@ -64,7 +64,7 @@ _vpnc()
         COMPREPLY=($(compgen -W '$(_parse_help "$1" --long-help)' -- "$cur"))
     elif _comp_looks_like_path "$cur"; then
         # explicit filename
-        _comp_compgen filedir conf
+        _comp_compgen_filedir conf
     else
         # config name, /etc/vpnc/<name>.conf
         local -a configs

--- a/completions/wget
+++ b/completions/wget
@@ -63,18 +63,18 @@ _comp_cmd_wget()
             return
             ;;
         --directory-prefix | --ca-directory | --warc-tempdir | -${noargopts}P)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --output-file | --append-output | --config | --load-cookies | \
             --save-cookies | --post-file | --certificate | --ca-certificate | \
             --private-key | --random-file | --egd-file | --warc-file | \
             --warc-dedup | -${noargopts}[oa])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --output-document | --input-file | -${noargopts}[Oi])
-            _comp_compgen filedir && [[ $cur == - || ! $cur ]] && COMPREPLY+=(-)
+            _comp_compgen_filedir && [[ $cur == - || ! $cur ]] && COMPREPLY+=(-)
             return
             ;;
         --secure-protocol)

--- a/completions/wine
+++ b/completions/wine
@@ -16,9 +16,9 @@ _comp_cmd_wine()
             COMPREPLY=($(compgen -W '--help --version' -- "$cur"))
             [[ ${COMPREPLY-} ]] && return
         fi
-        _comp_compgen filedir '@([eE][xX][eE]?(.[sS][oO])|[cC][oO][mM]|[sS][cC][rR]|[mM][sS][iI])'
+        _comp_compgen_filedir '@([eE][xX][eE]?(.[sS][oO])|[cC][oO][mM]|[sS][cC][rR]|[mM][sS][iI])'
     else
-        _comp_compgen filedir
+        _comp_compgen_filedir
     fi
 } &&
     complete -F _comp_cmd_wine wine{,64}{,-development,-stable}

--- a/completions/wodim
+++ b/completions/wodim
@@ -13,7 +13,7 @@ _comp_cmd_wodim()
         cur=${cur#*=}
         case $prev in
             textfile | cuefile | msifile)
-                _comp_compgen filedir
+                _comp_compgen_filedir
                 ;;
             blank)
                 COMPREPLY=($(compgen -W 'help all fast track unreserve trtail
@@ -32,7 +32,7 @@ _comp_cmd_wodim()
                                 1.4" -- "$cur"))
                             ;;
                         tattoofile)
-                            _comp_compgen filedir
+                            _comp_compgen_filedir
                             ;;
                     esac
                 else
@@ -82,7 +82,7 @@ _comp_cmd_wodim()
     fi
 
     # files are always eligible completion
-    _comp_compgen filedir
+    _comp_compgen_filedir
     # track options are always available
     COMPREPLY+=($(compgen -W '"${track_options[@]}"' -- "$cur"))
     # general options are no more available after file or track option

--- a/completions/wol
+++ b/completions/wol
@@ -25,7 +25,7 @@ _comp_cmd_wol()
             return
             ;;
         --file | -${noargopts}f)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/wsimport
+++ b/completions/wsimport
@@ -10,15 +10,15 @@ _comp_cmd_wsimport()
             return
             ;;
         -b)
-            _comp_compgen filedir '@(xml|xjb)'
+            _comp_compgen_filedir '@(xml|xjb)'
             return
             ;;
         -catalog)
-            _comp_compgen filedir '@(xml|soc|catalog)'
+            _comp_compgen_filedir '@(xml|soc|catalog)'
             return
             ;;
         -d | –s)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -target)
@@ -26,7 +26,7 @@ _comp_cmd_wsimport()
             return
             ;;
         -clientjar)
-            _comp_compgen filedir jar
+            _comp_compgen_filedir jar
             return
             ;;
     esac
@@ -41,7 +41,7 @@ _comp_cmd_wsimport()
         return
     fi
 
-    _comp_compgen filedir wsdl
+    _comp_compgen_filedir wsdl
 } &&
     complete -F _comp_cmd_wsimport wsimport
 

--- a/completions/wtf
+++ b/completions/wtf
@@ -6,7 +6,7 @@ _comp_cmd_wtf()
     local cur prev words cword comp_args addf
     _comp_initialize -- "$@" || return
 
-    [[ $prev == -f ]] && _comp_compgen filedir && return
+    [[ $prev == -f ]] && _comp_compgen_filedir && return
     [[ ${words[*]} == *\ -f* ]] && addf= || addf=-f
     if [[ $cur == -* ]]; then
         COMPREPLY=($addf)

--- a/completions/wvdial
+++ b/completions/wvdial
@@ -7,7 +7,7 @@ _comp_cmd_wvdial()
 
     case $prev in
         --config)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -49,7 +49,7 @@ _comp_cmd_xdg_mime()
             fi
             ((args == 3)) || return
             case ${words[2]} in
-                filetype) _comp_compgen filedir ;;
+                filetype) _comp_compgen_filedir ;;
                 default) _comp_cmd_xdg_mime__mimetype ;;
             esac
             ;;
@@ -72,7 +72,7 @@ _comp_cmd_xdg_mime()
             elif [[ $prev == --mode ]]; then
                 COMPREPLY=($(compgen -W 'user system' -- "$cur"))
             else
-                _comp_compgen filedir xml
+                _comp_compgen_filedir xml
             fi
             ;;
         uninstall)
@@ -81,7 +81,7 @@ _comp_cmd_xdg_mime()
             elif [[ $prev == --mode ]]; then
                 COMPREPLY=($(compgen -W 'user system' -- "$cur"))
             else
-                _comp_compgen filedir xml
+                _comp_compgen_filedir xml
             fi
             ;;
     esac

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -44,7 +44,7 @@ _comp_cmd_xfreerdp()
     esac
 
     if [[ $cur == /* ]]; then
-        _comp_compgen filedir rdp
+        _comp_compgen_filedir rdp
         COMPREPLY+=($(compgen -W '$("$1" --help |
             awk "\$1 ~ /^\\// && \$1 !~ /^.(flag\$|option:)/ { sub(\":.*\",\":\",\$1); print \$1 }")' \
             -- "$cur"))
@@ -62,7 +62,7 @@ _comp_cmd_xfreerdp()
                 COMPREPLY=($(compgen -W '"${COMPREPLY[@]%:}"' -- "$cur"))
         fi
     else
-        _comp_compgen filedir rdp
+        _comp_compgen_filedir rdp
         COMPREPLY+=($(compgen -W "$(awk '{print $1}' ~/.freerdp/known_hosts \
             2>/dev/null)" -- "$cur"))
     fi

--- a/completions/xmllint
+++ b/completions/xmllint
@@ -7,7 +7,7 @@ _comp_cmd_xmllint()
 
     case $prev in
         -o | --output)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --path | --dtdvalidfpi | --maxmem | --pattern | --xpath)
@@ -15,19 +15,19 @@ _comp_cmd_xmllint()
             return
             ;;
         --dtdvalid)
-            _comp_compgen filedir 'dtd?(.gz)'
+            _comp_compgen_filedir 'dtd?(.gz)'
             return
             ;;
         --relaxng)
-            _comp_compgen filedir 'rng?(.gz)'
+            _comp_compgen_filedir 'rng?(.gz)'
             return
             ;;
         --schema)
-            _comp_compgen filedir 'xsd?(.gz)'
+            _comp_compgen_filedir 'xsd?(.gz)'
             return
             ;;
         --schematron)
-            _comp_compgen filedir 'sch?(.gz)'
+            _comp_compgen_filedir 'sch?(.gz)'
             return
             ;;
         --encode)
@@ -46,7 +46,7 @@ _comp_cmd_xmllint()
         return
     fi
 
-    _comp_compgen filedir '@(*ml|htm|svg?(z)|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)?(.gz)'
+    _comp_compgen_filedir '@(*ml|htm|svg?(z)|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)?(.gz)'
 } &&
     complete -F _comp_cmd_xmllint xmllint
 

--- a/completions/xmlwf
+++ b/completions/xmlwf
@@ -7,7 +7,7 @@ _comp_cmd_xmlwf()
 
     case $prev in
         -*d)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         -*e)
@@ -27,7 +27,7 @@ _comp_cmd_xmlwf()
         return
     fi
 
-    _comp_compgen filedir '@(*ml|htm|svg|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)'
+    _comp_compgen_filedir '@(*ml|htm|svg|xs[dl]|rng|wsdl|jnlp|tld|dbk|docbook|page)'
 } &&
     complete -F _comp_cmd_xmlwf xmlwf
 

--- a/completions/xmms
+++ b/completions/xmms
@@ -22,7 +22,7 @@ _comp_cmd_xmms()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
     else
-        _comp_compgen filedir '@(mp[23]|ogg|wav|pls|m3u|xm|mod|s[3t]m|it|mtm|ult|flac)'
+        _comp_compgen_filedir '@(mp[23]|ogg|wav|pls|m3u|xm|mod|s[3t]m|it|mtm|ult|flac)'
     fi
 
 } &&

--- a/completions/xmodmap
+++ b/completions/xmodmap
@@ -16,7 +16,7 @@ _comp_cmd_xmodmap()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_xmodmap xmodmap
 

--- a/completions/xrdb
+++ b/completions/xrdb
@@ -10,7 +10,7 @@ _comp_cmd_xrdb()
             return
             ;;
         -cpp | -edit)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac
@@ -20,7 +20,7 @@ _comp_cmd_xrdb()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_xrdb xrdb
 

--- a/completions/xsltproc
+++ b/completions/xsltproc
@@ -7,7 +7,7 @@ _comp_cmd_xsltproc()
 
     case $prev in
         --output | -o)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         # TODO : number only
@@ -25,11 +25,11 @@ _comp_cmd_xsltproc()
             ;;
         # not really like --writesubtree
         --path)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
         --writesubtree)
-            _comp_compgen filedir -d
+            _comp_compgen_filedir -d
             return
             ;;
     esac
@@ -41,7 +41,7 @@ _comp_cmd_xsltproc()
         COMPREPLY=("${COMPREPLY[@]%:}")
     else
         # TODO: 1st file xsl|xslt, 2nd XML
-        _comp_compgen filedir '@(xsl|xslt|xml|dbk|docbook|page)'
+        _comp_compgen_filedir '@(xsl|xslt|xml|dbk|docbook|page)'
     fi
 } &&
     complete -F _comp_cmd_xsltproc xsltproc

--- a/completions/xvfb-run
+++ b/completions/xvfb-run
@@ -22,7 +22,7 @@ _comp_cmd_xvfb_run()
             return
             ;;
         --error-file | --auth-file | -${noargopts}[ef])
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
     esac

--- a/completions/xxd
+++ b/completions/xxd
@@ -17,7 +17,7 @@ _comp_cmd_xxd()
         return
     fi
 
-    _comp_compgen filedir
+    _comp_compgen_filedir
 } &&
     complete -F _comp_cmd_xxd xxd
 

--- a/completions/xz
+++ b/completions/xz
@@ -14,7 +14,7 @@ _comp_cmd_xz()
             xspec="!"$xspec
             ;;
         --files | --files0)
-            _comp_compgen filedir
+            _comp_compgen_filedir
             return
             ;;
         --check | -${noargopts}C)

--- a/completions/xzdec
+++ b/completions/xzdec
@@ -24,7 +24,7 @@ _comp_cmd_xzdec()
         return
     fi
 
-    _comp_compgen filedir xz # no lzma support here as of xz 4.999.9beta
+    _comp_compgen_filedir xz # no lzma support here as of xz 4.999.9beta
 } &&
     complete -F _comp_cmd_xzdec xzdec
 

--- a/completions/yum-arch
+++ b/completions/yum-arch
@@ -8,7 +8,7 @@ _comp_cmd_yum_arch()
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '-d -v -vv -n -c -z -s -l -q' -- "$cur"))
     else
-        _comp_compgen filedir -d
+        _comp_compgen_filedir -d
     fi
 } &&
     complete -F _comp_cmd_yum_arch yum-arch

--- a/completions/zopflipng
+++ b/completions/zopflipng
@@ -29,10 +29,10 @@ _comp_cmd_zopflipng()
         # 2 png args only if --prefix not given
         local args
         _count_args
-        ((args < 3)) && _comp_compgen filedir png
+        ((args < 3)) && _comp_compgen_filedir png
     else
         # otherwise arbitrary number of png args
-        _comp_compgen filedir png
+        _comp_compgen_filedir png
     fi
 } &&
     complete -F _comp_cmd_zopflipng zopflipng


### PR DESCRIPTION
> I think it's easy enough to remember that if no `_comp_compgen` features are needed, calling `_comp_compgen_FOO` directly is ok (and preferred) for efficiency. So I guess that's what I'd prefer, but whatever we go with would be good to be documented somewhere, e.g. in the style guide, or the related function commentary.

_Originally posted by @scop in https://github.com/scop/bash-completion/pull/954#discussion_r1186805078_

> The change `_comp_compgen filedir` => `_comp_compgen_filedir` is another large one and makes the GitHub interface unuseful, so I decided to separate the PR for it.

_Originally posted by @akinomyoga in https://github.com/scop/bash-completion/pull/954#discussion_r1186823627_

----

c91e6c4e7bc3adb7531158d21e99af2150f8b2ea is the rewrite.

I'm including the variable name changes in `_comp_compgen_filedir` to avoid conflicts that can be introduced when `_comp_comgen -v var filedir` is used (08477b4bdbd2dd4cb1ead7ce51500450805cb453).

> but whatever we go with would be good to be documented somewhere, e.g. in the style guide, or the related function commentary.

I added a `@remarks` in the function code document (ea3a88ece00d83dcd93aabf48180b073b66713bc) but haven't added it to the style guide. It seems even usage of `xfunc` is currently undocumented in `doc/*.md`, so it is consistent to describe both `_comp_xfunc` and `_comp_compgen` if we are to add commentary of the `_comp_compgen` usage in the style guide.

