### PR TITLE
fix: use `_comp_compgen` for multiline `COMPREPLY=($(compgen ...))`

### DIFF
--- a/completions/7z
+++ b/completions/7z
@@ -26,8 +26,7 @@ _comp_cmd_7z()
                 opt=${cur:0:2} cur=${cur:2}
             fi
             if [[ $cur != *[@\!]* ]]; then
-                COMPREPLY=($(compgen -P"$opt" -W '@ ! r@ r-@ r0@ r! r-! r0!' \
-                    -- "$cur"))
+                _comp_compgen -- -P"$opt" -W '@ ! r@ r-@ r0@ r! r-! r0!'
             elif [[ $cur == ?(r@(-|0|))@* ]]; then
                 _comp_compgen -c "${cur#*@}" -- -P"${opt}${cur%%@*}@" -f
                 compopt -o filenames
@@ -53,8 +52,7 @@ _comp_cmd_7z()
             return
             ;;
         -scs*)
-            COMPREPLY=($(compgen -P"${cur:0:4}" -W 'UTF-8 WIN DOS' \
-                -- "${cur:4}"))
+            _comp_compgen -c "${cur:4}" -- -P"${cur:0:4}" -W 'UTF-8 WIN DOS'
             return
             ;;
         -ssc?*)
@@ -63,14 +61,13 @@ _comp_cmd_7z()
             ;;
         -t*)
             if [[ $mode == w ]]; then
-                COMPREPLY=($(compgen -P"${cur:0:2}" -W '7z bzip2 gzip swfc
-                    tar wim xz zip' -- "${cur:2}"))
+                _comp_compgen -c "${cur:2}" -- -P"${cur:0:2}" -W '7z bzip2 gzip
+                    swfc tar wim xz zip'
             else
-                COMPREPLY=($(compgen -P"${cur:0:2}" -W '7z apm arj bzip2 cab
-                    chm cpio cramfs deb dmg elf fat flv gzip hfs iso lzh lzma
-                    lzma86 macho mbr mslz mub nsis ntfs pe ppmd rar rpm
-                    squashfs swf swfc tar udf vhd wim xar xz z zip' \
-                    -- "${cur:2}"))
+                _comp_compgen -c "${cur:2}" -- -P"${cur:0:2}" -W '7z apm arj
+                    bzip2 cab chm cpio cramfs deb dmg elf fat flv gzip hfs iso
+                    lzh lzma lzma86 macho mbr mslz mub nsis ntfs pe ppmd rar
+                    rpm squashfs swf swfc tar udf vhd wim xar xz z zip'
             fi
             return
             ;;
@@ -80,9 +77,8 @@ _comp_cmd_7z()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-ai -an -ao -ax -bd -i -m{x,s,f,he,hc,mt}=
-            -o -p -r -scs -sfx -si -slp -slt -so -ssc -t -u -v -w -x -y' \
-            -- "$cur"))
+        _comp_compgen -- -W '-ai -an -ao -ax -bd -i -m{x,s,f,he,hc,mt}=
+            -o -p -r -scs -sfx -si -slp -slt -so -ssc -t -u -v -w -x -y'
         [[ ${COMPREPLY-} == -@(an|bd|sfx|si|slt|so|ssc|[rwy]) ]] ||
             compopt -o nospace
         return

--- a/completions/_dmesg
+++ b/completions/_dmesg
@@ -15,8 +15,7 @@ _comp_cmd_dmesg()
             return
             ;;
         -f | --facility)
-            COMPREPLY=($(compgen -W 'kern user mail daemon auth syslog lpr
-                news' -- "$cur"))
+            _comp_compgen -- -W 'kern user mail daemon auth syslog lpr news'
             return
             ;;
         -l | --level | -n | --console-level)

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -18,11 +18,11 @@ _comp_cmd_mount()
                 cur="${cur##*,}"
                 split=set
             fi
-            COMPREPLY=($(compgen -W 'auto adfs affs autofs btrfs cifs coda
-                cramfs davfs debugfs devpts efs ext2 ext3 ext4 fuse hfs hfsplus
-                hpfs iso9660 jffs2 jfs minix msdos ncpfs nfs nfs4 ntfs ntfs-3g
-                proc qnx4 ramfs reiserfs romfs squashfs smbfs sysv tmpfs ubifs
-                udf ufs umsdos usbfs vfat xfs' -- "$cur"))
+            _comp_compgen -- -W 'auto adfs affs autofs btrfs cifs coda cramfs
+                davfs debugfs devpts efs ext2 ext3 ext4 fuse hfs hfsplus hpfs
+                iso9660 jffs2 jfs minix msdos ncpfs nfs nfs4 ntfs ntfs-3g proc
+                qnx4 ramfs reiserfs romfs squashfs smbfs sysv tmpfs ubifs udf
+                ufs umsdos usbfs vfat xfs'
             _fstypes
             [[ $split ]] && COMPREPLY=(${COMPREPLY[@]/#/$prev,})
             return
@@ -79,129 +79,131 @@ _comp_cmd_mount()
             # no completion if $cur is opt=smth
             [[ $cur == *=* ]] && return
             # mount options
-            COMPREPLY=($(compgen -W 'loop {,a}sync {,no}atime {,no}auto
+            _comp_compgen -- -W 'loop {,a}sync {,no}atime {,no}auto
                 {,fs,def,root}context= defaults {,no}dev {,no}diratime dirsync
                 {,no}exec group {,no}iversion {,no}mand _netdev nofail
                 {,no}relatime {,no}strictatime {,no}suid owner remount ro rw
-                {,no}user users' -- "$cur"))
+                {,no}user users'
             case "$fstype" in
                 adfs | auto)
                     _comp_compgen -a -- -W '{u,g}id= {own,oth}mask='
                     ;;&
                 affs | auto)
-                    COMPREPLY+=($(compgen -W '{u,g}id= set{u,g}id= mode= protect
-                    usemp verbose prefix= volume= reserved= root= bs=
-                    {,no,usr,grp}quota' -- "$cur"))
+                    _comp_compgen -a -- -W '{u,g}id= set{u,g}id= mode= protect
+                        usemp verbose prefix= volume= reserved= root= bs=
+                        {,no,usr,grp}quota'
                     ;;&
                 btrfs | auto)
-                    COMPREPLY+=($(compgen -W 'degraded subvol= subvolid= device=
-                    nodatasum nodatacow nobarrier max_inline= alloc_start=
-                    thread_pool= compress= compress-force= ssd noacl notreelog
-                    flushoncommit metadata_ratio= {,no}space_cache clear_cache
-                    user_subvol_rm_allowed autodefrag inode_cache' -- "$cur"))
+                    _comp_compgen -a -- -W 'degraded subvol= subvolid= device=
+                        nodatasum nodatacow nobarrier max_inline= alloc_start=
+                        thread_pool= compress= compress-force= ssd noacl
+                        notreelog flushoncommit metadata_ratio=
+                        {,no}space_cache clear_cache user_subvol_rm_allowed
+                        autodefrag inode_cache'
                     ;;&
                 cifs | auto)
-                    COMPREPLY+=($(compgen -W 'user= password= credentials= {u,g}id=
-                    force{u,g}id port= servern= netbiosname= {file,dir}_mode=
-                    ip= domain= guest iocharset {,no}setuids {,no,dyn}perm
-                    directio {,no}mapchars {,no}intr hard soft noacl nocase sec=
-                    nobrl sfu {,no}serverino nounix nouser_xattr {r,w}size=
-                    rwpidforward backup{u,g}id cache=' -- "$cur"))
+                    _comp_compgen -a -- -W 'user= password= credentials=
+                        {u,g}id= force{u,g}id port= servern= netbiosname=
+                        {file,dir}_mode= ip= domain= guest iocharset
+                        {,no}setuids {,no,dyn}perm directio {,no}mapchars
+                        {,no}intr hard soft noacl nocase sec= nobrl sfu
+                        {,no}serverino nounix nouser_xattr {r,w}size=
+                        rwpidforward backup{u,g}id cache='
                     ;;&
                 davfs | auto)
-                    COMPREPLY+=($(compgen -W 'conf= {file,dir}_mode= {u,g}id=
-                    username=' -- "$cur"))
+                    _comp_compgen -a -- -W 'conf= {file,dir}_mode= {u,g}id=
+                        username='
                     ;;&
                 ext[2-4] | auto)
-                    COMPREPLY+=($(compgen -W '{,no}acl bsddf minixdf check= debug
-                    errors= {,no}grpid {bsd,sysv}groups {,no,usr,grp}quota
-                    nobh nouid32 oldalloc orlov res{u,g}id= sb=
-                    {,no}user_xattr' -- "$cur"))
+                    _comp_compgen -a -- -W '{,no}acl bsddf minixdf check= debug
+                        errors= {,no}grpid {bsd,sysv}groups {,no,usr,grp}quota
+                        nobh nouid32 oldalloc orlov res{u,g}id= sb=
+                        {,no}user_xattr'
                     ;;&
                 ext[34] | auto)
-                    COMPREPLY+=($(compgen -W 'journal= journal_dev= norecovery
-                    noload data= barrier= commit=' -- "$cur"))
+                    _comp_compgen -a -- -W 'journal= journal_dev= norecovery
+                        noload data= barrier= commit='
                     ;;&
                 ext4 | auto)
-                    COMPREPLY+=($(compgen -W 'journal_checksum journal_async_commit
-                    nobarrier inode_readahead= stripe= {,no}delalloc abort
-                    {max,min}_batch_time= journal_ioprio= {,no}auto_da_alloc
-                    {,no}discard nouid32 resize {,no}block_validity
-                    dioread_{,no}lock max_dir_size_kb= i_version' -- "$cur"))
+                    _comp_compgen -a -- -W 'journal_checksum
+                        journal_async_commit nobarrier inode_readahead= stripe=
+                        {,no}delalloc abort {max,min}_batch_time=
+                        journal_ioprio= {,no}auto_da_alloc {,no}discard nouid32
+                        resize {,no}block_validity dioread_{,no}lock
+                        max_dir_size_kb= i_version'
                     ;;&
                 msdos | umsdos | vfat | auto)
-                    COMPREPLY+=($(compgen -W 'blocksize= {u,g}id= {u,d,f}mask=
-                    allow_utime= check= codepage= conv= cvf_format= cvf_option=
-                    debug fat= iocharset= tz= quiet showexec sys_immutable flush
-                    usefree {,no}dots dotsOK=' -- "$cur"))
+                    _comp_compgen -a -- -W 'blocksize= {u,g}id= {u,d,f}mask=
+                        allow_utime= check= codepage= conv= cvf_format=
+                        cvf_option= debug fat= iocharset= tz= quiet showexec
+                        sys_immutable flush usefree {,no}dots dotsOK='
                     ;;&
                 vfat | auto)
-                    COMPREPLY+=($(compgen -W 'uni_xlate posix nonumtail utf8
-                    shortname=' -- "$cur"))
+                    _comp_compgen -a -- -W 'uni_xlate posix nonumtail utf8
+                        shortname='
                     ;;&
                 iso9660 | auto)
-                    COMPREPLY+=($(compgen -W 'norock nojoliet check= {u,g}id= map=
-                    mode= unhide block= conv= cruft session= sbsector=
-                    iocharset= utf8' -- "$cur"))
+                    _comp_compgen -a -- -W 'norock nojoliet check= {u,g}id=
+                        map= mode= unhide block= conv= cruft session= sbsector=
+                        iocharset= utf8'
                     ;;&
                 jffs2 | auto)
                     _comp_compgen -a -- -W 'compr= rp_size='
                     ;;&
                 jfs | auto)
-                    COMPREPLY+=($(compgen -W 'iocharset= resize= {,no}integrity
-                    errors= {,no,usr,grp}quota' -- "$cur"))
+                    _comp_compgen -a -- -W 'iocharset= resize= {,no}integrity
+                        errors= {,no,usr,grp}quota'
                     ;;&
                 nfs | nfs4 | auto)
-                    COMPREPLY+=($(compgen -W 'soft hard timeo= retrans= {r,w}size=
-                    {,no}ac acreg{min,max}= acdir{min,max}= actimeo= bg fg
-                    retry= sec= {,no}sharecache {,no}resvport lookupcache=
-                    proto= port= {,no}intr {,no}cto  {,nfs}vers= ' -- "$cur"))
+                    _comp_compgen -a -- -W 'soft hard timeo= retrans= {r,w}size=
+                        {,no}ac acreg{min,max}= acdir{min,max}= actimeo= bg fg
+                        retry= sec= {,no}sharecache {,no}resvport lookupcache=
+                        proto= port= {,no}intr {,no}cto {,nfs}vers='
                     ;;&
                 nfs | auto)
-                    COMPREPLY+=($(compgen -W 'udp tcp rdma mount{port,proto,host}=
-                    mountvers= namlen={,no}lock {,no}acl {,no}rdirplus
-                    {,no}fsc' -- "$cur"))
+                    _comp_compgen -a -- -W 'udp tcp rdma mount{port,proto,host}=
+                        mountvers= namlen={,no}lock {,no}acl {,no}rdirplus
+                        {,no}fsc'
                     ;;&
                 nfs4 | auto)
-                    COMPREPLY+=($(compgen -W 'clientaddr= {,no}migration' \
-                        -- "$cur"))
+                    _comp_compgen -a -- -W 'clientaddr= {,no}migration'
                     ;;&
                 ntfs-3g)
-                    COMPREPLY+=($(compgen -W '{u,g}id= {u,f,d}mask= usermapping=
-                    permissions inherit locale= force {,no}recover
-                    ignore_case remove_hiberfile show_sys_files
-                    hide_{hid,dot}_files windows_names allow_other max_read=
-                    silent no_def_opts streams_interface= user_xattr efs_raw
-                    {,no}compression debug no_detach' -- "$cur"))
+                    _comp_compgen -a -- -W '{u,g}id= {u,f,d}mask= usermapping=
+                        permissions inherit locale= force {,no}recover
+                        ignore_case remove_hiberfile show_sys_files
+                        hide_{hid,dot}_files windows_names allow_other
+                        max_read= silent no_def_opts streams_interface=
+                        user_xattr efs_raw {,no}compression debug no_detach'
                     ;;&
                 proc | auto)
                     _comp_compgen -a -- -W '{u,g}id='
                     ;;&
                 reiserfs | auto)
-                    COMPREPLY+=($(compgen -W 'conv hash= {,no_un}hashed_relocation
-                    noborder nolog notail replayonly resize= user_xattr acl
-                    barrier=' -- "$cur"))
+                    _comp_compgen -a -- -W 'conv hash=
+                        {,no_un}hashed_relocation noborder nolog notail
+                        replayonly resize= user_xattr acl barrier='
                     ;;&
                 tmpfs | auto)
-                    COMPREPLY+=($(compgen -W 'size= nr_blocks= nr_inodes= mode=
-                    {u,g}id= mpol=' -- "$cur"))
+                    _comp_compgen -a -- -W 'size= nr_blocks= nr_inodes= mode=
+                      {u,g}id= mpol='
                     ;;&
                 udf | auto)
-                    COMPREPLY+=($(compgen -W '{u,g}id= umask= unhide undelete
-                    nostrict iocharset bs= novrs session= anchor= volume=
-                    partition= lastblock= fileset= rootdir=' -- "$cur"))
+                    _comp_compgen -a -- -W '{u,g}id= umask= unhide undelete
+                        nostrict iocharset bs= novrs session= anchor= volume=
+                        partition= lastblock= fileset= rootdir='
                     ;;&
                 usbfs | auto)
-                    COMPREPLY+=($(compgen -W 'dev{u,g}id= devmode= bus{u,g}id=
-                    busmode= list{u,g}id= listmode=' -- "$cur"))
+                    _comp_compgen -a -- -W 'dev{u,g}id= devmode= bus{u,g}id=
+                        busmode= list{u,g}id= listmode='
                     ;;&
                 xfs | auto)
-                    COMPREPLY+=($(compgen -W 'allocsize= {,no}attr2 barrier dmapi
-                    {,no}grpid {bsd,sysv}groups ihashsize= {,no}ikeep
-                    inode{32,64} {,no}largeio logbufs= logbsize= logdev=
-                    rtdev= mtpt= noalign norecovery nouuid osyncisosync
-                    {u,g,p}qnoenforce {,u,usr,g,grp,p,prj}quota sunit= swidth=
-                    swalloc' -- "$cur"))
+                    _comp_compgen -a -- -W 'allocsize= {,no}attr2 barrier dmapi
+                        {,no}grpid {bsd,sysv}groups ihashsize= {,no}ikeep
+                        inode{32,64} {,no}largeio logbufs= logbsize= logdev=
+                        rtdev= mtpt= noalign norecovery nouuid osyncisosync
+                        {u,g,p}qnoenforce {,u,usr,g,grp,p,prj}quota sunit=
+                        swidth= swalloc'
                     ;;&
             esac
             # COMP_WORDBREAKS is a real pain in the ass
@@ -213,10 +215,10 @@ _comp_cmd_mount()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--version --help --verbose --all --fork
-            --fake --internal-only -l --no-mtab --no-canonicalize --pass-fd -s
+        _comp_compgen -- -W '--version --help --verbose --all --fork --fake
+            --internal-only -l --no-mtab --no-canonicalize --pass-fd -s
             --read-only --rw -L -U --types --test-opts --options --bind --rbind
-            --move' -- "$cur"))
+            --move'
         [[ ${COMPREPLY-} ]] && return
     fi
 

--- a/completions/_nmcli
+++ b/completions/_nmcli
@@ -76,8 +76,8 @@ _comp_cmd_nmcli()
 
     if ((cword == 1)); then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--terse --pretty --mode --fields
-                --escape --version --help' -- "$cur"))
+            _comp_compgen -- -W '--terse --pretty --mode --fields --escape
+                --version --help'
         else
             _comp_compgen -- -W "nm con dev"
         fi
@@ -110,8 +110,8 @@ _comp_cmd_nmcli()
                         ;;
                 esac
 
-                COMPREPLY=($(compgen -W 'status permissions enable sleep
-                    wifi wwan wimax' -- "$cur"))
+                _comp_compgen -- -W 'status permissions enable sleep wifi wwan
+                    wimax'
                 ;;
             con)
                 case $command in
@@ -121,11 +121,9 @@ _comp_cmd_nmcli()
                         ;;
                     up)
                         if [[ $cur == -* ]]; then
-                            COMPREPLY=($(compgen -W '--nowait --timeout' \
-                                -- "$cur"))
+                            _comp_compgen -- -W '--nowait --timeout'
                         else
-                            COMPREPLY=($(compgen -W 'id uuid iface ap nsp' \
-                                -- "$cur"))
+                            _comp_compgen -- -W 'id uuid iface ap nsp'
                         fi
                         return
                         ;;
@@ -139,8 +137,7 @@ _comp_cmd_nmcli()
                         ;;
                 esac
 
-                COMPREPLY=($(compgen -W 'list status up down delete' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'list status up down delete'
                 ;;
             dev)
                 case $command in
@@ -150,8 +147,7 @@ _comp_cmd_nmcli()
                         ;;
                     disconnect)
                         if [[ $cur == -* ]]; then
-                            COMPREPLY=($(compgen -W '--nowait --timeout' \
-                                -- "$cur"))
+                            _comp_compgen -- -W '--nowait --timeout'
                         else
                             _comp_compgen -- -W 'iface'
                         fi
@@ -162,21 +158,19 @@ _comp_cmd_nmcli()
 
                         case $subcommand in
                             list)
-                                COMPREPLY=($(compgen -W 'iface bssid' \
-                                    -- "$cur"))
+                                _comp_compgen -- -W 'iface bssid'
                                 return
                                 ;;
                             connect)
                                 if [[ $cur == -* ]]; then
-                                    COMPREPLY=($(compgen -W '--private
-                                        --nowait --timeout' -- "$cur"))
+                                    _comp_compgen -- -W '--private --nowait
+                                        --timeout'
                                 else
                                     if [[ $prev == "connect" ]]; then
                                         _comp_cmd_nmcli__ap_ssid
                                     else
-                                        COMPREPLY=($(compgen -W 'password
-                                            wep-key-type iface bssid name' \
-                                            -- "$cur"))
+                                        _comp_compgen -- -W 'password
+                                            wep-key-type iface bssid name'
                                     fi
                                 fi
                                 return
@@ -188,8 +182,7 @@ _comp_cmd_nmcli()
                         ;;
                 esac
 
-                COMPREPLY=($(compgen -W 'status list disconnect wifi' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'status list disconnect wifi'
                 ;;
         esac
 

--- a/completions/_rfkill
+++ b/completions/_rfkill
@@ -13,8 +13,7 @@ _comp_cmd_rfkill()
     else
         case $cword in
             1)
-                COMPREPLY=($(compgen -W "help event list block unblock" \
-                    -- "$cur"))
+                _comp_compgen -- -W "help event list block unblock"
                 ;;
             2)
                 if [[ $prev == block || $prev == unblock ]]; then

--- a/completions/_slackpkg
+++ b/completions/_slackpkg
@@ -37,10 +37,10 @@ _comp_cmd_slackpkg()
 
     if [[ $cur == -* ]]; then
         compopt -o nospace
-        COMPREPLY=($(compgen -W '-delall= -checkmd5= -checkgpg=
-            -checksize= -postinst= -onoff= -download_all= -dialog=
-            -dialog_maxargs= -batch= -only_new_dotnew= -use_includes=
-            -spinning= -default_answer= -mirror=' -- "$cur"))
+        _comp_compgen -- -W '-delall= -checkmd5= -checkgpg= -checksize=
+            -postinst= -onoff= -download_all= -dialog= -dialog_maxargs= -batch=
+            -only_new_dotnew= -use_includes= -spinning= -default_answer=
+            -mirror='
         return
     fi
 
@@ -75,8 +75,8 @@ _comp_cmd_slackpkg()
             ;;
         remove)
             _comp_compgen_filedir
-            COMPREPLY+=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
-                xap xfce y' -- "$cur"))
+            _comp_compgen -a -- -W 'a ap d e f k kde kdei l n t tcl x xap xfce
+                y'
             COMPREPLY+=($(
                 command cd /var/log/packages
                 compgen -f -- "$cur"
@@ -85,8 +85,8 @@ _comp_cmd_slackpkg()
             ;;
         install | reinstall | upgrade | blacklist | download)
             _comp_compgen_filedir
-            COMPREPLY+=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
-                xap xfce y' -- "$cur"))
+            _comp_compgen -a -- -W 'a ap d e f k kde kdei l n t tcl x xap xfce
+                y'
             COMPREPLY+=($(cut -f 6 -d\  "${WORKDIR}/pkglist" 2>/dev/null |
                 command grep "^$cur"))
             return
@@ -101,11 +101,10 @@ _comp_cmd_slackpkg()
             _comp_compgen -- -W 'gpg'
             ;&
         *)
-            COMPREPLY+=($(compgen -W 'install reinstall upgrade remove
-                blacklist download update install-new upgrade-all
-                clean-system new-config check-updates help generate-template
-                install-template remove-template search file-search info' -- \
-                "$cur"))
+            _comp_compgen -a -- -W 'install reinstall upgrade remove blacklist
+                download update install-new upgrade-all clean-system new-config
+                check-updates help generate-template install-template
+                remove-template search file-search info'
             return
             ;;
     esac

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -29,8 +29,7 @@ _comp_cmd_udevadm()
             return
             ;;
         --query)
-            COMPREPLY=($(compgen -W 'name symlink path property all' \
-                -- "$cur"))
+            _comp_compgen -- -W 'name symlink path property all'
             return
             ;;
         --name)

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -105,11 +105,11 @@ _comp_cmd_umount()
                 cur="${cur##*,}"
                 split=set
             fi
-            COMPREPLY=($(compgen -W 'adfs affs autofs btrfs cifs coda
-                cramfs debugfs devpts efs ext2 ext3 ext4 fuse hfs hfsplus hpfs
-                iso9660 jfs minix msdos ncpfs nfs nfs4 ntfs ntfs-3g proc qnx4
-                ramfs reiserfs romfs squashfs smbfs sysv tmpfs ubifs udf ufs
-                umsdos usbfs vfat xfs' -- "$cur"))
+            _comp_compgen -- -W 'adfs affs autofs btrfs cifs coda cramfs
+                debugfs devpts efs ext2 ext3 ext4 fuse hfs hfsplus hpfs iso9660
+                jfs minix msdos ncpfs nfs nfs4 ntfs ntfs-3g proc qnx4 ramfs
+                reiserfs romfs squashfs smbfs sysv tmpfs ubifs udf ufs umsdos
+                usbfs vfat xfs'
             _fstypes
             [[ $split ]] && COMPREPLY=(${COMPREPLY[@]/#/$prev,})
             return
@@ -121,8 +121,8 @@ _comp_cmd_umount()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-V -h -v -n -r -d -i -a -t -O -f -l
-            --no-canonicalize --fake' -- "$cur"))
+        _comp_compgen -- -W '-V -h -v -n -r -d -i -a -t -O -f -l
+            --no-canonicalize --fake'
         [[ ${COMPREPLY-} ]] && return
     fi
 

--- a/completions/_xm
+++ b/completions/_xm
@@ -159,8 +159,8 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         *)
-                            COMPREPLY=($(compgen -W "script= ip= mac= bridge=
-                                backend=" -- "$cur"))
+                            _comp_compgen -- -W "script= ip= mac= bridge=
+                                backend="
                             ;;
                     esac
                     ;;

--- a/completions/_yum
+++ b/completions/_yum
@@ -82,12 +82,11 @@ _comp_cmd_yum()
 
     case $prev in
         list)
-            COMPREPLY=($(compgen -W 'all available updates installed extras
-                obsoletes recent' -- "$cur"))
+            _comp_compgen -- -W 'all available updates installed extras
+                obsoletes recent'
             ;;
         clean)
-            COMPREPLY=($(compgen -W 'packages headers metadata cache dbcache
-                all' -- "$cur"))
+            _comp_compgen -- -W 'packages headers metadata cache dbcache all'
             ;;
         repolist)
             _comp_compgen -- -W 'all enabled disabled'
@@ -130,11 +129,11 @@ _comp_cmd_yum()
             return
             ;;
         *)
-            COMPREPLY=($(compgen -W 'install update check-update upgrade
-                remove erase list info provides whatprovides clean makecache
-                groupinstall groupupdate grouplist groupremove groupinfo
-                search shell resolvedep localinstall localupdate deplist
-                repolist help' -- "$cur"))
+            _comp_compgen -- -W 'install update check-update upgrade remove
+                erase list info provides whatprovides clean makecache
+                groupinstall groupupdate grouplist groupremove groupinfo search
+                shell resolvedep localinstall localupdate deplist repolist
+                help'
             ;;
     esac
 

--- a/completions/aclocal
+++ b/completions/aclocal
@@ -19,8 +19,8 @@ _comp_cmd_aclocal()
             ;;
         --warnings | -W)
             local cats=(syntax unsupported)
-            COMPREPLY=($(compgen -W \
-                '"${cats[@]}" "${cats[@]/#/no-}" all none error' -- "$cur"))
+            _comp_compgen -- -W '"${cats[@]}" "${cats[@]/#/no-}" all none
+                error'
             return
             ;;
     esac

--- a/completions/add_members
+++ b/completions/add_members
@@ -19,8 +19,8 @@ _comp_cmd_add_members()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--regular-members-file --digest-members-file
-            --welcome-msg --admin-notify --help' -- "$cur"))
+        _comp_compgen -- -W '--regular-members-file --digest-members-file
+            --welcome-msg --admin-notify --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/apt-build
+++ b/completions/apt-build
@@ -36,15 +36,14 @@ _comp_cmd_apt_build()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--help --show-upgraded -u --build-dir
+        _comp_compgen -- -W '--help --show-upgraded -u --build-dir
             --repository-dir --build-only --build-command --reinstall --rebuild
             --remove-builddep --no-wrapper --purge --patch --patch-strip -p
-            --yes -y --version -v --no-source' -- "$cur"))
+            --yes -y --version -v --no-source'
 
     else
-        COMPREPLY=($(compgen -W 'update upgrade install remove source
-            dist-upgrade world clean info clean-build update-repository' \
-            -- "$cur"))
+        _comp_compgen -- -W 'update upgrade install remove source dist-upgrade
+            world clean info clean-build update-repository'
     fi
 
 } &&

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -71,9 +71,7 @@ _comp_cmd_apt_cache()
             ;;
         --with-source)
             _comp_compgen_filedir '@(deb|dsc|changes)'
-            COMPREPLY+=($(
-                compgen -f -o plusdirs -X '!?(*/)@(Sources|Packages)' -- "$cur"
-            ))
+            _comp_compgen -a -- -f -o plusdirs -X '!?(*/)@(Sources|Packages)'
             return
             ;;
         search)
@@ -84,16 +82,16 @@ _comp_cmd_apt_cache()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--pkg-cache --src-cache --quiet --important
+        _comp_compgen -- -W '--pkg-cache --src-cache --quiet --important
             --no-pre-depends --no-depends --no-recommends --no-suggests
             --no-conflicts --no-breaks --no-replaces --no-enhances --implicit
             --full --all-versions --no-all-versions --generate --no-generate
-            --names-only --all-names --recurse --installed --with-source --help
-            --version --config-file --option' -- "$cur"))
+            --names-only --all-names --recurse --installed --with-source
+            --help --version --config-file --option'
     elif [[ ! $special ]]; then
-        COMPREPLY=($(compgen -W 'gencaches showpkg stats showsrc dump
-            dumpavail unmet show search depends rdepends pkgnames dotty xvcg
-            policy madison' -- "$cur"))
+        _comp_compgen -- -W 'gencaches showpkg stats showsrc dump dumpavail
+            unmet show search depends rdepends pkgnames dotty xvcg policy
+            madison'
     fi
 
 } &&

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -85,7 +85,7 @@ _comp_cmd_apt_get()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--no-install-recommends --install-suggests
+        _comp_compgen -- -W '--no-install-recommends --install-suggests
             --download-only --fix-broken --ignore-missing --fix-missing
             --no-download --quiet --simulate --just-print --dry-run --recon
             --no-act --yes --assume-yes --assume-no --no-show-upgraded
@@ -98,12 +98,11 @@ _comp_cmd_apt_get()
             --diff-only --dsc-only --tar-only --arch-only --indep-only
             --allow-unauthenticated --no-allow-insecure-repositories
             --allow-releaseinfo-change --show-progress --with-source --error-on
-            --help --version --config-file --option' -- "$cur"))
+            --help --version --config-file --option'
     else
-        COMPREPLY=($(compgen -W 'update upgrade dist-upgrade
-            dselect-upgrade install reinstall remove purge source build-dep
-            satisfy check download clean autoclean autoremove changelog
-            indextargets' -- "$cur"))
+        _comp_compgen -- -W 'update upgrade dist-upgrade dselect-upgrade
+            install reinstall remove purge source build-dep satisfy check
+            download clean autoclean autoremove changelog indextargets'
     fi
 
 } &&

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -52,13 +52,12 @@ _comp_cmd_apt_mark()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--file= --help --version --config-file
-            --option' -- "$cur"))
+        _comp_compgen -- -W '--file= --help --version --config-file --option'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W 'auto manual minimize-manual showauto
-            showmanual hold unhold showhold install remove purge
-            showinstall showremove showpurge' -- "$cur"))
+        _comp_compgen -- -W 'auto manual minimize-manual showauto showmanual
+            hold unhold showhold install remove purge showinstall showremove
+            showpurge'
     fi
 
 } &&

--- a/completions/aptitude
+++ b/completions/aptitude
@@ -47,8 +47,8 @@ _comp_cmd_aptitude()
             return
             ;;
         --sort | -${noargopts}O)
-            COMPREPLY=($(compgen -W 'installsize installsizechange debsize
-                name priority version' -- "$cur"))
+            _comp_compgen -- -W 'installsize installsizechange debsize name
+                priority version'
             return
             ;;
         --target-release | --default-release | -${noargopts}t)
@@ -95,11 +95,11 @@ _comp_cmd_aptitude()
         ((${#COMPREPLY[@]})) &&
             _comp_compgen -- -W '"${COMPREPLY[@]}"'
     else
-        COMPREPLY=($(compgen -W 'update upgrade safe-upgrade forget-new
-            clean autoclean install reinstall remove hold unhold purge markauto
+        _comp_compgen -- -W 'update upgrade safe-upgrade forget-new clean
+            autoclean install reinstall remove hold unhold purge markauto
             unmarkauto why why-not dist-upgrade full-upgrade download search
             show forbid-version changelog keep keep-all build-dep add-user-tag
-            remove-user-tag versions' -- "$cur"))
+            remove-user-tag versions'
     fi
 
 } &&

--- a/completions/arp
+++ b/completions/arp
@@ -22,8 +22,8 @@ _comp_cmd_arp()
             ;;
         --hw-type | -${noargopts}[Ht])
             # TODO: parse from --help output?
-            COMPREPLY=($(compgen -W 'ash ether ax25 netrom rose arcnet \
-                dlci fddi hippi irda x25 eui64' -- "$cur"))
+            _comp_compgen -- -W 'ash ether ax25 netrom rose arcnet dlci fddi
+                hippi irda x25 eui64'
             return
             ;;
     esac

--- a/completions/aspell
+++ b/completions/aspell
@@ -40,8 +40,7 @@ _comp_cmd_aspell()
             return
             ;;
         --sug-mode)
-            COMPREPLY=($(compgen -W 'ultra fast normal bad-speller' \
-                -- "$cur"))
+            _comp_compgen -- -W 'ultra fast normal bad-speller'
             return
             ;;
         --keymapping)
@@ -62,7 +61,7 @@ _comp_cmd_aspell()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--conf= --conf-dir= --data-dir= --dict-dir=
+        _comp_compgen -- -W '--conf= --conf-dir= --data-dir= --dict-dir=
             --encoding= --add-filter= --rem-filter= --mode= --add-extra-dicts=
             --rem-extra-dicts= --home-dir= --ignore= --ignore-accents
             --dont-ignore-accents --ignore-case --dont-ignore-case
@@ -79,11 +78,11 @@ _comp_cmd_aspell()
             --add-tex-command= --rem-tex-command= --tex-check-comments
             --dont-tex-check-comments --add-tex-extension --rem-tex-extension
             --add-sgml-check= --rem-sgml-check= --add-sgml-extension
-            --rem-sgml-extension' -- "$cur"))
+            --rem-sgml-extension'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W 'usage help check pipe list config soundslike
-            filter version dump create merge' -- "$cur"))
+        _comp_compgen -- -W 'usage help check pipe list config soundslike
+            filter version dump create merge'
     fi
 } &&
     complete -F _comp_cmd_aspell aspell

--- a/completions/autoconf
+++ b/completions/autoconf
@@ -15,8 +15,8 @@ _comp_cmd_autoconf()
             ;;
         --warnings | -W)
             local cats=(cross obsolete syntax)
-            COMPREPLY=($(compgen -W \
-                '"${cats[@]}" "${cats[@]/#/no-}" all none error' -- "$cur"))
+            _comp_compgen -- -W '"${cats[@]}" "${cats[@]/#/no-}" all none
+                error'
             return
             ;;
         --prepend-include | -B | --include | -I)

--- a/completions/automake
+++ b/completions/automake
@@ -11,8 +11,8 @@ _comp_cmd_automake()
             ;;
         --warnings | -W)
             local cats=(gnu obsolete override portability syntax unsupported)
-            COMPREPLY=($(compgen -W \
-                '"${cats[@]}" "${cats[@]/#/no-}" all none error' -- "$cur"))
+            _comp_compgen -- -W '"${cats[@]}" "${cats[@]/#/no-}" all none
+                error'
             return
             ;;
         --libdir)

--- a/completions/autoreconf
+++ b/completions/autoreconf
@@ -12,8 +12,8 @@ _comp_cmd_autoreconf()
         --warnings | -W)
             local cats=(cross gnu obsolete override portability syntax
                 unsupported)
-            COMPREPLY=($(compgen -W \
-                '"${cats[@]}" "${cats[@]/#/no-}" all none error' -- "$cur"))
+            _comp_compgen -- -W '"${cats[@]}" "${cats[@]/#/no-}" all none
+                error'
             return
             ;;
         --prepend-include | -B | --include | -I)

--- a/completions/autorpm
+++ b/completions/autorpm
@@ -5,8 +5,8 @@ _comp_cmd_autorpm()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W '--notty --debug --help --version auto add
-        fullinfo info help install list remove set' -- "$cur"))
+    _comp_compgen -- -W '--notty --debug --help --version auto add fullinfo
+        info help install list remove set'
 
 } &&
     complete -F _comp_cmd_autorpm autorpm

--- a/completions/bind
+++ b/completions/bind
@@ -10,8 +10,8 @@ _comp_cmd_bind()
             return
             ;;
         -*m)
-            COMPREPLY=($(compgen -W "emacs emacs-standard emacs-meta
-                emacs-ctlx vi vi-move vi-command vi-insert" -- "$cur"))
+            _comp_compgen -- -W "emacs emacs-standard emacs-meta emacs-ctlx vi
+                vi-move vi-command vi-insert"
             return
             ;;
         -*f)

--- a/completions/brctl
+++ b/completions/brctl
@@ -9,9 +9,9 @@ _comp_cmd_brctl()
 
     case $cword in
         1)
-            COMPREPLY=($(compgen -W "addbr delbr addif delif setageing
+            _comp_compgen -- -W "addbr delbr addif delif setageing
                 setbridgeprio setfd sethello setmaxage setpathcost setportprio
-                show showmacs showstp stp" -- "$cur"))
+                show showmacs showstp stp"
             ;;
         2)
             case $command in

--- a/completions/btdownloadheadless.py
+++ b/completions/btdownloadheadless.py
@@ -13,15 +13,14 @@ _comp_cmd_btdownload()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--max_uploads --keepalive_interval
+        _comp_compgen -- -W '--max_uploads --keepalive_interval
             --download_slice_size --request_backlog --max_message_length
             --ip --minport --maxport --responsefile --url --saveas --timeout
             --timeout_check_interval --max_slice_length --max_rate_period
             --bind --upload_rate_fudge --display_interval --rerequest_interval
             --min_peers --http_timeout --max_initiate --max_allow_in
             --check_hashes --max_upload_rate --snub_time --spew
-            --rarest_first_cutoff --min_uploads --report_hash_failures' \
-            -- "$cur"))
+            --rarest_first_cutoff --min_uploads --report_hash_failures'
     else
         _comp_compgen_filedir
     fi

--- a/completions/bts
+++ b/completions/bts
@@ -32,9 +32,9 @@ _comp_cmd_bts()
             return
             ;;
         select)
-            COMPREPLY=($(compgen -W 'package: source: maintainer: submitter:
+            _comp_compgen -- -W 'package: source: maintainer: submitter:
                 severity: status: tag: owner: correspondent: affects: bugs:
-                users:  archive:' -- "$cur"))
+                users:  archive:'
             return
             ;;
         status)
@@ -47,13 +47,13 @@ _comp_cmd_bts()
             return
             ;;
         severity)
-            COMPREPLY=($(compgen -W 'wishlist minor normal important serious
-                grave critical' -- "$cur"))
+            _comp_compgen -- -W 'wishlist minor normal important serious grave
+                critical'
             return
             ;;
         limit)
-            COMPREPLY=($(compgen -W 'submitter date subject msgid package
-                source tag severity owner affects archive' -- "$cur"))
+            _comp_compgen -- -W 'submitter date subject msgid package source
+                tag severity owner affects archive'
             return
             ;;
         clone | "done" | reopen | archive | unarchive | retitle | summary | submitter | found | notfound | fixed | notfixed | merge | forcemerge | unmerge | claim | unclaim | forwarded | notforwarded | owner | noowner | subscribe | unsubscribe | reportspam | spamreport | affects | usertag | usertags | reassign | tag | tags)
@@ -94,20 +94,19 @@ _comp_cmd_bts()
 
     [[ $was_split ]] && return
 
-    COMPREPLY=($(compgen -W '--offline --online --no-offline
-        --no-action --cache --no-cache --cache-mode --cache-delay --mbox
-        --mailreader --cc-addr --use-default-cc --no-use-default-cc
-        --sendmail --mutt --no-mutt --smtp-host --smtp-username
-        --smtp-helo --bts-server --force-refresh --no-force-refresh
-        --only-new --include-resolved --no-include-resolved --no-ack --ack
-        --interactive --force-interactive --no-interactive --quiet
-        --no-conf --noconf
+    _comp_compgen -- -W '--offline --online --no-offline --no-action --cache
+        --no-cache --cache-mode --cache-delay --mbox --mailreader --cc-addr
+        --use-default-cc --no-use-default-cc --sendmail --mutt --no-mutt
+        --smtp-host --smtp-username --smtp-helo --bts-server --force-refresh
+        --no-force-refresh --only-new --include-resolved --no-include-resolved
+        --no-ack --ack --interactive --force-interactive --no-interactive
+        --quiet --no-conf --noconf
         show bugs select status clone done reopen archive unarchive retitle
         summary submitter reassign found notfound fixed notfixed block unblock
         merge forcemerge unmerge tag tags affects user usertag usertags claim
         unclaim severity forwarded notforwarded package limit owner noowner
         subscribe unsubscribe reportspam spamreport cache cleancache version
-        help' -- "$cur"))
+        help'
 
 } &&
     complete -F _comp_cmd_bts bts

--- a/completions/cardctl
+++ b/completions/cardctl
@@ -6,8 +6,8 @@ _comp_cmd_cardctl()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'status config ident suspend resume reset
-            eject insert scheme' -- "$cur"))
+        _comp_compgen -- -W 'status config ident suspend resume reset eject
+            insert scheme'
     fi
 } &&
     complete -F _comp_cmd_cardctl cardctl pccardctl

--- a/completions/change_pw
+++ b/completions/change_pw
@@ -15,8 +15,8 @@ _comp_cmd_change_pw()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--all --domain --listname --password --quiet
-            --help' -- "$cur"))
+        _comp_compgen -- -W '--all --domain --listname --password --quiet
+            --help'
     fi
 
 } &&

--- a/completions/chgrp
+++ b/completions/chgrp
@@ -20,9 +20,9 @@ _comp_cmd_chgrp()
         for w in "${words[@]}"; do
             [[ $w == -@(R|-recursive) ]] && opts="-H -L -P" && break
         done
-        COMPREPLY=($(compgen -W '-c -h -f -R -v --changes --dereference
+        _comp_compgen -- -W '-c -h -f -R -v --changes --dereference
             --no-dereference --silent --quiet --reference --recursive --verbose
-            --help --version $opts' -- "$cur"))
+            --help --version $opts'
         return
     fi
 

--- a/completions/chkconfig
+++ b/completions/chkconfig
@@ -20,12 +20,10 @@ _comp_cmd_chkconfig()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--list --add --del --override --level' \
-            -- "$cur"))
+        _comp_compgen -- -W '--list --add --del --override --level'
     else
         if ((cword == 2 || cword == 4)); then
-            COMPREPLY=($(compgen -W 'on off reset resetpriorities' \
-                -- "$cur"))
+            _comp_compgen -- -W 'on off reset resetpriorities'
         else
             _services
             _xinetd_services

--- a/completions/chown
+++ b/completions/chown
@@ -25,9 +25,9 @@ _comp_cmd_chown()
         for w in "${words[@]}"; do
             [[ $w == -@(R|-recursive) ]] && opts="-H -L -P" && break
         done
-        COMPREPLY=($(compgen -W '-c -h -f -R -v --changes --dereference
+        _comp_compgen -- -W '-c -h -f -R -v --changes --dereference
             --no-dereference --from --silent --quiet --reference --recursive
-            --verbose --help --version $opts' -- "$cur"))
+            --verbose --help --version $opts'
     else
         local args
 

--- a/completions/chpasswd
+++ b/completions/chpasswd
@@ -9,8 +9,7 @@ _comp_cmd_chpasswd()
     # shellcheck disable=SC2254
     case $prev in
         --crypt | -${noargopts}c)
-            COMPREPLY=($(compgen -W 'DES MD5 NONE SHA256 SHA512' \
-                -- "$cur"))
+            _comp_compgen -- -W 'DES MD5 NONE SHA256 SHA512'
             return
             ;;
         --sha-rounds | -${noargopts}s)

--- a/completions/cleanarch
+++ b/completions/cleanarch
@@ -6,8 +6,7 @@ _comp_cmd_cleanarch()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--status --dry-run --quiet --help' \
-            -- "$cur"))
+        _comp_compgen -- -W '--status --dry-run --quiet --help'
     fi
 
 } &&

--- a/completions/clisp
+++ b/completions/clisp
@@ -9,9 +9,9 @@ _comp_cmd_clisp()
 
     # completing an option (may or may not be separated by a space)
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-h --help --version --license -B -K -M -m -L
-            -N -E -q --quiet --silent -w -I -ansi -traditional -p -C -norc -i
-            -c -l -o -x ' -- "$cur"))
+        _comp_compgen -- -W '-h --help --version --license -B -K -M -m -L -N -E
+            -q --quiet --silent -w -I -ansi -traditional -p -C -norc -i -c -l
+            -o -x '
     else
         _comp_compgen_filedir
     fi

--- a/completions/clone_member
+++ b/completions/clone_member
@@ -15,8 +15,8 @@ _comp_cmd_clone_member()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--listname --remove --admin --quiet
-            --nomodify --help' -- "$cur"))
+        _comp_compgen -- -W '--listname --remove --admin --quiet --nomodify
+            --help'
     fi
 
 } &&

--- a/completions/complete
+++ b/completions/complete
@@ -7,16 +7,16 @@ _comp_cmd_complete()
 
     case $prev in
         -*o)
-            COMPREPLY=($(compgen -W 'bashdefault default dirnames filenames
-                nospace plusdirs' -- "$cur"))
+            _comp_compgen -- -W 'bashdefault default dirnames filenames nospace
+                plusdirs'
             return
             ;;
 
         -*A)
-            COMPREPLY=($(compgen -W 'alias arrayvar binding builtin command
+            _comp_compgen -- -W 'alias arrayvar binding builtin command
                 directory disabled enabled export file function group helptopic
                 hostname job keyword running service setopt shopt signal
-                stopped user variable' -- "$cur"))
+                stopped user variable'
             return
             ;;
 

--- a/completions/convert
+++ b/completions/convert
@@ -4,8 +4,8 @@ _comp_cmd_convert__common_options()
 {
     case $prev in
         -channel)
-            COMPREPLY=($(compgen -W 'Red Green Blue Opacity Matte Cyan
-                Magenta Yellow Black' -- "$cur"))
+            _comp_compgen -- -W 'Red Green Blue Opacity Matte Cyan Magenta
+                Yellow Black'
             return
             ;;
         -colormap)
@@ -13,30 +13,29 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -colorspace)
-            COMPREPLY=($(compgen -W 'GRAY OHTA RGB Transparent XYZ YCbCr YIQ
-                YPbPr YUV CMYK' -- "$cur"))
+            _comp_compgen -- -W 'GRAY OHTA RGB Transparent XYZ YCbCr YIQ YPbPr
+                YUV CMYK'
             return
             ;;
         -compose)
-            COMPREPLY=($(compgen -W 'Over In Out Atop Xor Plus Minus Add
-                Subtract Difference Multiply Bumpmap Copy CopyRed CopyGreen
-                CopyBlue CopyOpacity' -- "$cur"))
+            _comp_compgen -- -W 'Over In Out Atop Xor Plus Minus Add Subtract
+                Difference Multiply Bumpmap Copy CopyRed CopyGreen CopyBlue
+                CopyOpacity'
             return
             ;;
         -compress)
-            COMPREPLY=($(compgen -W 'None BZip Fax Group4 JPEG Lossless LZW
-                RLE Zip' -- "$cur"))
+            _comp_compgen -- -W 'None BZip Fax Group4 JPEG Lossless LZW RLE
+                Zip'
             return
             ;;
         -dispose)
-            COMPREPLY=($(compgen -W 'Undefined None Background Previous' \
-                -- "$cur"))
+            _comp_compgen -- -W 'Undefined None Background Previous'
             return
             ;;
         -encoding)
-            COMPREPLY=($(compgen -W 'AdobeCustom AdobeExpert AdobeStandard
+            _comp_compgen -- -W 'AdobeCustom AdobeExpert AdobeStandard
                 AppleRoman BIG5 GB2312 Latin2 None SJIScode Symbol Unicode
-                Wansung' -- "$cur"))
+                Wansung'
             return
             ;;
         -endian)
@@ -44,9 +43,9 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -filter)
-            COMPREPLY=($(compgen -W 'Point Box Triangle Hermite Hanning
-                Hamming Blackman Gaussian Quadratic Cubic Catrom Mitchell
-                Lanczos Bessel Sinc' -- "$cur"))
+            _comp_compgen -- -W 'Point Box Triangle Hermite Hanning Hamming
+                Blackman Gaussian Quadratic Cubic Catrom Mitchell Lanczos
+                Bessel Sinc'
             return
             ;;
         -format)
@@ -56,13 +55,12 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -gravity)
-            COMPREPLY=($(compgen -W 'Northwest North NorthEast West Center
-                East SouthWest South SouthEast' -- "$cur"))
+            _comp_compgen -- -W 'Northwest North NorthEast West Center East
+                SouthWest South SouthEast'
             return
             ;;
         -intent)
-            COMPREPLY=($(compgen -W 'Absolute Perceptual Relative
-                Saturation' -- "$cur"))
+            _comp_compgen -- -W 'Absolute Perceptual Relative Saturation'
             return
             ;;
         -interlace)
@@ -74,27 +72,25 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -list)
-            COMPREPLY=($(compgen -W 'Delegate Format Magic Module Resource
-                Type' -- "$cur"))
+            _comp_compgen -- -W 'Delegate Format Magic Module Resource Type'
             return
             ;;
         -map)
-            COMPREPLY=($(compgen -W 'best default gray red green blue' \
-                -- "$cur"))
+            _comp_compgen -- -W 'best default gray red green blue'
             _comp_compgen -a filedir
             return
             ;;
         -noise)
-            COMPREPLY=($(compgen -W 'Uniform Gaussian Multiplicative
-                Impulse Laplacian Poisson' -- "$cur"))
+            _comp_compgen -- -W 'Uniform Gaussian Multiplicative Impulse
+                Laplacian Poisson'
             return
             ;;
         -preview)
-            COMPREPLY=($(compgen -W 'Rotate Shear Roll Hue Saturation
-                Brightness Gamma Spiff Dull Grayscale Quantize Despeckle
-                ReduceNoise AddNoise Sharpen Blur Threshold EdgeDetect Spread
-                Shade Raise Segment Solarize Swirl Implode Wave OilPaint
-                CharcoalDrawing JPEG' -- "$cur"))
+            _comp_compgen -- -W 'Rotate Shear Roll Hue Saturation Brightness
+                Gamma Spiff Dull Grayscale Quantize Despeckle ReduceNoise
+                AddNoise Sharpen Blur Threshold EdgeDetect Spread Shade Raise
+                Segment Solarize Swirl Implode Wave OilPaint CharcoalDrawing
+                JPEG'
             return
             ;;
         -mask | -profile | -texture | -tile | -write)
@@ -102,14 +98,13 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -type)
-            COMPREPLY=($(compgen -W 'Bilevel Grayscale Palette PaletteMatte
+            _comp_compgen -- -W 'Bilevel Grayscale Palette PaletteMatte
                 TrueColor TrueColorMatte ColorSeparation ColorSeparationlMatte
-                Optimize' -- "$cur"))
+                Optimize'
             return
             ;;
         -units)
-            COMPREPLY=($(compgen -W 'Undefined PixelsPerInch
-                PixelsPerCentimeter' -- "$cur"))
+            _comp_compgen -- -W 'Undefined PixelsPerInch PixelsPerCentimeter'
             return
             ;;
         -virtual-pixel)
@@ -117,9 +112,8 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -visual)
-            COMPREPLY=($(compgen -W 'StaticGray GrayScale StaticColor
-                PseudoColor TrueColor DirectColor default visualid' \
-                -- "$cur"))
+            _comp_compgen -- -W 'StaticGray GrayScale StaticColor PseudoColor
+                TrueColor DirectColor default visualid'
             return
             ;;
     esac
@@ -137,9 +131,9 @@ _comp_cmd_convert()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+adjoin +append +compress +contrast +debug
-            +dither +endian +gamma +label +map +mask +matte +negate +noise
-            +page +raise +render +write' -- "$cur"))
+        _comp_compgen -- -W '+adjoin +append +compress +contrast +debug +dither
+            +endian +gamma +label +map +mask +matte +negate +noise +page +raise
+            +render +write'
     else
         _comp_compgen_filedir
     fi
@@ -156,8 +150,8 @@ _comp_cmd_mogrify()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
-            +gamma +label +map +mask +matte +negate +page +raise' -- "$cur"))
+        _comp_compgen -- -W '+compress +contrast +debug +dither +endian +gamma
+            +label +map +mask +matte +negate +page +raise'
     else
         _comp_compgen_filedir
     fi
@@ -174,8 +168,8 @@ _comp_cmd_display()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+compress +contrast +debug +dither +endian
-            +gamma +label +map +matte +negate +page +raise +write' -- "$cur"))
+        _comp_compgen -- -W '+compress +contrast +debug +dither +endian +gamma
+            +label +map +matte +negate +page +raise +write'
     else
         _comp_compgen_filedir
     fi
@@ -192,8 +186,7 @@ _comp_cmd_animate()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+debug +dither +gamma +map +matte' \
-            -- "$cur"))
+        _comp_compgen -- -W '+debug +dither +gamma +map +matte'
     else
         _comp_compgen_filedir
     fi
@@ -227,8 +220,8 @@ _comp_cmd_montage()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+adjoin +compress +debug +dither +endian
-            +gamma +label +matte +page' -- "$cur"))
+        _comp_compgen -- -W '+adjoin +compress +debug +dither +endian +gamma
+            +label +matte +page'
     else
         _comp_compgen_filedir
     fi
@@ -245,8 +238,8 @@ _comp_cmd_composite()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -help
     elif [[ $cur == +* ]]; then
-        COMPREPLY=($(compgen -W '+compress +debug +dither +endian +label
-            +matte +negate +page +write' -- "$cur"))
+        _comp_compgen -- -W '+compress +debug +dither +endian +label +matte
+            +negate +page +write'
     else
         _comp_compgen_filedir
     fi

--- a/completions/cowsay
+++ b/completions/cowsay
@@ -14,8 +14,7 @@ _comp_cmd_cowsay()
     esac
 
     # relevant options completion
-    COMPREPLY=($(compgen -W '-b -d -g -p -s -t -w -y -e -f -h -l -n -T -W' \
-        -- "$cur"))
+    _comp_compgen -- -W '-b -d -g -p -s -t -w -y -e -f -h -l -n -T -W'
 
 } &&
     complete -F _comp_cmd_cowsay -o default cowsay cowthink

--- a/completions/cpio
+++ b/completions/cpio
@@ -10,8 +10,7 @@ _comp_cmd_cpio()
     # shellcheck disable=SC2254
     case $prev in
         --format | -${noargopts}H)
-            COMPREPLY=($(compgen -W \
-                'bin odc newc crc tar ustar hpbin hpodc' -- "$cur"))
+            _comp_compgen -- -W 'bin odc newc crc tar ustar hpbin hpodc'
             return
             ;;
         --file | --pattern-file | -${noargopts}[EFI])
@@ -38,36 +37,33 @@ _comp_cmd_cpio()
         case ${words[1]} in
             -o | --create)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '-0 -a -c -v -A -B -L -V -C -H -M
-                        -O -F --file --format --message --null
-                        --reset-access-time --verbose --dot --append
-                        --block-size --dereference --io-size --quiet
-                        --force-local --rsh-command --help --version' \
-                        -- "$cur"))
+                    _comp_compgen -- -W '-0 -a -c -v -A -B -L -V -C -H -M -O -F
+                        --file --format --message --null --reset-access-time
+                        --verbose --dot --append --block-size --dereference
+                        --io-size --quiet --force-local --rsh-command --help
+                        --version'
                 fi
                 ;;
             -i | --extract)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '-b -c -d -f -m -n -r -t -s -u -v
-                        -B -S -V -C -E -H -M -R -I -F --file --make-directories
+                    _comp_compgen -- -W '-b -c -d -f -m -n -r -t -s -u -v -B -S
+                        -V -C -E -H -M -R -I -F --file --make-directories
                         --nonmatching --preserve-modification-time
                         --numeric-uid-gid --rename --list --swap-bytes --swap
                         --dot --unconditional --verbose --block-size
                         --swap-halfwords --io-size --pattern-file --format
                         --owner --no-preserve-owner --message --force-local
                         --no-absolute-filenames --sparse --only-verify-crc
-                        --quiet --rsh-command --help --to-stdout --version' \
-                        -- "$cur"))
+                        --quiet --rsh-command --help --to-stdout --version'
                 fi
                 ;;
             -p* | --pass-through)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '-0 -a -d -l -m -u -v -L -V -R
-                        --null --reset-access-time --make-directories --link
-                        --quiet --preserve-modification-time --unconditional
-                        --verbose --dot --dereference --owner
-                        --no-preserve-owner --sparse --help --version' \
-                        -- "$cur"))
+                    _comp_compgen -- -W '-0 -a -d -l -m -u -v -L -V -R --null
+                        --reset-access-time --make-directories --link --quiet
+                        --preserve-modification-time --unconditional --verbose
+                        --dot --dereference --owner --no-preserve-owner
+                        --sparse --help --version'
                 else
                     _comp_compgen_filedir -d
                 fi

--- a/completions/cppcheck
+++ b/completions/cppcheck
@@ -23,9 +23,8 @@ _comp_cmd_cppcheck()
                 cur="${cur##*,}"
                 split="set"
             fi
-            COMPREPLY=($(compgen -W 'all warning style performance
-                portability information unusedFunction missingInclude' \
-                -- "$cur"))
+            _comp_compgen -- -W 'all warning style performance portability
+                information unusedFunction missingInclude'
             [[ $split ]] && COMPREPLY=(${COMPREPLY[@]/#/"$prev,"})
             return
             ;;
@@ -51,14 +50,12 @@ _comp_cmd_cppcheck()
             return
             ;;
         --std)
-            COMPREPLY=($(compgen -W 'c89 c99 c11 c++03 c++11 c++14 c++17
-                c++20' -- "$cur"))
+            _comp_compgen -- -W 'c89 c99 c11 c++03 c++11 c++14 c++17 c++20'
             return
             ;;
         --platform)
             _comp_compgen_filedir
-            COMPREPLY+=($(compgen -W 'unix32 unix64 win32A win32W win64
-                native' -- "$cur"))
+            _comp_compgen -a -- -W 'unix32 unix64 win32A win32W win64 native'
             return
             ;;
         -rp | --relative-paths)

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -41,10 +41,10 @@ _comp_cmd_cryptsetup()
             _comp_compgen_help
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
-            COMPREPLY=($(compgen -W 'open close resize status benchmark
-                repair erase luksFormat luksAddKey luksRemoveKey luksChangeKey
+            _comp_compgen -- -W 'open close resize status benchmark repair
+                erase luksFormat luksAddKey luksRemoveKey luksChangeKey
                 luksKillSlot luksUUID isLuks luksDump tcryptDump luksSuspend
-                luksResume luksHeaderBackup luksHeaderRestore' -- "$cur"))
+                luksResume luksHeaderBackup luksHeaderRestore'
         fi
     else
         local args

--- a/completions/curl
+++ b/completions/curl
@@ -135,11 +135,8 @@ _comp_cmd_curl()
             ;;
         --request | -${noargopts}X)
             # TODO: these are valid for http(s) only
-            COMPREPLY=($(
-                compgen -W \
-                    'GET HEAD POST PUT DELETE CONNECT OPTIONS TRACE PATCH' \
-                    -- "$cur"
-            ))
+            _comp_compgen -- -W 'GET HEAD POST PUT DELETE CONNECT OPTIONS TRACE
+                PATCH'
             return
             ;;
         --stderr)

--- a/completions/cvs
+++ b/completions/cvs
@@ -175,9 +175,9 @@ _comp_cmd_cvs()
                         done
                     fi
                 done
+                # shellcheck disable=SC2154 # global var _comp_backup_glob
                 ((${#files[@]})) &&
-                    COMPREPLY=($(compgen -X "$_comp_backup_glob" -W '"${files[@]}"' \
-                        -- "$cur"))
+                    _comp_compgen -- -X "$_comp_backup_glob" -W '"${files[@]}"'
             else
                 _comp_cmd_cvs__command_options "$1" "$mode"
             fi

--- a/completions/dd
+++ b/completions/dd
@@ -11,17 +11,15 @@ _comp_cmd_dd()
             return
             ;;
         conv=*)
-            cur=${cur#*=}
-            COMPREPLY=($(compgen -W 'ascii ebcdic ibm block unblock lcase
-                ucase sparse swab sync excl nocreat notrunc noerror fdatasync
-                fsync' -- "$cur"))
+            _comp_compgen -c "${cur#*=}" -- -W 'ascii ebcdic ibm block unblock
+                lcase ucase sparse swab sync excl nocreat notrunc noerror
+                fdatasync fsync'
             return
             ;;
         iflag=* | oflag=*)
-            cur=${cur#*=}
-            COMPREPLY=($(compgen -W 'append direct directory dsync sync
-                fullblock nonblock noatime nocache noctty nofollow count_bytes
-                skip_bytes seek_bytes' -- "$cur"))
+            _comp_compgen -c "${cur#*=}" -- -W 'append direct directory dsync
+                sync fullblock nonblock noatime nocache noctty nofollow
+                count_bytes skip_bytes seek_bytes'
             return
             ;;
         status=*)

--- a/completions/dot
+++ b/completions/dot
@@ -33,8 +33,8 @@ _comp_cmd_dot()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-V -v -G -N -E -T -K -l -o -O -P -q -s -y -n
-            -n1 -n2 -x -Lg -LO -Ln -LU -LC -LT -m -c -?' -- "$cur"))
+        _comp_compgen -- -W '-V -v -G -N -E -T -K -l -o -O -P -q -s -y -n -n1
+            -n2 -x -Lg -LO -Ln -LU -LC -LT -m -c -?'
         [[ ${COMPREPLY-} == -@([GNETKo]|L[nUCT]) ]] && compopt -o nospace
         return
     fi

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -176,8 +176,8 @@ _comp_cmd_dpkg_reconfigure()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--frontend --priority --all --unseen-only
-            --help --showold --force --terse' -- "$cur"))
+        _comp_compgen -- -W '--frontend --priority --all --unseen-only --help
+            --showold --force --terse'
     else
         _comp_xfunc_dpkg_installed_packages
     fi

--- a/completions/dpkg-source
+++ b/completions/dpkg-source
@@ -78,8 +78,7 @@ _comp_cmd_dpkg_source()
                     _comp_compgen -- -W "$fields"
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W "$packopts $unpackopts" \
-                        -- "$cur"))
+                    _comp_compgen -- -W '$packopts $unpackopts'
                     ;;
             esac
             return

--- a/completions/dselect
+++ b/completions/dselect
@@ -19,8 +19,7 @@ _comp_cmd_dselect()
     if [[ $cur == -* ]]; then
         _comp_compgen_help
     else
-        COMPREPLY=($(compgen -W 'access update select install config remove
-            quit' -- "$cur"))
+        _comp_compgen -- -W 'access update select install config remove quit'
     fi
 
 } &&

--- a/completions/dumpdb
+++ b/completions/dumpdb
@@ -6,8 +6,7 @@ _comp_cmd_dumpdb()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--marshal --pickle --noprint --help' \
-            -- "$cur"))
+        _comp_compgen -- -W '--marshal --pickle --noprint --help'
     else
         _comp_compgen_filedir
     fi

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -44,7 +44,7 @@ _comp_cmd_ebtables()
             ;;
         *)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '--802_3-sap --802_3-type --among-dst
+                _comp_compgen -- -W '--802_3-sap --802_3-type --among-dst
             --among-dst-file --among-src --among-src-file --append
             --arp-gratuitous --arp-htype --arp-ip-dst --arp-ip-src
             --arp-mac-dst --arp-mac-src --arp-opcode --arp-ptype --arpreply-mac
@@ -70,7 +70,7 @@ _comp_cmd_ebtables()
             --stp-sender-prio --stp-type --table --to-destination --to-dst
             --to-source --to-src --ulog --ulog-cprange --ulog-nlgroup
             --ulog-prefix --ulog-qthreshold --version --vlan-encap --vlan-id
-            --vlan-prio --zero' -- "$cur"))
+            --vlan-prio --zero'
             fi
             ;;
     esac

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -35,11 +35,11 @@ _comp_cmd_fbgs()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--bell --help --password -fp --firstpage
-            -lp --lastpage --color -l -xl -xxl --resolution --autozoom
+        _comp_compgen -- -W '--bell --help --password -fp --firstpage -lp
+            --lastpage --color -l -xl -xxl --resolution --autozoom
             --{,no}autoup --{,no}autodown --{,no}fitwidth --{,no}verbose
             --{,no}random --vt --scroll --timeout --{,no}once --gamma --font
-            --device --mode' -- "$cur"))
+            --device --mode'
         [[ ${COMPREPLY-} ]] && return
     fi
 

--- a/completions/fbi
+++ b/completions/fbi
@@ -36,12 +36,11 @@ _comp_cmd_fbi()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--help --version --store --list --text
-            --autozoom --{,no}autoup --{,no}autodown --{,no}fitwidth
-            --{,no}verbose --{,no}random --{,no}comments --{,no}edit
-            --{,no}backup --{,no}preserve --{,no}readahead --cachemem --blend
-            --vt --scroll --timeout --{,no}once --resolution --gamma --font
-            --device --mode' -- "$cur"))
+        _comp_compgen -- -W '--help --version --store --list --text --autozoom
+            --{,no}autoup --{,no}autodown --{,no}fitwidth --{,no}verbose
+            --{,no}random --{,no}comments --{,no}edit --{,no}backup
+            --{,no}preserve --{,no}readahead --cachemem --blend --vt --scroll
+            --timeout --{,no}once --resolution --gamma --font --device --mode'
         [[ ${COMPREPLY-} ]] && return
     fi
 

--- a/completions/feh
+++ b/completions/feh
@@ -57,8 +57,8 @@ _comp_cmd_feh()
             return
             ;;
         --sort | -${noargopts}S)
-            COMPREPLY=($(compgen -W 'name filename mtime width height
-                pixels size format' -- "$cur"))
+            _comp_compgen -- -W 'name filename mtime width height pixels size
+                format'
             return
             ;;
         --reload | --limit-height | --limit-width | --thumb-height | --thumb-width | \

--- a/completions/file
+++ b/completions/file
@@ -16,8 +16,8 @@ _comp_cmd_file()
             return
             ;;
         --exclude | -${noargopts}e)
-            COMPREPLY=($(compgen -W 'apptype ascii cdf compress elf encoding
-                soft tar text tokens troff' -- "$cur"))
+            _comp_compgen -- -W 'apptype ascii cdf compress elf encoding soft
+                tar text tokens troff'
             return
             ;;
     esac

--- a/completions/find
+++ b/completions/find
@@ -57,8 +57,8 @@ _comp_cmd_find()
             return
             ;;
         -regextype)
-            COMPREPLY=($(compgen -W 'emacs posix-awk posix-basic posix-egrep
-                posix-extended' -- "$cur"))
+            _comp_compgen -- -W 'emacs posix-awk posix-basic posix-egrep
+                posix-extended'
             return
             ;;
     esac
@@ -76,16 +76,15 @@ _comp_cmd_find()
     fi
 
     # complete using basic options
-    COMPREPLY=($(compgen -W '-daystart -depth -follow -help
-        -ignore_readdir_race -maxdepth -mindepth -mindepth -mount
-        -noignore_readdir_race -noleaf -regextype -version -warn -nowarn -xdev
-        -amin -anewer -atime -cmin -cnewer -ctime -empty -executable -false
-        -fstype -gid -group -ilname -iname -inum -ipath -iregex -iwholename
-        -links -lname -mmin -mtime -name -newer -nogroup -nouser -path -perm
-        -readable -regex -samefile -size -true -type -uid -used -user
-        -wholename -writable -xtype -context -delete -exec -execdir -fls
-        -fprint -fprint0 -fprintf -ls -ok -okdir -print -print0 -printf -prune
-        -quit' -- "$cur"))
+    _comp_compgen -- -W '-daystart -depth -follow -help -ignore_readdir_race
+        -maxdepth -mindepth -mindepth -mount -noignore_readdir_race -noleaf
+        -regextype -version -warn -nowarn -xdev -amin -anewer -atime -cmin
+        -cnewer -ctime -empty -executable -false -fstype -gid -group -ilname
+        -iname -inum -ipath -iregex -iwholename -links -lname -mmin -mtime
+        -name -newer -nogroup -nouser -path -perm -readable -regex -samefile
+        -size -true -type -uid -used -user -wholename -writable -xtype -context
+        -delete -exec -execdir -fls -fprint -fprint0 -fprintf -ls -ok -okdir
+        -print -print0 -printf -prune -quit'
 
     if ((${#COMPREPLY[@]} != 0)); then
         # this removes any options from the list of completions that have

--- a/completions/find_member
+++ b/completions/find_member
@@ -15,8 +15,7 @@ _comp_cmd_find_member()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--listname --exclude --owners --help' \
-            -- "$cur"))
+        _comp_compgen -- -W '--listname --exclude --owners --help'
     fi
 
 } &&

--- a/completions/freebsd-update
+++ b/completions/freebsd-update
@@ -21,8 +21,7 @@ _comp_cmd_freebsd_update()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W "fetch cron upgrade install rollback IDS" -- \
-        "$cur"))
+    _comp_compgen -- -W 'fetch cron upgrade install rollback IDS'
 } &&
     complete -F _comp_cmd_freebsd_update freebsd-update
 

--- a/completions/gcl
+++ b/completions/gcl
@@ -9,8 +9,8 @@ _comp_cmd_gcl()
 
     # completing an option (may or may not be separated by a space)
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-eval -load -f -batch -dir -libdir -compile
-            -o-file -c-file -h-file -data-file -system-p' -- "$cur"))
+        _comp_compgen -- -W '-eval -load -f -batch -dir -libdir -compile
+            -o-file -c-file -h-file -data-file -system-p'
     else
         _comp_compgen_filedir
     fi

--- a/completions/gdb
+++ b/completions/gdb
@@ -38,8 +38,7 @@ _comp_cmd_gdb()
         COMPREPLY=($(compgen -W "$(command ps axo comm,pid |
             awk '{if ($1 ~ /^'"${prev##*/}"'/) print $2}')" -- "$cur"))
         compopt -o filenames
-        COMPREPLY+=($(compgen -f -X '!?(*/)core?(.?*)' -o plusdirs \
-            -- "$cur"))
+        _comp_compgen -a -- -f -X '!?(*/)core?(.?*)' -o plusdirs
     fi
 } &&
     complete -F _comp_cmd_gdb gdb

--- a/completions/getent
+++ b/completions/getent
@@ -70,9 +70,9 @@ _comp_cmd_getent()
         _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ ! $has_db ]]; then
-        COMPREPLY=($(compgen -W 'passwd group hosts services protocols
-            networks ahosts ahostsv4 ahostsv6 aliases ethers netgroup rpc
-            shadow gshadow' -- "$cur"))
+        _comp_compgen -- -W 'passwd group hosts services protocols networks
+            ahosts ahostsv4 ahostsv6 aliases ethers netgroup rpc shadow
+            gshadow'
     fi
 } &&
     complete -F _comp_cmd_getent getent

--- a/completions/gnatmake
+++ b/completions/gnatmake
@@ -8,14 +8,14 @@ _comp_cmd_gnatmake()
 
     if [[ $cur == -* ]]; then
         # relevant (and less relevant ;-) )options completion
-        COMPREPLY=($(compgen -W '-a -c -f -i -j -k -m -M -n -o -q -s -v -z
-            -aL -A -aO -aI -I -I- -L -nostdinc -nostdlib -cargs -bargs -largs
+        _comp_compgen -- -W '-a -c -f -i -j -k -m -M -n -o -q -s -v -z -aL -A
+            -aO -aI -I -I- -L -nostdinc -nostdlib -cargs -bargs -largs
             -fstack-check -fno-inline -g -O1 -O0 -O2 -O3 -gnata -gnatA -gnatb
             -gnatc -gnatd -gnatD -gnate -gnatE -gnatf -gnatF -gnatg -gnatG
             -gnath -gnati -gnatk -gnatl -gnatL -gnatm -gnatn -gnato -gnatO
             -gnatp -gnatP -gnatq -gnatR -gnats -gnatt -gnatT -gnatu -gnatU
             -gnatv -gnatws -gnatwe -gnatwl -gnatwu -gnatW -gnatx -gnatX -gnaty
-            -gnatz -gnatZ -gnat83' -- "$cur"))
+            -gnatz -gnatZ -gnat83'
     else
         # source file completion
         _comp_compgen_filedir '@(adb|ads)'

--- a/completions/gnokii
+++ b/completions/gnokii
@@ -30,9 +30,8 @@ _comp_cmd_gnokii()
             return
             ;;
         --help)
-            COMPREPLY=($(compgen -W 'all monitor sms mms phonebook calendar
-                todo dial profile settings wap logo ringtone security file
-                other' -- "$cur"))
+            _comp_compgen -- -W 'all monitor sms mms phonebook calendar todo
+                dial profile settings wap logo ringtone security file other'
             return
             ;;
         --version | --shell | ping)
@@ -48,8 +47,7 @@ _comp_cmd_gnokii()
             return
             ;;
         --netmonitor)
-            COMPREPLY=($(compgen -W 'reset off field devel next nr' \
-                -- "$cur"))
+            _comp_compgen -- -W 'reset off field devel next nr'
             return
             ;;
 
@@ -59,8 +57,8 @@ _comp_cmd_gnokii()
             return
             ;;
         --savesms)
-            COMPREPLY=($(compgen -W '--sender --smsc --smscno --folder
-                --location --sent --read --deliver --datetime' -- "$cur"))
+            _comp_compgen -- -W '--sender --smsc --smscno --folder --location
+                --sent --read --deliver --datetime'
             return
             ;;
         --memory-type | --memory | --getsms | --deletesms | --getmms | --deletemms | \
@@ -82,8 +80,8 @@ _comp_cmd_gnokii()
             return
             ;;
         --writephonebook)
-            COMPREPLY=($(compgen -W '--overwrite --find-free --memory-type
-                --location --vcard --ldif' -- "$cur"))
+            _comp_compgen -- -W '--overwrite --find-free --memory-type
+                --location --vcard --ldif'
             return
             ;;
         --writecalendarnote | --writetodo)
@@ -135,8 +133,7 @@ _comp_cmd_gnokii()
             return
             ;;
         --setlogo | --getlogo)
-            COMPREPLY=($(compgen -W 'op startup caller dealer text' \
-                -- "$cur"))
+            _comp_compgen -- -W 'op startup caller dealer text'
             return
             ;;
         --viewlogo)
@@ -174,8 +171,7 @@ _comp_cmd_gnokii()
                 return
                 ;;
             --divert)
-                COMPREPLY=($(compgen -W 'register enable query disable
-                    erasure' -- "$cur"))
+                _comp_compgen -- -W 'register enable query disable erasure'
                 return
                 ;;
         esac
@@ -214,8 +210,7 @@ _comp_cmd_gnokii()
                 return
                 ;;
             --divert)
-                COMPREPLY=($(compgen -W 'all busy noans outofreach notavail' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'all busy noans outofreach notavail'
                 return
                 ;;
         esac

--- a/completions/gprof
+++ b/completions/gprof
@@ -15,9 +15,8 @@ _comp_cmd_gprof()
             return
             ;;
         -O*)
-            cur=${cur:2}
-            COMPREPLY=($(compgen -P -O -W 'auto bsd 4.4bsd magic prof' \
-                -- "$cur"))
+            _comp_compgen -c "${cur:2}" -- -P -O -W 'auto bsd 4.4bsd magic
+                prof'
             return
             ;;
     esac

--- a/completions/growisofs
+++ b/completions/growisofs
@@ -25,8 +25,7 @@ _comp_cmd_growisofs()
 
     if [[ $cur == -* ]]; then
         # TODO: mkisofs options
-        COMPREPLY=($(compgen -W '-dvd-compat -overburn -speed= -Z -M' \
-            -- "$cur"))
+        _comp_compgen -- -W '-dvd-compat -overburn -speed= -Z -M'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -16,15 +16,13 @@ _comp_cmd_hcitool__bluetooth_devices()
 
 _comp_cmd_hcitool__bluetooth_services()
 {
-    COMPREPLY=($(compgen -W 'DID SP DUN LAN FAX OPUSH FTP HS HF HFAG SAP NAP
-        GN PANU HCRP HID CIP A2SRC A2SNK AVRCT AVRTG UDIUE UDITE SYNCML' \
-        -- "$cur"))
+    _comp_compgen -- -W 'DID SP DUN LAN FAX OPUSH FTP HS HF HFAG SAP NAP
+        GN PANU HCRP HID CIP A2SRC A2SNK AVRCT AVRTG UDIUE UDITE SYNCML'
 }
 
 _comp_cmd_hcitool__bluetooth_packet_types()
 {
-    COMPREPLY=($(compgen -W 'DM1 DM3 DM5 DH1 DH3 DH5 HV1 HV2 HV3' \
-        -- "$cur"))
+    _comp_compgen -- -W 'DM1 DM3 DM5 DH1 DH3 DH5 HV1 HV2 HV3'
 }
 
 _comp_cmd_hcitool()
@@ -55,9 +53,8 @@ _comp_cmd_hcitool()
         if [[ $cur == -* ]]; then
             _comp_compgen_help
         else
-            COMPREPLY=($(compgen -W 'dev inq scan name info spinq epinq cmd
-                con cc dc sr cpt rssi lq tpl afh lst auth enc key clkoff
-                clock' -- "$cur"))
+            _comp_compgen -- -W 'dev inq scan name info spinq epinq cmd con cc
+                dc sr cpt rssi lq tpl afh lst auth enc key clkoff clock'
         fi
     else
         local args
@@ -127,15 +124,14 @@ _comp_cmd_sdptool()
         if [[ $cur == -* ]]; then
             _comp_compgen_help
         else
-            COMPREPLY=($(compgen -W 'search browse records add del get
-                setattr setseq' -- "$cur"))
+            _comp_compgen -- -W 'search browse records add del get setattr
+                setseq'
         fi
     else
         case $arg in
             search)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '--bdaddr --tree --raw --xml' \
-                        -- "$cur"))
+                    _comp_compgen -- -W '--bdaddr --tree --raw --xml'
                 else
                     _comp_cmd_hcitool__bluetooth_services
                 fi
@@ -156,8 +152,7 @@ _comp_cmd_sdptool()
                 ;;
             get)
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '--bdaddr --tree --raw --xml' \
-                        -- "$cur"))
+                    _comp_compgen -- -W '--bdaddr --tree --raw --xml'
                 fi
                 ;;
         esac
@@ -211,8 +206,7 @@ _comp_cmd_rfcomm()
         if [[ $cur == -* ]]; then
             _comp_compgen_help
         else
-            COMPREPLY=($(compgen -W 'show connect listen watch bind
-                release' -- "$cur"))
+            _comp_compgen -- -W 'show connect listen watch bind release'
         fi
     else
         local args
@@ -251,8 +245,7 @@ _comp_cmd_ciptool()
         if [[ $cur == -* ]]; then
             _comp_compgen_help
         else
-            COMPREPLY=($(compgen -W 'show search connect release loopback' \
-                -- "$cur"))
+            _comp_compgen -- -W 'show search connect release loopback'
         fi
     else
         local args
@@ -287,8 +280,7 @@ _comp_cmd_dfutool()
         _count_args
         case $args in
             1)
-                COMPREPLY=($(compgen -W 'verify modify upgrade archive' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'verify modify upgrade archive'
                 ;;
             2)
                 _comp_compgen_filedir
@@ -309,11 +301,11 @@ _comp_cmd_hciconfig()
         if [[ $cur == -* ]]; then
             _comp_compgen -- -W '--help --all'
         else
-            COMPREPLY=($(compgen -W 'up down reset rstat auth noauth encrypt
+            _comp_compgen -- -W 'up down reset rstat auth noauth encrypt
                 noencrypt secmgr nosecmgr piscan noscan iscan pscan ptype name
                 class voice iac inqmode inqdata inqtype inqparams pageparms
                 pageto afhmode aclmtu scomtu putkey delkey commands features
-                version revision lm' -- "$cur"))
+                version revision lm'
         fi
     else
         local args
@@ -327,8 +319,7 @@ _comp_cmd_hciconfig()
             lm)
                 _count_args
                 if ((args == 2)); then
-                    COMPREPLY=($(compgen -W 'MASTER SLAVE NONE ACCEPT' \
-                        -- "$cur"))
+                    _comp_compgen -- -W 'MASTER SLAVE NONE ACCEPT'
                 fi
                 ;;
             ptype)
@@ -356,16 +347,16 @@ _comp_cmd_hciattach()
             1)
                 _comp_expand_glob COMPREPLY '/dev/tty*'
                 ((${#COMPREPLY[@]})) &&
-                    COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"
-                        "${COMPREPLY[@]#/dev/}"' -- "$cur"))
+                    _comp_compgen -- -W '"${COMPREPLY[@]}"
+                        "${COMPREPLY[@]#/dev/}"'
                 ;;
             2)
-                COMPREPLY=($(compgen -W 'any ericsson digi xircom csr bboxes
-                    swave bcsp 0x0105 0x080a 0x0160 0x0002' -- "$cur"))
+                _comp_compgen -- -W 'any ericsson digi xircom csr bboxes swave
+                    bcsp 0x0105 0x080a 0x0160 0x0002'
                 ;;
             3)
-                COMPREPLY=($(compgen -W '9600 19200 38400 57600 115200 230400
-                    460800 921600' -- "$cur"))
+                _comp_compgen -- -W '9600 19200 38400 57600 115200 230400
+                    460800 921600'
                 ;;
             4)
                 _comp_compgen -- -W 'flow noflow'

--- a/completions/hid2hci
+++ b/completions/hid2hci
@@ -6,8 +6,7 @@ _comp_cmd_hid2hci()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--help --quiet -0 --tohci -1 --tohid' \
-            -- "$cur"))
+        _comp_compgen -- -W '--help --quiet -0 --tohci -1 --tohid'
     fi
 } &&
     complete -F _comp_cmd_hid2hci hid2hci

--- a/completions/idn
+++ b/completions/idn
@@ -12,8 +12,8 @@ _comp_cmd_idn()
             return
             ;;
         --profile | -${noargopts}p)
-            COMPREPLY=($(compgen -W 'Nameprep iSCSI Nodeprep Resourceprep
-                trace SASLprep' -- "$cur"))
+            _comp_compgen -- -W 'Nameprep iSCSI Nodeprep Resourceprep trace
+                SASLprep'
             return
             ;;
     esac

--- a/completions/installpkg
+++ b/completions/installpkg
@@ -21,8 +21,8 @@ _comp_cmd_installpkg()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--warn --md5sum --root --infobox --terse
-            --menu --ask --priority --tagfile' -- "$cur"))
+        _comp_compgen -- -W '--warn --md5sum --root --infobox --terse --menu
+            --ask --priority --tagfile'
         return
     fi
 

--- a/completions/ip
+++ b/completions/ip
@@ -99,8 +99,8 @@ _comp_cmd_ip()
                             ;;
                         3)
                             [[ $prev == type ]] &&
-                                COMPREPLY=($(compgen -W 'vlan veth vcan dummy
-                                    ifb macvlan can' -- "$cur"))
+                                _comp_compgen -- -W 'vlan veth vcan dummy ifb
+                                    macvlan can'
                             ;;
                     esac
                     ;;
@@ -137,8 +137,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add delete set show' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'help add delete set show'
                     ;;
             esac
             ;;
@@ -166,9 +165,9 @@ _comp_cmd_ip()
                 show | flush)
                     if ((cword == subcword + 1)); then
                         _available_interfaces
-                        COMPREPLY+=($(compgen -W 'dev scope to label dynamic
+                        _comp_compgen -a -- -W 'dev scope to label dynamic
                             permanent tentative deprecated dadfailed temporary
-                            primary secondary up' -- "$cur"))
+                            primary secondary up'
                     elif [[ $prev == dev ]]; then
                         _available_interfaces
                     elif [[ $prev == scope ]]; then
@@ -177,8 +176,8 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add change replace del
-                            show flush' -- "$cur"))
+                        _comp_compgen -- -W 'help add change replace del show
+                            flush'
                     ;;
             esac
             ;;
@@ -194,8 +193,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help list add del flush' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'help list add del flush'
                     ;;
             esac
             ;;
@@ -234,8 +232,8 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help list flush get add del
-                            change append replace monitor' -- "$cur"))
+                        _comp_compgen -- -W 'help list flush get add del change
+                            append replace monitor'
                     ;;
             esac
             ;;
@@ -255,10 +253,10 @@ _comp_cmd_ip()
                             _comp_compgen -- -W 'local main default'
                             ;;
                         *)
-                            COMPREPLY=($(compgen -W 'from to tos dsfield fwmark
-                                uidrange ipproto sport dport priority table lookup
-                                protocol suppress_prefixlength suppress_ifgroup realms
-                                nat goto iif oif not' -- "$cur"))
+                            _comp_compgen -- -W 'from to tos dsfield fwmark
+                                uidrange ipproto sport dport priority table
+                                lookup protocol suppress_prefixlength
+                                suppress_ifgroup realms nat goto iif oif not'
                             ;;
                     esac
                     ;;
@@ -272,8 +270,8 @@ _comp_cmd_ip()
                 restore | show) ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add del list flush save
-                            restore show' -- "$cur"))
+                        _comp_compgen -- -W 'help add del list flush save
+                            restore show'
                     ;;
             esac
             ;;
@@ -288,8 +286,8 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add del change replace
-                            show flush' -- "$cur"))
+                        _comp_compgen -- -W 'help add del change replace show
+                            flush'
                     ;;
             esac
             ;;
@@ -304,8 +302,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help change show' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'help change show'
                     ;;
             esac
             ;;
@@ -319,8 +316,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add change del show prl
-                            6rd' -- "$cur"))
+                        _comp_compgen -- -W 'help add change del show prl 6rd'
                     ;;
             esac
             ;;
@@ -340,8 +336,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add del show' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'help add del show'
                     ;;
             esac
             ;;
@@ -380,8 +375,8 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'help add delete exec
-                            identify list list-id monitor pids set' -- "$cur"))
+                        _comp_compgen -- -W 'help add delete exec identify list
+                            list-id monitor pids set'
                     ;;
             esac
             ;;
@@ -393,8 +388,7 @@ _comp_cmd_ip()
                     ;;
                 *)
                     ((cword == subcword)) &&
-                        COMPREPLY=($(compgen -W 'state policy monitor' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'state policy monitor'
                     ;;
             esac
             ;;

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -42,8 +42,7 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*L)
-            COMPREPLY=($(compgen -W 'CALLBACK USER OPERATOR ADMINISTRATOR' \
-                -- "$cur"))
+            _comp_compgen -- -W 'CALLBACK USER OPERATOR ADMINISTRATOR'
             return
             ;;
         -*A)
@@ -107,8 +106,7 @@ _comp_cmd_ipmitool()
                         _comp_compgen -- -W 'print set'
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'print set alert stats' \
-                        -- "$cur"))
+                    _comp_compgen -- -W 'print set alert stats'
                     ;;
             esac
             ;;
@@ -118,8 +116,8 @@ _comp_cmd_ipmitool()
                 get | info | type | list | entity) ;;
 
                 elist)
-                    COMPREPLY=($(compgen -W 'all full compact event mclog fru
-                        generic' -- "$cur"))
+                    _comp_compgen -- -W 'all full compact event mclog fru
+                        generic'
                     ;;
                 dump)
                     _comp_compgen_filedir
@@ -135,8 +133,8 @@ _comp_cmd_ipmitool()
                     esac
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'get info type list elist entity
-                        dump fill' -- "$cur"))
+                    _comp_compgen -- -W 'get info type list elist entity dump
+                        fill'
                     ;;
             esac
             ;;
@@ -163,8 +161,8 @@ _comp_cmd_ipmitool()
                         _comp_compgen -- -W 'get set'
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'info clear list elist delete add
-                        get save writeraw readraw time' -- "$cur"))
+                    _comp_compgen -- -W 'info clear list elist delete add get
+                        save writeraw readraw time'
                     ;;
             esac
             ;;
@@ -178,16 +176,16 @@ _comp_cmd_ipmitool()
                         _comp_compgen -- -W 'name password'
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'summary list set disable enable
-                        priv test' -- "$cur"))
+                    _comp_compgen -- -W 'summary list set disable enable priv
+                        test'
                     ;;
             esac
             ;;
 
         set)
             [[ $prev == set ]] &&
-                COMPREPLY=($(compgen -W 'hostname username password privlvl
-                    authtype localaddr targetaddr port csv verbose' -- "$cur"))
+                _comp_compgen -- -W 'hostname username password privlvl
+                    authtype localaddr targetaddr port csv verbose'
             ;;
 
     esac

--- a/completions/ipsec
+++ b/completions/ipsec
@@ -20,21 +20,19 @@ _comp_cmd_ipsec__freeswan()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'auto barf eroute klipsdebug look manual
-            pluto ranbits rsasigkey setup showdefaults showhostkey spi spigrp
-            tncfg whack' -- "$cur"))
+        _comp_compgen -- -W 'auto barf eroute klipsdebug look manual pluto
+            ranbits rsasigkey setup showdefaults showhostkey spi spigrp tncfg
+            whack'
         return
     fi
 
     case ${words[1]} in
         auto)
-            COMPREPLY=($(compgen -W '--asynchronous --up --add --delete
-                --replace --down --route --unroute --ready --status
-                --rereadsecrets' -- "$cur"))
+            _comp_compgen -- -W '--asynchronous --up --add --delete --replace
+                --down --route --unroute --ready --status --rereadsecrets'
             ;;
         manual)
-            COMPREPLY=($(compgen -W '--up --down --route --unroute --union' \
-                -- "$cur"))
+            _comp_compgen -- -W '--up --down --route --unroute --union'
             ;;
         ranbits)
             _comp_compgen -- -W '--quick --continuous --bytes'
@@ -53,15 +51,15 @@ _comp_cmd_ipsec__strongswan()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'down irdumm leases listaacerts listacerts
-            listalgs listall listcacerts listcainfos listcards listcerts
-            listcrls listgroups listocsp listocspcerts listpubkeys openac pki
-            pluto pool purgecerts purgecrls purgeike purgeocsp ready reload
-            rereadaacerts rereadacerts rereadall rereadcacerts rereadcrls
-            rereadgroups rereadocspcerts rereadsecrets restart route scdecrypt
-            scencrypt scepclient secrets start starter status statusall stop
-            stroke unroute uci up update version whack --confdir --copyright
-            --directory --help --version --versioncode' -- "$cur"))
+        _comp_compgen -- -W 'down irdumm leases listaacerts listacerts listalgs
+            listall listcacerts listcainfos listcards listcerts listcrls
+            listgroups listocsp listocspcerts listpubkeys openac pki pluto pool
+            purgecerts purgecrls purgeike purgeocsp ready reload rereadaacerts
+            rereadacerts rereadall rereadcacerts rereadcrls rereadgroups
+            rereadocspcerts rereadsecrets restart route scdecrypt scencrypt
+            scepclient secrets start starter status statusall stop stroke
+            unroute uci up update version whack --confdir --copyright
+            --directory --help --version --versioncode'
         return
     fi
 
@@ -74,12 +72,12 @@ _comp_cmd_ipsec__strongswan()
             _comp_compgen -- -W '--utc'
             ;;
         restart | start)
-            COMPREPLY=($(compgen -W '--attach-gdb --auto-update --debug
-                --debug-all --debug-more --nofork' -- "$cur"))
+            _comp_compgen -- -W '--attach-gdb --auto-update --debug --debug-all
+                --debug-more --nofork'
             ;;
         pki)
-            COMPREPLY=($(compgen -W '--gen --issue --keyid --print --pub
-                --req --self --signcrl --verify' -- "$cur"))
+            _comp_compgen -- -W '--gen --issue --keyid --print --pub --req
+                --self --signcrl --verify'
             ;;
         pool) ;;
 

--- a/completions/iscsiadm
+++ b/completions/iscsiadm
@@ -9,8 +9,7 @@ _comp_cmd_iscsiadm()
     # shellcheck disable=SC2254
     case $prev in
         --mode | -${noargopts}m)
-            COMPREPLY=($(compgen -W 'discovery node session iface fw host' \
-                -- "$cur"))
+            _comp_compgen -- -W 'discovery node session iface fw host'
             return
             ;;
         --op | -${noargopts}o)

--- a/completions/isort
+++ b/completions/isort
@@ -23,8 +23,8 @@ _comp_cmd_isort()
             return
             ;;
         --section-default | -sd)
-            COMPREPLY=($(compgen -W 'FUTURE STDLIB THIRDPARTY FIRSTPARTY
-                                      LOCALFOLDER' -- "$cur"))
+            _comp_compgen -- -W 'FUTURE STDLIB THIRDPARTY FIRSTPARTY
+                LOCALFOLDER'
             return
             ;;
     esac

--- a/completions/iwconfig
+++ b/completions/iwconfig
@@ -7,8 +7,8 @@ _comp_cmd_iwconfig()
 
     case $prev in
         mode)
-            COMPREPLY=($(compgen -W 'managed ad-hoc master repeater secondary
-                monitor' -- "$cur"))
+            _comp_compgen -- -W 'managed ad-hoc master repeater secondary
+                monitor'
             return
             ;;
         essid)
@@ -80,8 +80,8 @@ _comp_cmd_iwconfig()
             _available_interfaces -w
         fi
     else
-        COMPREPLY=($(compgen -W 'essid nwid mode freq channel sens mode ap
-            nick rate rts frag enc key power txpower commit' -- "$cur"))
+        _comp_compgen -- -W 'essid nwid mode freq channel sens mode ap nick
+            rate rts frag enc key power txpower commit'
     fi
 
 } &&

--- a/completions/iwlist
+++ b/completions/iwlist
@@ -12,9 +12,9 @@ _comp_cmd_iwlist()
             _available_interfaces -w
         fi
     else
-        COMPREPLY=($(compgen -W 'scan scanning freq frequency channel rate
-            bit bitrate key enc encryption power txpower retry ap accesspoint
-            peers event' -- "$cur"))
+        _comp_compgen -- -W 'scan scanning freq frequency channel rate bit
+            bitrate key enc encryption power txpower retry ap accesspoint peers
+            event'
     fi
 } &&
     complete -F _comp_cmd_iwlist iwlist

--- a/completions/jarsigner
+++ b/completions/jarsigner
@@ -43,11 +43,10 @@ _comp_cmd_jarsigner()
     if [[ ! $jar ]]; then
         if [[ $cur == -* ]]; then
             # Documented as "should not be used": -internalsf, -sectionsonly
-            COMPREPLY=($(compgen -W '-keystore -storepass -storetype
-                -keypass -sigfile -signedjar -digestalg -sigalg -verify
-                -verbose -certs -tsa -tsacert -altsigner -altsignerpath
-                -protected -providerName -providerClass -providerArg' \
-                -- "$cur"))
+            _comp_compgen -- -W '-keystore -storepass -storetype -keypass
+                -sigfile -signedjar -digestalg -sigalg -verify -verbose -certs
+                -tsa -tsacert -altsigner -altsignerpath -protected
+                -providerName -providerClass -providerArg'
         fi
         _comp_compgen -a filedir '@(jar|apk)'
     fi

--- a/completions/java
+++ b/completions/java
@@ -185,13 +185,13 @@ _comp_cmd_java()
             return
             ;;
         -Xgc:*)
-            COMPREPLY=($(compgen -W 'singlecon gencon singlepar genpar' \
-                -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'singlecon gencon singlepar
+                genpar'
             return
             ;;
         -Xgcprio:*)
-            COMPREPLY=($(compgen -W 'throughput pausetime deterministic' \
-                -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'throughput pausetime
+                deterministic'
             return
             ;;
         -Xloggc:* | -Xverboselog:*)
@@ -203,8 +203,8 @@ _comp_cmd_java()
             return
             ;;
         -Xverbose:*)
-            COMPREPLY=($(compgen -W 'memory load jni cpuinfo codegen opt
-                gcpause gcreport' -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" -- -W 'memory load jni cpuinfo codegen
+                opt gcpause gcreport'
             return
             ;;
         -Xverify:*)

--- a/completions/jq
+++ b/completions/jq
@@ -49,12 +49,12 @@ _comp_cmd_jq()
         else
             # Otherwise, use a hard-coded list of known flags, some of which do
             # not appear in the output of --help as of jq 1.6.
-            COMPREPLY=($(compgen -W '--version --seq --stream --slurp
-                --raw-input --null-input --compact-output --tab --indent
-                --color-output -monochrome-output --ascii-output --unbuffered
-                --sort-keys --raw-output --join-output --from-file --exit-status
-                --arg --argjson --slurpfile --rawfile --argfile --args
-                --jsonargs --run-tests --help' -- "$cur"))
+            _comp_compgen -- -W '--version --seq --stream --slurp --raw-input
+                --null-input --compact-output --tab --indent --color-output
+                -monochrome-output --ascii-output --unbuffered --sort-keys
+                --raw-output --join-output --from-file --exit-status --arg
+                --argjson --slurpfile --rawfile --argfile --args --jsonargs
+                --run-tests --help'
         fi
         return
     fi

--- a/completions/json_xs
+++ b/completions/json_xs
@@ -7,15 +7,14 @@ _comp_cmd_json_xs()
 
     case $prev in
         -*f)
-            COMPREPLY=($(compgen -W 'json cbor storable storable-file bencode
-                clzf eval yaml string none' -- "$cur"))
+            _comp_compgen -- -W 'json cbor storable storable-file bencode clzf
+                eval yaml string none'
             return
             ;;
         -*t)
-            COMPREPLY=($(compgen -W 'json json-utf-8 json-pretty
-                json-utf-16le json-utf-16be json-utf-32le json-utf-32be
-                cbor storable storable-file bencode clzf yaml dump dumper
-                string none' -- "$cur"))
+            _comp_compgen -- -W 'json json-utf-8 json-pretty json-utf-16le
+                json-utf-16be json-utf-32le json-utf-32be cbor storable
+                storable-file bencode clzf yaml dump dumper string none'
             return
             ;;
         -*e)

--- a/completions/kcov
+++ b/completions/kcov
@@ -11,8 +11,7 @@ _comp_cmd_kcov()
             return
             ;;
         --sort-type | -s)
-            COMPREPLY=($(compgen -W 'filename percent reverse lines
-                uncovered' -- "$cur"))
+            _comp_compgen -- -W 'filename percent reverse lines uncovered'
             return
             ;;
         --include-path | --exclude-path)

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -14,9 +14,8 @@ _comp_cmd_ktutil__heimdal_realms()
 
 _comp_cmd_ktutil__heimdal_encodings()
 {
-    COMPREPLY=($(compgen -W 'des-cbc-mcrc des-cbc-md4 des-cbc-md5
-        des3-cbc-sha1 arcfour-hmac-md5 aes128-cts-hmac-sha1-96
-        aes256-cts-hmac-sha1-96' -- "$cur"))
+    _comp_compgen -- -W 'des-cbc-mcrc des-cbc-md4 des-cbc-md5 des3-cbc-sha1
+        arcfour-hmac-md5 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha1-96'
 }
 
 _comp_cmd_ktutil()

--- a/completions/larch
+++ b/completions/larch
@@ -7,7 +7,7 @@ _comp_cmd_larch()
     _comp_initialize -- "$@" || return
 
     if [[ $cword -eq 1 || $prev == -* ]]; then
-        COMPREPLY=($(compgen -W ' \
+        _comp_compgen -- -W ' \
             my-id my-default-archive register-archive whereis-archive archives \
             init-tree tree-root tree-version set-tree-version inventory \
             tagging-method tree-lint missing-tags add delete \
@@ -29,8 +29,7 @@ _comp_cmd_larch()
             touched-files-prereqs patch-set-web update-distributions \
             distribution-name notify my-notifier mail-new-categories \
             mail-new-branches mail-new-versions mail-new-revisions \
-            notify-library notify-browser push-new-revisions sendmail-mailx' \
-            "$cur"))
+            notify-library notify-browser push-new-revisions sendmail-mailx'
     fi
 
 } &&

--- a/completions/ldapvi
+++ b/completions/ldapvi
@@ -13,8 +13,8 @@ _comp_cmd_ldapvi()
             return
             ;;
         --sasl-mech | -${noargopts}Y)
-            COMPREPLY=($(compgen -W 'EXTERNAL GSSAPI DIGEST-MD5 CRAM-MD5
-                PLAIN ANONYMOUS' -- "$cur"))
+            _comp_compgen -- -W 'EXTERNAL GSSAPI DIGEST-MD5 CRAM-MD5 PLAIN
+                ANONYMOUS'
             return
             ;;
         --bind)
@@ -30,8 +30,7 @@ _comp_cmd_ldapvi()
             return
             ;;
         --deref)
-            COMPREPLY=($(compgen -W 'never searching finding always' \
-                -- "$cur"))
+            _comp_compgen -- -W 'never searching finding always'
             return
             ;;
         --encoding)

--- a/completions/lilo
+++ b/completions/lilo
@@ -40,8 +40,7 @@ _comp_cmd_lilo()
             ;;
         -T)
             # topic completion
-            COMPREPLY=($(compgen -W 'help ChRul EBDA geom geom= table=
-                video' -- "$cur"))
+            _comp_compgen -- -W 'help ChRul EBDA geom geom= table= video'
             return
             ;;
         -B)
@@ -56,8 +55,8 @@ _comp_cmd_lilo()
 
     if [[ $cur == -* ]]; then
         # relevant options completion
-        COMPREPLY=($(compgen -W '-A -B -b -c -C -d -E -f -g -i -I -l -L -m -M
-            -p -P -q -r -R -s -S -t -T -u -U -v -V -w -x -z' -- "$cur"))
+        _comp_compgen -- -W '-A -B -b -c -C -d -E -f -g -i -I -l -L -m -M -p -P
+            -q -r -R -s -S -t -T -u -U -v -V -w -x -z'
     fi
 } &&
     complete -F _comp_cmd_lilo lilo

--- a/completions/lintian
+++ b/completions/lintian
@@ -124,8 +124,8 @@ _comp_cmd_lintian()
 
     case "$cur" in
         --*)
-            COMPREPLY=($(compgen -W "$lint_actions $general_opts
-                $behaviour_opts $configuration_opts" -- "$cur"))
+            _comp_compgen -- -W "$lint_actions $general_opts $behaviour_opts
+                $configuration_opts"
             ;;
         *,)
             # If we're here, the user is trying to complete on

--- a/completions/lisp
+++ b/completions/lisp
@@ -9,9 +9,8 @@ _comp_cmd_lisp()
 
     # completing an option (may or may not be separated by a space)
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-core -lib -batch -quit -edit -eval -init
-        -dynamic-space-size -hinit -noinit -nositeinit -load -slave' \
-            -- "$cur"))
+        _comp_compgen -- -W '-core -lib -batch -quit -edit -eval -init
+            -dynamic-space-size -hinit -noinit -nositeinit -load -slave'
     else
         _comp_compgen_filedir
     fi

--- a/completions/list_lists
+++ b/completions/list_lists
@@ -14,8 +14,8 @@ _comp_cmd_list_lists()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--advertised --virtual-host-overview --bare
-            --help' -- "$cur"))
+        _comp_compgen -- -W '--advertised --virtual-host-overview --bare
+            --help'
     fi
 
 } &&

--- a/completions/list_members
+++ b/completions/list_members
@@ -15,8 +15,7 @@ _comp_cmd_list_members()
             return
             ;;
         -n | --nomail)
-            COMPREPLY=($(compgen -W 'byadmin byuser bybounce unknown' \
-                -- "$cur"))
+            _comp_compgen -- -W 'byadmin byuser bybounce unknown'
             return
             ;;
     esac

--- a/completions/list_owners
+++ b/completions/list_owners
@@ -6,8 +6,7 @@ _comp_cmd_list_owners()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--with-listnames --moderators --help' \
-            -- "$cur"))
+        _comp_compgen -- -W '--with-listnames --moderators --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/lsof
+++ b/completions/lsof
@@ -43,9 +43,9 @@ _comp_cmd_lsof()
     esac
 
     if [[ $cur == [-+]* ]]; then
-        COMPREPLY=($(compgen -W '-h -a -A -b -c +c -C +d -d +D -D +f -f -F -g
-            -i -k -l +L -L +m -m +M -M -n -N -o -O -p -P +r -r -R -s -S -T -t
-            -u -U -v -V +w -w -x -X -z -Z' -- "$cur"))
+        _comp_compgen -- -W '-h -a -A -b -c +c -C +d -d +D -D +f -f -F -g -i -k
+            -l +L -L +m -m +M -M -n -N -o -O -p -P +r -r -R -s -S -T -t -u -U
+            -v -V +w -w -x -X -z -Z'
         return
     fi
 

--- a/completions/lvm
+++ b/completions/lvm
@@ -95,8 +95,8 @@ _comp_cmd_pvs()
     # shellcheck disable=SC2254
     case $prev in
         --options | --sort | -${noargopts}[oO])
-            COMPREPLY=($(compgen -W 'pv_fmt pv_uuid pv_size pv_free pv_used
-                pv_name pv_attr pv_pe_count pv_pe_alloc_count' -- "$cur"))
+            _comp_compgen -- -W 'pv_fmt pv_uuid pv_size pv_free pv_used pv_name
+                pv_attr pv_pe_count pv_pe_alloc_count'
             return
             ;;
         --units)
@@ -248,10 +248,9 @@ _comp_cmd_vgs()
     # shellcheck disable=SC2254
     case $prev in
         --options | --sort | -${noargopts}[oO])
-            COMPREPLY=($(compgen -W 'vg_fmt vg_uuid vg_name vg_attr vg_size
-                vg_free vg_sysid vg_extent_size vg_extent_count vg_free_count
-                max_lv max_pv pv_count lv_count snap_count vg_seqno' \
-                -- "$cur"))
+            _comp_compgen -- -W 'vg_fmt vg_uuid vg_name vg_attr vg_size vg_free
+                vg_sysid vg_extent_size vg_extent_count vg_free_count max_lv
+                max_pv pv_count lv_count snap_count vg_seqno'
             return
             ;;
         --units)
@@ -637,9 +636,9 @@ _comp_cmd_lvs()
     # shellcheck disable=SC2254
     case $prev in
         --options | --sort | -${noargopts}[oO])
-            COMPREPLY=($(compgen -W 'lv_uuid lv_name lv_attr lv_minor lv_size
+            _comp_compgen -- -W 'lv_uuid lv_name lv_attr lv_minor lv_size
                 seg_count origin snap_percent segtype stripes stripesize
-                chunksize seg_start seg_size' -- "$cur"))
+                chunksize seg_start seg_size'
             return
             ;;
         --units)
@@ -882,13 +881,13 @@ _comp_cmd_lvm()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W 'dumpconfig help lvchange lvcreate lvdisplay
+        _comp_compgen -- -W 'dumpconfig help lvchange lvcreate lvdisplay
             lvextend lvmchange lvmdiskscan lvmsadc lvmsar lvreduce lvremove
             lvrename lvresize lvs lvscan pvchange pvcreate pvdata pvdisplay
             pvmove pvremove pvresize pvs pvscan vgcfgbackup vgcfgrestore
             vgchange vgck vgconvert vgcreate vgdisplay vgexport vgextend
             vgimport vgmerge vgmknodes vgreduce vgremove vgrename vgs vgscan
-            vgsplit version' -- "$cur"))
+            vgsplit version'
     else
         case "${words[1]}" in
             pvchange | pvcreate | pvdisplay | pvmove | pvremove | pvresize | pvs | pvscan | \

--- a/completions/lzop
+++ b/completions/lzop
@@ -22,13 +22,12 @@ _comp_cmd_lzop()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-1 -2 -3 -4 -5 -6 -7 -8 -9 -P
+        _comp_compgen -- -W '-{1..9} -P
             --fast --best --decompress --extract --test --list --ls --info
             --sysinfo --license --help --version --stdout --output --path
             --force --no-checksum --no-name --name --no-mode --no-time --suffix
             --keep --delete --crc32 --no-warn --ignore-warn --quiet --verbose
-            --no-stdin --filter --checksum --no-color --mono --color' \
-            -- "$cur"))
+            --no-stdin --filter --checksum --no-color --mono --color'
         return
     fi
 

--- a/completions/mailmanctl
+++ b/completions/mailmanctl
@@ -6,8 +6,8 @@ _comp_cmd_mailmanctl()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--no-restart --run-as-user
-            --stale-lock-cleanup --quiet --help' -- "$cur"))
+        _comp_compgen -- -W '--no-restart --run-as-user --stale-lock-cleanup
+            --quiet --help'
     else
         _comp_compgen -- -W 'start stop restart reopen'
     fi

--- a/completions/mdadm
+++ b/completions/mdadm
@@ -21,13 +21,12 @@ _comp_cmd_mdadm__raid_level()
 
     case $mode in
         create)
-            COMPREPLY=($(compgen -W 'linear raid0 0 stripe raid1 1 mirror
-                raid4 4 raid5 5 raid6 6 raid10 10 multipath mp faulty' \
-                -- "$cur"))
+            _comp_compgen -- -W 'linear raid0 0 stripe raid1 1 mirror raid4 4
+                raid5 5 raid6 6 raid10 10 multipath mp faulty'
             ;;
         build)
-            COMPREPLY=($(compgen -W 'linear stripe raid0 0 raid1 multipath mp
-                faulty' -- "$cur"))
+            _comp_compgen -- -W 'linear stripe raid0 0 raid1 multipath mp
+                faulty'
             ;;
     esac
 }
@@ -44,16 +43,16 @@ _comp_cmd_mdadm__raid_layout()
 
     case $level in
         raid5)
-            COMPREPLY=($(compgen -W 'left-asymmetric left-symmetric
-                right-asymmetric right-symmetric la ra ls rs' -- "$cur"))
+            _comp_compgen -- -W 'left-asymmetric left-symmetric
+                right-asymmetric right-symmetric la ra ls rs'
             ;;
         raid10)
             _comp_compgen -- -W 'n o p'
             ;;
         faulty)
-            COMPREPLY=($(compgen -W 'write-transient wt read-transient rt
+            _comp_compgen -- -W 'write-transient wt read-transient rt
                 write-persistent wp read-persistent rp write-all read-fixable
-                rf clear flush none' -- "$cur"))
+                rf clear flush none'
             ;;
     esac
 }
@@ -65,8 +64,8 @@ _comp_cmd_mdadm__auto_flag()
 
 _comp_cmd_mdadm__update_flag()
 {
-    COMPREPLY=($(compgen -W 'sparc2.2 summaries uuid name homehost resync
-        byteorder super-minor' -- "$cur"))
+    _comp_compgen -- -W 'sparc2.2 summaries uuid name homehost resync byteorder
+        super-minor'
 }
 
 _comp_cmd_mdadm()
@@ -106,40 +105,37 @@ _comp_cmd_mdadm()
 
     if [[ $cur == -* ]]; then
         if ((cword == 1)); then
-            COMPREPLY=($(compgen -W "$options --assemble --build --create
-                --monitor --grow" -- "$cur"))
+            _comp_compgen -- -W "$options --assemble --build --create --monitor
+                --grow"
         else
             # shellcheck disable=SC2254
             case ${words[cword - 1]} in
                 --assemble | -${noargopts}A*)
-                    COMPREPLY=($(compgen -W "$options --uuid= --super-minor=
+                    _comp_compgen -- -W "$options --uuid= --super-minor=
                         --name= --force --run --no-degraded --auto= --bitmap=
-                        --backup-file= --update= --auto-update-homehost" \
-                        -- "$cur"))
+                        --backup-file= --update= --auto-update-homehost"
                     ;;
                 --build | --create | --grow | -${noargopts}[BCG]*)
-                    COMPREPLY=($(compgen -W "$options --raid-devices=
+                    _comp_compgen -- -W "$options --raid-devices=
                         --spare-devices= --size= --chunk= --rounding= --level=
                         --layout= --parity= --bitmap= --bitmap-chunk=
                         --write-mostly --write-behind= --assume-clean
-                        --backup-file= --name= --run --force --auto=" \
-                        -- "$cur"))
+                        --backup-file= --name= --run --force --auto="
                     ;;
                 --follow | --monitor | -${noargopts}F)
-                    COMPREPLY=($(compgen -W "$options --mail --program
-                        --alert --syslog --delay --daemonise --pid-file
-                        --oneshot --test" -- "$cur"))
+                    _comp_compgen -- -W "$options --mail --program --alert
+                        --syslog --delay --daemonise --pid-file --oneshot
+                        --test"
 
                     ;;
                 /dev/* | --add | --fail | --remove)
-                    COMPREPLY=($(compgen -W "$options --add --re-add
-                        --remove --fail --set-faulty" -- "$cur"))
+                    _comp_compgen -- -W "$options --add --re-add --remove
+                        --fail --set-faulty"
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W "$options --query --detail
-                        --examine --sparc2.2 --examine-bitmap --run --stop
-                        --readonly --readwrite --zero-superblock --test" \
-                        -- "$cur"))
+                    _comp_compgen -- -W "$options --query --detail --examine
+                        --sparc2.2 --examine-bitmap --run --stop --readonly
+                        --readwrite --zero-superblock --test"
                     ;;
             esac
         fi

--- a/completions/mdtool
+++ b/completions/mdtool
@@ -16,16 +16,15 @@ _comp_cmd_mdtool()
     if [[ $command ]]; then
         case $command in
             "build")
-                COMPREPLY=($(compgen -W '--f --buildfile --p --project' \
-                    -S":" -- "$cur"))
+                _comp_compgen -- -W '--f --buildfile --p --project' -S":"
                 # TODO: This does not work :(
                 #if [[ "$prev" == *: ]]; then
                 #   case $prev in
                 #       @(--p:|--project:))
-                #           COMPREPLY=( $(compgen -f -G "*.mdp" -- "$cur") )
+                #           _comp_compgen -- -f -G "*.mdp"
                 #           ;;
                 #       @(--f:|--buildfile:))
-                #           COMPREPLY=( $(compgen -f -G "*.mdp" -G "*.mds" -- "$cur") )
+                #           _comp_compgen -- -f -G "*.mdp" -G "*.mds"
                 #           ;;
                 #   esac
                 #fi
@@ -35,25 +34,23 @@ _comp_cmd_mdtool()
                 compopt -o filenames
                 _comp_compgen -- -o filenames -G"*.mds"
                 if [[ $prev == *mds ]]; then
-                    COMPREPLY=($(compgen -W '--simple-makefiles --s --d:' \
-                        -- "$cur"))
+                    _comp_compgen -- -W '--simple-makefiles --s --d:'
                 fi
                 return
                 ;;
             "setup")
                 # TODO: at least return filenames after these options.
-                COMPREPLY=($(compgen -W 'install i uninstall u check-install
-                    ci update up list l list-av la list-update lu rep-add ra
+                _comp_compgen -- -W 'install i uninstall u check-install ci
+                    update up list l list-av la list-update lu rep-add ra
                     rep-remove rr rep-update ru rep-list rl reg-update
-                    reg-build rgu info rep-build rb pack p help h dump-file' \
-                    -- "$cur"))
+                    reg-build rgu info rep-build rb pack p help h dump-file'
                 return
                 ;;
         esac
     fi
 
-    COMPREPLY=($(compgen -W 'gsetup build dbgen project-export
-        generate-makefiles gettext-update setup -q' -- "$cur"))
+    _comp_compgen -- -W 'gsetup build dbgen project-export generate-makefiles
+        gettext-update setup -q'
 
 } &&
     complete -F _comp_cmd_mdtool mdtool

--- a/completions/mii-diag
+++ b/completions/mii-diag
@@ -7,8 +7,8 @@ _comp_cmd_mii_diag()
 
     case $prev in
         -F | -A | --advertise | --fixed-speed)
-            COMPREPLY=($(compgen -W '100baseT4 100baseTx 100baseTx-FD
-                100baseTx-HD 10baseT 10baseT-FD 10baseT-HD' -- "$cur"))
+            _comp_compgen -- -W '100baseT4 100baseTx 100baseTx-FD 100baseTx-HD
+                10baseT 10baseT-FD 10baseT-HD'
             return
             ;;
     esac

--- a/completions/mii-tool
+++ b/completions/mii-tool
@@ -9,13 +9,13 @@ _comp_cmd_mii_tool()
     # shellcheck disable=SC2254
     case $prev in
         --force | -${noargopts}F)
-            COMPREPLY=($(compgen -W '100baseTx-FD 100baseTx-HD 10baseT-FD
-                10baseT-HD' -- "$cur"))
+            _comp_compgen -- -W '100baseTx-FD 100baseTx-HD 10baseT-FD
+                10baseT-HD'
             return
             ;;
         --advertise | -${noargopts}A)
-            COMPREPLY=($(compgen -W '100baseT4 100baseTx-FD 100baseTx-HD
-                10baseT-FD 10baseT-HD' -- "$cur"))
+            _comp_compgen -- -W '100baseT4 100baseTx-FD 100baseTx-HD 10baseT-FD
+                10baseT-HD'
             return
             ;;
     esac

--- a/completions/minicom
+++ b/completions/minicom
@@ -19,8 +19,7 @@ _comp_cmd_minicom()
         --ptty | -${noargopts}p)
             _comp_expand_glob COMPREPLY '/dev/tty*'
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"' \
-                    -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"'
             return
             ;;
     esac

--- a/completions/mkinitrd
+++ b/completions/mkinitrd
@@ -23,12 +23,11 @@ _comp_cmd_mkinitrd()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--version --help -v -f --preload \
-            --force-scsi-probe --omit-scsi-modules \
-            --omit-ide-modules --image-version --force-raid-probe \
-            --omit-raid-modules --with= --force-lvm-probe \
-            --omit-lvm-modules --builtin --omit-dmraid --net-dev \
-            --fstab --nocompress --dsdt --bootchart' -- "$cur"))
+        _comp_compgen -- -W '--version --help -v -f --preload
+            --force-scsi-probe --omit-scsi-modules --omit-ide-modules
+            --image-version --force-raid-probe --omit-raid-modules --with=
+            --force-lvm-probe --omit-lvm-modules --builtin --omit-dmraid
+            --net-dev --fstab --nocompress --dsdt --bootchart'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         local args

--- a/completions/modinfo
+++ b/completions/modinfo
@@ -9,10 +9,10 @@ _comp_cmd_modinfo()
     # shellcheck disable=SC2254
     case "$prev" in
         --field | -${noargopts}F)
-            COMPREPLY=($(compgen -W 'alias author depends description
+            _comp_compgen -c "${cur,,}" -- -W 'alias author depends description
                 filename firmware intree license name parm release_date
                 retpoline sig_hashalgo sig_key signat signer softdep srcversion
-                staging vermagic version' -- "${cur,,}"))
+                staging vermagic version'
             return
             ;;
         --set-version | -${noargopts}k)

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -30,13 +30,13 @@ _comp_cmd_modprobe()
     if [[ $cur == -* ]]; then
         _comp_compgen_help
         if [[ ! ${COMPREPLY-} ]]; then
-            COMPREPLY=($(compgen -W '-a --all -b --use-blacklist -C --config
+            _comp_compgen -- -W '-a --all -b --use-blacklist -C --config
                 -c --showconfig --dump-modversions -d --dirname --first-time
                 --force-vermagic --force-modversion -f --force -i
                 --ignore-install --ignore-remove -l --list -n --dry-run -q
                 --quiet -R --resolve-alias -r --remove -S --set-version
                 --show-depends -s --syslog -t --type -V --version -v
-                --verbose' -- "$cur"))
+                --verbose'
         fi
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -142,28 +142,26 @@ _comp_cmd_mplayer()
             return
             ;;
         -aspect | -monitoraspect)
-            COMPREPLY=($(compgen -W '1:1 3:2 4:3 5:4 14:9 14:10 16:9 16:10
-                2.35:1' -- "$cur"))
+            _comp_compgen -- -W '1:1 3:2 4:3 5:4 14:9 14:10 16:9 16:10 2.35:1'
             _comp_ltrim_colon_completions "$cur"
             return
             ;;
         -lavdopts)
-            COMPREPLY=($(compgen -W 'bitexact bug= debug= ec= er= fast gray
-                idct= lowres= sb= st= skiploopfilter= skipidct= skipframe=
-                threads= vismv= vstats' -- "$cur"))
+            _comp_compgen -- -W 'bitexact bug= debug= ec= er= fast gray idct=
+                lowres= sb= st= skiploopfilter= skipidct= skipframe= threads=
+                vismv= vstats'
             return
             ;;
         -lavcopts)
-            COMPREPLY=($(compgen -W 'vcodec= vqmin= vqscale= vqmax= mbqmin=
-                mbqmax= vqdiff= vmax_b_frames= vme= vhq v4mv keyint=
-                vb_strategy= vpass= aspect= vbitrate= vratetol= vrc_maxrate=
-                vrc_minrate= vrc_buf_size= vb_qfactor= vi_qfactor= vb_qoffset=
-                vi_qoffset= vqblur= vqcomp= vrc_eq= vrc_override=
-                vrc_init_cplx= vqsquish= vlelim= vcelim= vstrict= vdpart
-                vpsize= gray vfdct= idct= lumi_mask= dark_mask= tcplx_mask=
-                scplx_mask= naq ildct format= pred qpel precmp= cmp= subcmp=
-                predia= dia= trell last_pred= preme= subq= psnr mpeg_quant aic
-                umv' -- "$cur"))
+            _comp_compgen -- -W 'vcodec= vqmin= vqscale= vqmax= mbqmin= mbqmax=
+                vqdiff= vmax_b_frames= vme= vhq v4mv keyint= vb_strategy=
+                vpass= aspect= vbitrate= vratetol= vrc_maxrate= vrc_minrate=
+                vrc_buf_size= vb_qfactor= vi_qfactor= vb_qoffset= vi_qoffset=
+                vqblur= vqcomp= vrc_eq= vrc_override= vrc_init_cplx= vqsquish=
+                vlelim= vcelim= vstrict= vdpart vpsize= gray vfdct= idct=
+                lumi_mask= dark_mask= tcplx_mask= scplx_mask= naq ildct format=
+                pred qpel precmp= cmp= subcmp= predia= dia= trell last_pred=
+                preme= subq= psnr mpeg_quant aic umv'
             return
             ;;
         -ssf)
@@ -171,8 +169,8 @@ _comp_cmd_mplayer()
             return
             ;;
         -jpeg)
-            COMPREPLY=($(compgen -W 'noprogressive progressive nobaseline
-                baseline optimize= smooth= quality= outdir=' -- "$cur"))
+            _comp_compgen -- -W 'noprogressive progressive nobaseline baseline
+                optimize= smooth= quality= outdir='
             return
             ;;
         -xvidopts)
@@ -180,59 +178,57 @@ _comp_cmd_mplayer()
             return
             ;;
         -xvidencopts)
-            COMPREPLY=($(compgen -W 'pass= bitrate= fixed_quant= me_quality=
-                4mv rc_reaction_delay_factor= rc_averaging_period= rc_buffer=
+            _comp_compgen -- -W 'pass= bitrate= fixed_quant= me_quality= 4mv
+                rc_reaction_delay_factor= rc_averaging_period= rc_buffer=
                 quant_range= min_key_interval= max_key_interval= mpeg_quant
                 mod_quant lumi_mask hintedme hintfile debug keyframe_boost=
-                kfthreshold= kfreduction=' -- "$cur"))
+                kfthreshold= kfreduction='
             return
             ;;
         -divx4opts)
-            COMPREPLY=($(compgen -W 'br= key= deinterlace q= min_quant=
-                max_quant= rc_period= rc_reaction_period= crispness=
-                rc_reaction_ratio= pass= vbrpass= help' -- "$cur"))
+            _comp_compgen -- -W 'br= key= deinterlace q= min_quant= max_quant=
+                rc_period= rc_reaction_period= crispness= rc_reaction_ratio=
+                pass= vbrpass= help'
             return
             ;;
         -info)
-            COMPREPLY=($(compgen -W 'name= artist= genre= subject=
-                copyright= srcform= comment= help' -- "$cur"))
+            _comp_compgen -- -W 'name= artist= genre= subject= copyright=
+                srcform= comment= help'
             return
             ;;
         -lameopts)
-            COMPREPLY=($(compgen -W 'vbr= abr cbr br= q= aq= ratio= vol=
-                mode= padding= fast preset= help' -- "$cur"))
+            _comp_compgen -- -W 'vbr= abr cbr br= q= aq= ratio= vol= mode=
+                padding= fast preset= help'
             return
             ;;
         -rawaudio)
-            COMPREPLY=($(compgen -W 'on channels= rate= samplesize= format=' \
-                -- "$cur"))
+            _comp_compgen -- -W 'on channels= rate= samplesize= format='
             return
             ;;
         -rawvideo)
-            COMPREPLY=($(compgen -W 'on fps= sqcif qcif cif 4cif pal ntsc w=
-                h= y420 yv12 yuy2 y8 format= size=' -- "$cur"))
+            _comp_compgen -- -W 'on fps= sqcif qcif cif 4cif pal ntsc w= h=
+                y420 yv12 yuy2 y8 format= size='
             return
             ;;
         -aop)
-            COMPREPLY=($(compgen -W 'list= delay= format= fout= volume= mul=
-                softclip' -- "$cur"))
+            _comp_compgen -- -W 'list= delay= format= fout= volume= mul=
+                softclip'
             return
             ;;
         -dxr2)
-            COMPREPLY=($(compgen -W 'ar-mode= iec958-encoded iec958-decoded
-                mute ucode= 75ire bw color interlaced macrovision= norm=
+            _comp_compgen -- -W 'ar-mode= iec958-encoded iec958-decoded mute
+                ucode= 75ire bw color interlaced macrovision= norm=
                 square-pixel ccir601-pixel cr-left= cr-right= cr-top= cr-bot=
                 ck-rmin= ck-gmin= ck-bmin= ck-rmax= ck-gmax= ck-bmax= ck-r=
                 ck-g= ck-b= ignore-cache= ol-osd= olh-cor= olw-cor= olx-cor=
-                oly-cor= overlay overlay-ratio= update-cache' -- "$cur"))
+                oly-cor= overlay overlay-ratio= update-cache'
             return
             ;;
         -tv)
-            COMPREPLY=($(compgen -W 'on noaudio driver= device= input= freq=
+            _comp_compgen -- -W 'on noaudio driver= device= input= freq=
                 outfmt= width= height= buffersize= norm= channel= chanlist=
                 audiorate= forceaudio alsa amode= forcechan= adevice= audioid=
-                volume= bass= treble= balance= fps= channels= immediatemode=' \
-                -- "$cur"))
+                volume= bass= treble= balance= fps= channels= immediatemode='
             return
             ;;
         -mf)
@@ -240,14 +236,13 @@ _comp_cmd_mplayer()
             return
             ;;
         -cdda)
-            COMPREPLY=($(compgen -W 'speed= paranoia= generic-dev=
-                sector-size= overlap= toc-bias toc-offset= skip noskip' \
-                -- "$cur"))
+            _comp_compgen -- -W 'speed= paranoia= generic-dev= sector-size=
+                overlap= toc-bias toc-offset= skip noskip'
             return
             ;;
         -input)
-            COMPREPLY=($(compgen -W 'conf= ar-delay ar-rate keylist cmdlist
-                js-dev file' -- "$cur"))
+            _comp_compgen -- -W 'conf= ar-delay ar-rate keylist cmdlist js-dev
+                file'
             return
             ;;
         -af-adv)

--- a/completions/msynctool
+++ b/completions/msynctool
@@ -32,10 +32,10 @@ _comp_cmd_msynctool()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W '--listgroups --listplugins --listobjects
-        --showformats --showgroup --sync --filter-objtype --slow-sync --wait
-        --multi --addgroup --delgroup --addmember --configure --manual
-        --configdir --conflict' -- "$cur"))
+    _comp_compgen -- -W '--listgroups --listplugins --listobjects --showformats
+        --showgroup --sync --filter-objtype --slow-sync --wait --multi
+        --addgroup --delgroup --addmember --configure --manual --configdir
+        --conflict'
 } &&
     complete -F _comp_cmd_msynctool msynctool
 

--- a/completions/munin-update
+++ b/completions/munin-update
@@ -17,9 +17,9 @@ _comp_cmd_munin_update()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--force-root --noforce-root --service --host
+        _comp_compgen -- -W '--force-root --noforce-root --service --host
             --config --help --debug --nodebug --fork --nofork --stdout
-            --nostdout --timeout' -- "$cur"))
+            --nostdout --timeout'
     fi
 } &&
     complete -F _comp_cmd_munin_update munin-update

--- a/completions/mutt
+++ b/completions/mutt
@@ -159,8 +159,8 @@ _comp_cmd_mutt()
 
     case $cur in
         -*)
-            COMPREPLY=($(compgen -W '-A -a -b -c -e -f -F -H -i -m -n -p -Q -R -s
-            -v -x -y -z -Z -h' -- "$cur"))
+            _comp_compgen -- -W '-A -a -b -c -e -f -F -H -i -m -n -p -Q -R -s
+                -v -x -y -z -Z -h'
             return
             ;;
         *)

--- a/completions/mysqladmin
+++ b/completions/mysqladmin
@@ -53,10 +53,10 @@ _comp_cmd_mysqladmin()
 
     _comp_compgen_help
 
-    COMPREPLY+=($(compgen -W 'create debug drop extended-status flush-hosts
+    _comp_compgen -a -- -W 'create debug drop extended-status flush-hosts
         flush-logs flush-status flush-tables flush-threads flush-privileges
         kill password old-password ping processlist reload refresh shutdown
-        status start-slave stop-slave variables version' -- "$cur"))
+        status start-slave stop-slave variables version'
 
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&

--- a/completions/nc
+++ b/completions/nc
@@ -19,9 +19,8 @@ _comp_cmd_nc()
             return
             ;;
         -*T)
-            COMPREPLY=($(compgen -W 'critical inetcontrol lowcost lowdelay
-                netcontrol throughput reliability ef af{11..43} cs{0..7}' \
-                -- "$cur"))
+            _comp_compgen -- -W 'critical inetcontrol lowcost lowdelay
+                netcontrol throughput reliability ef af{11..43} cs{0..7}'
             return
             ;;
         -*X)

--- a/completions/nslookup
+++ b/completions/nslookup
@@ -45,9 +45,9 @@ _comp_cmd_nslookup()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-all -class= -debug -nodebug -d2 -nod2
-            -domain= -search -nosearch -port= -querytype= -recurse -norecurse
-            -retry= -timeout= -vc -novc -fail -nofail' -- "$cur"))
+        _comp_compgen -- -W '-all -class= -debug -nodebug -d2 -nod2 -domain=
+            -search -nosearch -port= -querytype= -recurse -norecurse -retry=
+            -timeout= -vc -novc -fail -nofail'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/nsupdate
+++ b/completions/nsupdate
@@ -19,8 +19,7 @@ _comp_cmd_nsupdate()
             ;;
         -*y)
             if [[ $cur == h* ]]; then
-                COMPREPLY=($(compgen -W "hmac-{md5,sha{1,224,256,384,512}}" \
-                    -S : -- "$cur"))
+                _comp_comtpen -- -W "hmac-{md5,sha{1,224,256,384,512}}" -S :
                 [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             fi
             return

--- a/completions/openssl
+++ b/completions/openssl
@@ -99,10 +99,8 @@ _comp_cmd_openssl()
                 return
                 ;;
             -starttls)
-                COMPREPLY=($(compgen -W '
-                    smtp pop3 imap ftp xmpp xmpp-server telnet irc mysql
-                    postgres lmtp nntp sieve ldap
-                    ' -- "$cur"))
+                _comp_compgen -- -W ' smtp pop3 imap ftp xmpp xmpp-server
+                    telnet irc mysql postgres lmtp nntp sieve ldap'
                 return
                 ;;
             -cipher)
@@ -124,10 +122,10 @@ _comp_cmd_openssl()
             _comp_compgen -- -W "$options"
         else
             if [[ $command == speed ]]; then
-                COMPREPLY=($(compgen -W 'md2 mdc2 md5 hmac sha1 rmd160
-                    idea-cbc rc2-cbc rc5-cbc bf-cbc des-cbc des-ede3 rc4
-                    rsa512 rsa1024 rsa2048 rsa4096 dsa512 dsa1024 dsa2048 idea
-                    rc2 des rsa blowfish' -- "$cur"))
+                _comp_compgen -- -W 'md2 mdc2 md5 hmac sha1 rmd160 idea-cbc
+                    rc2-cbc rc5-cbc bf-cbc des-cbc des-ede3 rc4 rsa512 rsa1024
+                    rsa2048 rsa4096 dsa512 dsa1024 dsa2048 idea rc2 des rsa
+                    blowfish'
             else
                 _comp_compgen_filedir
             fi

--- a/completions/opera
+++ b/completions/opera
@@ -16,9 +16,8 @@ _comp_cmd_opera()
             return
             ;;
         ?(-)-remote)
-            COMPREPLY=($(compgen -W 'openURL\\( openFile\\( openM2\\(
-                openComposer\\( addBookmark\\( raise\\(\\) lower\\(\\)' \
-                -- "$cur"))
+            _comp_compgen -- -W 'openURL\\( openFile\\( openM2\\(
+                openComposer\\( addBookmark\\( raise\\(\\) lower\\(\\)'
             [[ ${COMPREPLY-} == *\( ]] && compopt -o nospace
             return
             ;;

--- a/completions/optipng
+++ b/completions/optipng
@@ -30,8 +30,7 @@ _comp_cmd_optipng()
             return
             ;;
         -zw)
-            COMPREPLY=($(compgen -W '256 512 1k 2k 4k 8k 16k 32k' \
-                -- "$cur"))
+            _comp_compgen -- -W '256 512 1k 2k 4k 8k 16k 32k'
             return
             ;;
         -strip)

--- a/completions/p4
+++ b/completions/p4
@@ -19,9 +19,8 @@ _comp_cmd_p4()
     elif ((cword == 2)); then
         case $prev in
             help)
-                COMPREPLY=($(compgen -W "simple commands environment
-                    filetypes jobview revisions usage views $p4commands" \
-                    -- "$cur"))
+                _comp_compgen -- -W "simple commands environment filetypes
+                    jobview revisions usage views $p4commands"
                 ;;
             admin)
                 _comp_compgen -- -W "checkpoint stop"

--- a/completions/pack200
+++ b/completions/pack200
@@ -55,12 +55,12 @@ _comp_cmd_pack200()
 
     if [[ ! $pack ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--no-gzip --gzip --strip-debug
+            _comp_compgen -- -W '--no-gzip --gzip --strip-debug
                 --no-keep-file-order --segment-limit= --effort= --deflate-hint=
                 --modification-time= --pass-file= --unknown-attribute=
                 --class-attribute= --field-attribute= --method-attribute=
                 --code-attribute= --config-file= --verbose --quiet --log-file=
-                --help --version -J --repack' -- "$cur"))
+                --help --version -J --repack'
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
             _comp_compgen_filedir 'pack?(.gz)'

--- a/completions/patch
+++ b/completions/patch
@@ -26,8 +26,7 @@ _comp_cmd_patch()
             return
             ;;
         --quoting-style)
-            COMPREPLY=($(compgen -W 'literal shell shell-always c escape' \
-                -- "$cur"))
+            _comp_compgen -- -W 'literal shell shell-always c escape'
             return
             ;;
         --version-control | -${noargopts}V)

--- a/completions/perl
+++ b/completions/perl
@@ -83,8 +83,8 @@ _comp_cmd_perl()
         return
 
     elif [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-C -s -T -u -U -W -X -h -v -V -c -w -d -D -p
-            -n -a -F -l -0 -I -m -M -P -S -x -i -e' -- "$cur"))
+        _comp_compgen -- -W '-C -s -T -u -U -W -X -h -v -V -c -w -d -D -p -n -a
+            -F -l -0 -I -m -M -P -S -x -i -e'
     else
         _comp_compgen_filedir
     fi

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -11,8 +11,7 @@ _comp_cmd_perlcritic()
             return
             ;;
         --severity)
-            COMPREPLY=($(compgen -W "{1..5} brutal cruel harsh stern gentle" \
-                -- "$cur"))
+            _comp_compgen -- -W '{1..5} brutal cruel harsh stern gentle'
             return
             ;;
         --profile | -p)

--- a/completions/pine
+++ b/completions/pine
@@ -15,8 +15,8 @@ _comp_cmd_pine()
             return
             ;;
         -sort)
-            COMPREPLY=($(compgen -W 'arrival subject threaded orderedsubject
-                date from size score to cc' -- "$cur"))
+            _comp_compgen -- -W 'arrival subject threaded orderedsubject date
+                from size score to cc'
             return
             ;;
     esac

--- a/completions/ping
+++ b/completions/ping
@@ -24,9 +24,9 @@ _comp_cmd_ping()
             ;;
         -*N)
             if [[ $cur != *= ]]; then
-                COMPREPLY=($(compgen -W 'name ipv6 ipv6-global ipv6-sitelocal
+                _comp_compgen -- -W 'name ipv6 ipv6-global ipv6-sitelocal
                     ipv6-linklocal ipv6-all ipv4 ipv4-all subject-ipv6=
-                    subject-ipv4= subject-name= subject-fqdn=' -- "$cur"))
+                    subject-ipv4= subject-name= subject-fqdn='
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             fi
             return

--- a/completions/pkgtool
+++ b/completions/pkgtool
@@ -25,9 +25,8 @@ _comp_cmd_pkgtool()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--sets --ignore-tagfiles --tagfile
-            --source-mounted --source_dir --target_dir --source_device' \
-            -- "$cur"))
+        _comp_compgen -- -W '--sets --ignore-tagfiles --tagfile
+            --source-mounted --source_dir --target_dir --source_device'
     fi
 } &&
     complete -F _comp_cmd_pkgtool pkgtool

--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -49,12 +49,10 @@ _comp_cmd_pkgutil()
 
     if [[ $prev == -@(p|-param) ]]; then
         compopt -o nospace
-        COMPREPLY=($(compgen -W "
-            mirror: pkgaddopts: pkgrmopts: wgetopts: use_gpg: use_md5:
-            pkgliststyle: maxpkglist: noncsw: stop_on_hook_soft_error:
+        _comp_compgen -- -W 'mirror: pkgaddopts: pkgrmopts: wgetopts: use_gpg:
+            use_md5: pkgliststyle: maxpkglist: noncsw: stop_on_hook_soft_error:
             exclude_pattern: gpg_homedir: root_path: deptree_filter_common:
-            show_current: catalog_not_cached: catalog_update:
-        " -- "$cur"))
+            show_current: catalog_not_cached: catalog_update:'
         return
     fi
 
@@ -63,11 +61,8 @@ _comp_cmd_pkgutil()
         # as a separator, borrowed from maven completion code which borrowed
         # it from darcs completion code :)
         local colonprefixes=${cur%"${cur##*:}"}
-        COMPREPLY=($(
-            compgen -W \
-                "sparc:5.9 sparc:5.10 sparc:5.11 i386:5.9 i386:5.10 i386:5.11" \
-                -- "$cur"
-        ))
+        _comp_compgen -- -W 'sparc:5.9 sparc:5.10 sparc:5.11 i386:5.9 i386:5.10
+            i386:5.11'
         local i=${#COMPREPLY[*]}
         while ((i-- > 0)); do
             COMPREPLY[i]=${COMPREPLY[i]#"$colonprefixes"}

--- a/completions/plague-client
+++ b/completions/plague-client
@@ -6,8 +6,8 @@ _comp_cmd_plague_client()
     _comp_initialize -- "$@" || return
 
     ((cword == 1)) &&
-        COMPREPLY=($(compgen -W 'build detail finish help is_paused kill list
-            list_builders pause requeue unpause update_builders' -- "$cur"))
+        _comp_compgen -- -W 'build detail finish help is_paused kill list
+            list_builders pause requeue unpause update_builders'
 } &&
     complete -F _comp_cmd_plague_client plague-client
 

--- a/completions/pm-is-supported
+++ b/completions/pm-is-supported
@@ -5,8 +5,7 @@ _comp_cmd_pm_is_supported()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W '--help --suspend --hibernate --suspend-hybrid' \
-        -- "$cur"))
+    _comp_compgen -- -W '--help --suspend --hibernate --suspend-hybrid'
 } &&
     complete -F _comp_cmd_pm_is_supported pm-is-supported
 

--- a/completions/postfix
+++ b/completions/postfix
@@ -21,8 +21,8 @@ _comp_cmd_postfix()
         return
     fi
 
-    COMPREPLY=($(compgen -W 'check start stop abort flush reload status
-        set-permissions upgrade-configuration' -- "$cur"))
+    _comp_compgen -- -W 'check start stop abort flush reload status
+        set-permissions upgrade-configuration'
 } &&
     complete -F _comp_cmd_postfix postfix
 

--- a/completions/ps
+++ b/completions/ps
@@ -7,8 +7,7 @@ _comp_cmd_ps()
 
     case $prev in
         --help)
-            COMPREPLY=($(compgen -W 'simple list output threads misc all' \
-                -- "$cur"))
+            _comp_compgen -- -W 'simple list output threads misc all'
             return
             ;;
         --info | V | --version)
@@ -41,8 +40,7 @@ _comp_cmd_ps()
         ?(-)t | [^-]*t | --tty)
             _comp_expand_glob COMPREPLY '/dev/tty*'
             ((${#COMPREPLY[@]})) &&
-                COMPREPLY=($(compgen -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"' \
-                    -- "$cur"))
+                _comp_compgen -- -W '"${COMPREPLY[@]}" "${COMPREPLY[@]#/dev/}"'
             return
             ;;
         ?(-)U | [^-]*U | -u | --[Uu]ser)

--- a/completions/puppet
+++ b/completions/puppet
@@ -110,9 +110,8 @@ _comp_cmd_puppet()
                     subcommand=apply
                     ;;
                 *)
-                    COMPREPLY=($(compgen -W 'agent apply cert describe doc
-                        filebucket kick master parser queue resource' \
-                        -- "$cur"))
+                    _comp_compgen -- -W 'agent apply cert describe doc
+                        filebucket kick master parser queue resource'
                     return
                     ;;
             esac
@@ -186,8 +185,8 @@ _comp_cmd_puppet()
                     ;;
                 *)
                     action=$prev
-                    COMPREPLY=($(compgen -W '--digest --debug --help --verbose
-                         --version' -- "$cur"))
+                    _comp_compgen -- -W '--digest --debug --help --verbose
+                         --version'
                     case $action in
                         fingerprint | list | verify | --fingerprint | --list | \
                             --verify)
@@ -209,9 +208,8 @@ _comp_cmd_puppet()
                             return
                             ;;
                         *)
-                            COMPREPLY+=($(compgen -W 'clean fingerprint
-                                generate list print revoke sign verify
-                                reinventory' -- "$cur"))
+                            _comp_compgen -a -- -W 'clean fingerprint generate
+                                list print revoke sign verify reinventory'
                             return
                             ;;
                     esac
@@ -263,8 +261,7 @@ _comp_cmd_puppet()
                     if [[ $cur == -* ]]; then
                         _comp_cmd_puppet__subcmd_opts "$1" "$subcommand"
                     else
-                        COMPREPLY=($(compgen -W 'backup get restore' \
-                            -- "$cur"))
+                        _comp_compgen -- -W 'backup get restore'
                         _comp_compgen -a filedir
                     fi
                     return

--- a/completions/pylint
+++ b/completions/pylint
@@ -84,8 +84,8 @@ _comp_cmd_pylint()
         --confidence)
             local prefix=
             [[ $cur == *,* ]] && prefix="${cur%,*},"
-            COMPREPLY=($(compgen -W "HIGH INFERENCE INFERENCE_FAILURE
-                UNDEFINED" -- "${cur##*,}"))
+            _comp_compgen -c "${cur##*,}" -- -W "HIGH INFERENCE
+                INFERENCE_FAILURE UNDEFINED"
             ((${#COMPREPLY[@]} == 1)) && COMPREPLY=(${COMPREPLY/#/$prefix})
             return
             ;;

--- a/completions/pylint
+++ b/completions/pylint
@@ -90,8 +90,7 @@ _comp_cmd_pylint()
             return
             ;;
         --format | -${noargopts}f)
-            COMPREPLY=($(compgen -W 'text parseable colorized json msvs' \
-                -- "$cur"))
+            _comp_compgen -- -W 'text parseable colorized json msvs'
             return
             ;;
         --import-graph | --ext-import-graph | --int-import-graph)

--- a/completions/pytest
+++ b/completions/pytest
@@ -33,8 +33,7 @@ _comp_cmd_pytest()
             return
             ;;
         --tb)
-            COMPREPLY=($(compgen -W "auto long short line native no" \
-                -- "$cur"))
+            _comp_compgen -- -W 'auto long short line native no'
             return
             ;;
         --show-capture)
@@ -66,9 +65,7 @@ _comp_cmd_pytest()
             return
             ;;
         --doctest-report)
-            COMPREPLY=($(
-                compgen -W "none cdiff ndiff udiff only_first_failure" -- "$cur"
-            ))
+            _comp_compgen -- -W 'none cdiff ndiff udiff only_first_failure'
             return
             ;;
         --assert)

--- a/completions/pytest
+++ b/completions/pytest
@@ -114,8 +114,8 @@ _comp_cmd_pytest()
             fi
         done 2>/dev/null <"$file"
         ((!${#COMPREPLY[@]})) ||
-            COMPREPLY=($(compgen -P "$file::$class::" -W '"${COMPREPLY[@]}"' \
-                -- "${cur##*:?(:)}"))
+            _comp_compgen -c "${cur##*:?(:)}" -- -P "$file::$class::" \
+                -W '"${COMPREPLY[@]}"'
         _comp_ltrim_colon_completions "$cur"
         return
     elif [[ $cur == *.py:* ]]; then
@@ -128,8 +128,8 @@ _comp_cmd_pytest()
             fi
         done 2>/dev/null <"$file"
         ((!${#COMPREPLY[@]})) ||
-            COMPREPLY=($(compgen -P "$file::" -W '"${COMPREPLY[@]}"' \
-                -- "${cur##*.py:?(:)}"))
+            _comp_compgen -c "${cur##*.py:?(:)}" -- -P "$file::" \
+                -W '"${COMPREPLY[@]}"'
         _comp_ltrim_colon_completions "$cur"
         return
     fi

--- a/completions/python
+++ b/completions/python
@@ -11,8 +11,8 @@ _comp_xfunc_python_modules()
 # @since 2.12
 _comp_xfunc_python_warning_actions()
 {
-    COMPREPLY+=($(compgen -W "ignore default all module once error" \
-        ${prefix:+-P "$prefix"} -- "$cur"))
+    _comp_compgen -a -- -W "ignore default all module once error" \
+        ${prefix:+-P "$prefix"}
 }
 
 _comp_deprecate_func _python_modules _comp_xfunc_python_modules
@@ -42,8 +42,7 @@ _comp_cmd_python()
             return
             ;;
         -${noargopts}Q)
-            COMPREPLY=($(compgen -W "old new warn warnall" -P "$prefix" \
-                -- "$cur"))
+            _comp_compgen -- -W 'old new warn warnall' -P "$prefix"
             return
             ;;
         -${noargopts}W)

--- a/completions/qemu
+++ b/completions/qemu
@@ -42,8 +42,7 @@ _comp_cmd_qemu()
             return
             ;;
         -usbdevice)
-            COMPREPLY=($(compgen -W 'mouse tablet disk: host: serial: braille
-                net' -- "$cur"))
+            _comp_compgen -- -W 'mouse tablet disk: host: serial: braille net'
             return
             ;;
         -net)
@@ -52,8 +51,8 @@ _comp_cmd_qemu()
             return
             ;;
         -serial | -parallel | -monitor)
-            COMPREPLY=($(compgen -W 'vc pty none null /dev/ file: stdio pipe:
-                COM udp: tcp: telnet: unix: mon: braille' -- "$cur"))
+            _comp_compgen -- -W 'vc pty none null /dev/ file: stdio pipe: COM
+                udp: tcp: telnet: unix: mon: braille'
             return
             ;;
         -redir)
@@ -69,8 +68,8 @@ _comp_cmd_qemu()
             return
             ;;
         -drive)
-            COMPREPLY=($(compgen -S"=" -W 'file if bus unit index media cyls
-                snapshot cache format serial addr' -- "$cur"))
+            _comp_compgen -- -S"=" -W 'file if bus unit index media cyls
+                snapshot cache format serial addr'
             return
             ;;
         -balloon)
@@ -87,8 +86,7 @@ _comp_cmd_qemu()
             return
             ;;
         -watchdog-action)
-            COMPREPLY=($(compgen -W 'reset shutdown poweroff pause debug
-                none' -- "$cur"))
+            _comp_compgen -- -W 'reset shutdown poweroff pause debug none'
             return
             ;;
         -runas)

--- a/completions/qrunner
+++ b/completions/qrunner
@@ -8,8 +8,7 @@ _comp_cmd_qrunner()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--runner --once --list --verbose --subproc
-            --help' -- "$cur"))
+        _comp_compgen -- -W '--runner --once --list --verbose --subproc --help'
     fi
 
 } &&

--- a/completions/querybts
+++ b/completions/querybts
@@ -9,8 +9,7 @@ _comp_cmd_querybts()
     # shellcheck disable=SC2254
     case $prev in
         --bts | -${noargopts}B)
-            COMPREPLY=($(compgen -W "debian guug kde mandrake help" \
-                -- "$cur"))
+            _comp_compgen -- -W 'debian guug kde mandrake help'
             return
             ;;
         --ui | --interface | -${noargopts}u)
@@ -30,11 +29,11 @@ _comp_cmd_querybts()
         _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W 'wnpp boot-floppies kernel bugs.debian.org
+        _comp_compgen -- -W 'wnpp boot-floppies kernel bugs.debian.org
             cdimage.debian.org general installation-reports listarchives
             lists.debian.org mirrors nm.debian.org press project qa.debian.org
             release-notes security.debian.org tech-ctte upgrade-reports
-            www.debian.org $(_comp_xfunc apt-cache packages)' -- "$cur"))
+            www.debian.org $(_comp_xfunc apt-cache packages)'
     fi
 } &&
     complete -F _comp_cmd_querybts querybts

--- a/completions/rdesktop
+++ b/completions/rdesktop
@@ -33,8 +33,8 @@ _comp_cmd_rdesktop()
                 *:*) ;;
 
                 *)
-                    COMPREPLY=($(compgen -W 'comport: disk: lptport:
-                        printer: sound: lspci scard' -- "$cur"))
+                    _comp_compgen -- -W 'comport: disk: lptport: printer:
+                        sound: lspci scard'
                     [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
                     ;;
             esac

--- a/completions/rdesktop
+++ b/completions/rdesktop
@@ -27,8 +27,7 @@ _comp_cmd_rdesktop()
         -*r)
             case $cur in
                 sound:*)
-                    COMPREPLY=($(compgen -W 'local off remote' \
-                        -- "${cur#sound:}"))
+                    _comp_compgen -c "${cur#sound:}" -- -W 'local off remote'
                     ;;
                 *:*) ;;
 

--- a/completions/remove_members
+++ b/completions/remove_members
@@ -15,8 +15,8 @@ _comp_cmd_remove_members()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--file --all --fromall --nouserack
-            --noadminack --help' -- "$cur"))
+        _comp_compgen -- -W '--file --all --fromall --nouserack --noadminack
+            --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -65,11 +65,11 @@ _comp_cmd_reportbug()
         return
     fi
 
-    COMPREPLY=($(compgen -W 'wnpp boot-floppies kernel bugs.debian.org
+    _comp_compgen -- -W 'wnpp boot-floppies kernel bugs.debian.org
         cdimage.debian.org general installation-reports listarchives
         lists.debian.org mirrors nm.debian.org press project qa.debian.org
         release-notes security.debian.org tech-ctte upgrade-reports
-        www.debian.org $(_comp_xfunc apt-cache packages)' -- "$cur"))
+        www.debian.org $(_comp_xfunc apt-cache packages)'
     _comp_compgen -a filedir
 } &&
     complete -F _comp_cmd_reportbug reportbug

--- a/completions/rpm
+++ b/completions/rpm
@@ -55,11 +55,10 @@ _comp_cmd_rpm()
         # first parameter on line
         case $cur in
             --*)
-                COMPREPLY=($(compgen -W '--help --version --initdb
-                    --checksig --addsign --delsign --rebuilddb --showrc
-                    --setperms --setugids --eval --install --upgrade --query
-                    --freshen --erase --verify --querytags --import' \
-                    -- "$cur"))
+                _comp_compgen -- -W '--help --version --initdb --checksig
+                    --addsign --delsign --rebuilddb --showrc --setperms
+                    --setugids --eval --install --upgrade --query --freshen
+                    --erase --verify --querytags --import'
                 ;;
             *)
                 _comp_compgen -- -W '-e -E -F -i -q -t -U -V'
@@ -131,21 +130,21 @@ _comp_cmd_rpm()
     case ${words[1]} in
         -[iFU]* | --install | --freshen | --upgrade)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '"${opts[@]}" --percent --force --test
-                --replacepkgs --replacefiles --root --excludedocs --includedocs
-                --noscripts --ignorearch --dbpath --prefix= --ignoreos --nodeps
-                --allfiles --ftpproxy --ftpport --justdb --httpproxy --httpport
-                --noorder --relocate= --badreloc --notriggers --excludepath=
-                --ignoresize --oldpackage --queryformat --repackage
-                --nosuggests' -- "$cur"))
+                _comp_compgen -- -W '"${opts[@]}" --percent --force --test
+                    --replacepkgs --replacefiles --root --excludedocs
+                    --includedocs --noscripts --ignorearch --dbpath --prefix=
+                    --ignoreos --nodeps --allfiles --ftpproxy --ftpport
+                    --justdb --httpproxy --httpport --noorder --relocate=
+                    --badreloc --notriggers --excludepath= --ignoresize
+                    --oldpackage --queryformat --repackage --nosuggests'
             else
                 _comp_compgen_filedir '[rs]pm'
             fi
             ;;
         -e | --erase)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '"${opts[@]}" --allmatches --noscripts
-                    --notriggers --nodeps --test --repackage' -- "$cur"))
+                _comp_compgen -- -W '"${opts[@]}" --allmatches --noscripts
+                    --notriggers --nodeps --test --repackage'
             else
                 _comp_xfunc_rpm_installed_packages "$1"
             fi
@@ -164,8 +163,8 @@ _comp_cmd_rpm()
             if [[ ${words[*]} == *\ -@(*([^ -])f|-file )* ]]; then
                 # -qf completion
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '"${opts[@]}" --dbpath --fscontext
-                        --last --root --state' -- "$cur"))
+                    _comp_compgen -- -W '"${opts[@]}" --dbpath --fscontext
+                        --last --root --state'
                 else
                     _comp_compgen_filedir
                 fi
@@ -175,20 +174,20 @@ _comp_cmd_rpm()
             elif [[ ${words[*]} == *\ -@(*([^ -])p|-package )* ]]; then
                 # -qp; uninstalled package completion
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '"${opts[@]}" --ftpport --ftpproxy
-                        --httpport --httpproxy --nomanifest' -- "$cur"))
+                    _comp_compgen -- -W '"${opts[@]}" --ftpport --ftpproxy
+                        --httpport --httpproxy --nomanifest'
                 else
                     _comp_compgen_filedir '[rs]pm'
                 fi
             else
                 # -q; installed package completion
                 if [[ $cur == -* ]]; then
-                    COMPREPLY=($(compgen -W '"${opts[@]}" --all --file --fileid
+                    _comp_compgen -- -W '"${opts[@]}" --all --file --fileid
                         --dbpath --fscontext --ftswalk --group --hdrid --last
                         --package --pkgid --root= --specfile --state
                         --triggeredby --whatenhances --whatprovides
                         --whatrecommends --whatrequires --whatsuggests
-                        --whatsupplements' -- "$cur"))
+                        --whatsupplements'
                 elif [[ ${words[*]} != *\ -@(*([^ -])a|-all )* ]]; then
                     _comp_xfunc_rpm_installed_packages "$1"
                 fi
@@ -196,20 +195,18 @@ _comp_cmd_rpm()
             ;;
         -K* | --checksig)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '"${opts[@]}" --nopgp --nogpg --nomd5' \
-                    -- "$cur"))
+                _comp_compgen -- -W '"${opts[@]}" --nopgp --nogpg --nomd5'
             else
                 _comp_compgen_filedir '[rs]pm'
             fi
             ;;
         -[Vy]* | --verify)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '"${opts[@]}" --root= --dbpath --nodeps
+                _comp_compgen -- -W '"${opts[@]}" --root= --dbpath --nodeps
                     --nogroup --nolinkto --nomode --nomtime --nordev --nouser
                     --nofiles --noscripts --nomd5 --querytags --specfile
                     --whatenhances --whatprovides --whatrecommends
-                    --whatrequires --whatsuggests --whatsupplements' \
-                    -- "$cur"))
+                    --whatrequires --whatsuggests --whatsupplements'
             # check whether we're doing file completion
             elif [[ ${words[*]} == *\ -@(*([^ -])f|-file )* ]]; then
                 _comp_compgen_filedir
@@ -229,8 +226,7 @@ _comp_cmd_rpm()
             ;;
         --import | --dbpath | --root)
             if [[ $cur == -* ]]; then
-                COMPREPLY=($(compgen -W '--import --dbpath --root=' \
-                    -- "$cur"))
+                _comp_compgen -- -W '--import --dbpath --root='
             else
                 _comp_compgen_filedir
             fi

--- a/completions/rpmcheck
+++ b/completions/rpmcheck
@@ -13,8 +13,8 @@ _comp_cmd_rpmcheck()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-explain -failures -successes -dump
-            -dump-all -base -help -compressed-input' -- "$cur"))
+        _comp_compgen -- -W '-explain -failures -successes -dump -dump-all
+            -base -help -compressed-input'
     else
         _comp_compgen_filedir
     fi

--- a/completions/rrdtool
+++ b/completions/rrdtool
@@ -6,8 +6,8 @@ _comp_cmd_rrdtool()
     _comp_initialize -- "$@" || return
 
     if ((${#words[@]} == 2)); then
-        COMPREPLY=($(compgen -W 'create update updatev graph dump restore
-            last lastupdate first info fetch tune resize xport' -- "$cur"))
+        _comp_compgen -- -W 'create update updatev graph dump restore last
+            lastupdate first info fetch tune resize xport'
     else
         _comp_compgen_filedir rrd
     fi

--- a/completions/sbcl
+++ b/completions/sbcl
@@ -9,9 +9,9 @@ _comp_cmd_sbcl()
 
     # completing an option (may or may not be separated by a space)
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--core --noinform --help --version
-            --sysinit --userinit --eval --noprint --disable-debugger
-            --end-runtime-options --end-toplevel-options ' -- "$cur"))
+        _comp_compgen -- -W '--core --noinform --help --version --sysinit
+            --userinit --eval --noprint --disable-debugger
+            --end-runtime-options --end-toplevel-options'
     else
         _comp_compgen_filedir
     fi

--- a/completions/screen
+++ b/completions/screen
@@ -42,8 +42,8 @@ _comp_cmd_screen__sessions()
         case ${words[1]} in
             /dev*)
                 if ((cword == 2)); then
-                    COMPREPLY=($(compgen -W '110 300 600 1200 2400 4800 9600 \
-                14400 19200 38400 57600 115200 128000 256000' -- "$cur"))
+                    _comp_compgen -- -W '110 300 600 1200 2400 4800 9600 14400
+                        19200 38400 57600 115200 128000 256000'
                     # TODO more, comma separated options
                 fi
                 return

--- a/completions/sh
+++ b/completions/sh
@@ -10,9 +10,8 @@ _comp_cmd_sh()
             return
             ;;
         -o | +o)
-            COMPREPLY=($(compgen -W 'allexport errexit ignoreeof monitor
-                noclobber noglob noexec nolog notify nounset verbose vi
-                xtrace' -- "$cur"))
+            _comp_compgen -- -W 'allexport errexit ignoreeof monitor noclobber
+                noglob noexec nolog notify nounset verbose vi xtrace'
             return
             ;;
     esac

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -12,8 +12,8 @@ _comp_cmd_sitecopy()
     # shellcheck disable=SC2254
     case $prev in
         --debug | -${noargopts}d)
-            COMPREPLY=($(compgen -W "socket files rcfile ftp http httpbody
-                rsh sftp xml xmlparse cleartext" -- "$cur"))
+            _comp_compgen -- -W 'socket files rcfile ftp http httpbody rsh sftp
+                xml xmlparse cleartext'
             compopt -o nospace
             return
             ;;

--- a/completions/slapt-get
+++ b/completions/slapt-get
@@ -76,8 +76,7 @@ _comp_cmd_slapt_get()
             return
             ;;
         set) # --install-set
-            COMPREPLY=($(compgen -W 'a ap d e f k kde kdei l n t tcl x
-                xap xfce y' -- "$cur"))
+            _comp_compgen -- -W 'a ap d e f k kde kdei l n t tcl x xap xfce y'
             return
             ;;
     esac

--- a/completions/smartctl
+++ b/completions/smartctl
@@ -10,9 +10,8 @@ _comp_cmd_smartctl__device()
             _comp_compgen -- -W 'hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5}'
             ;;
         *)
-            COMPREPLY=($(compgen -W "ata scsi sat usbcypress usbjmicron
-                usbsunplus marvell areca 3ware hpt megaraid cciss auto test" \
-                -- "$cur"))
+            _comp_compgen -- -W 'ata scsi sat usbcypress usbjmicron usbsunplus
+                marvell areca 3ware hpt megaraid cciss auto test'
             case "${COMPREPLY[@]}" in
                 areca | 3ware | hpt | megaraid | cciss)
                     compopt -o nospace
@@ -24,9 +23,9 @@ _comp_cmd_smartctl__device()
 _comp_cmd_smartctl__test()
 {
     [[ $cur == @(pending|scttempint|vendor), ]] && return
-    COMPREPLY=($(compgen -W 'offline short long conveyance select,
-        select,redo select,next afterselect,on afterselect,off pending,
-        scttempint, vendor,' -- "$cur"))
+    _comp_compgen -- -W 'offline short long conveyance select, select,redo
+        select,next afterselect,on afterselect,off pending, scttempint,
+        vendor,'
     [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
 }
 _comp_cmd_smartctl__drivedb()
@@ -57,10 +56,7 @@ _comp_cmd_smartctl()
             return
             ;;
         --tolerance | -${noargopts}T)
-            COMPREPLY=($(
-                compgen -W 'normal conservative permissive verypermissive' \
-                    -- "$cur"
-            ))
+            _comp_compgen -- -W 'normal conservative permissive verypermissive'
             return
             ;;
         --badsum | -${noargopts}b)
@@ -80,24 +76,20 @@ _comp_cmd_smartctl()
             return
             ;;
         --log | -${noargopts}l)
-            COMPREPLY=($(
-                compgen -W 'error selftest selective directory
-                background sasphy sasphy,reset sataphy sataphy,reset scttemp
-                scttempsts scttemphist scterc gplog smartlog xerror xselftest' \
-                    -- "$cur"
-            ))
+            _comp_compgen -- -W 'error selftest selective directory background
+                sasphy sasphy,reset sataphy sataphy,reset scttemp scttempsts
+                scttemphist scterc gplog smartlog xerror xselftest'
             return
             ;;
         --vendorattribute | -${noargopts}v)
-            COMPREPLY=($(compgen -W 'help 9,minutes 9,seconds 9,halfminutes
-                9,temp 192,emergencyretractcyclect 193,loadunload
-                194,10xCelsius 194,unknown 198,offlinescanuncsectorct
-                200,writeerrorcount 201,detectedtacount 220,temp' -- "$cur"))
+            _comp_compgen -- -W 'help 9,minutes 9,seconds 9,halfminutes 9,temp
+                192,emergencyretractcyclect 193,loadunload 194,10xCelsius
+                194,unknown 198,offlinescanuncsectorct 200,writeerrorcount
+                201,detectedtacount 220,temp'
             return
             ;;
         --firmwarebug | -${noargopts}F)
-            COMPREPLY=($(compgen -W 'none samsung samsung2 samsung3 swapid' \
-                -- "$cur"))
+            _comp_compgen -- -W 'none samsung samsung2 samsung3 swapid'
             return
             ;;
         --presets | -${noargopts}P)

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -29,9 +29,9 @@ _comp_cmd_smbclient__debuglevel()
 
 _comp_cmd_smbclient__sockopts()
 {
-    COMPREPLY=($(compgen -W 'SO_KEEPALIVE SO_REUSEADDR SO_BROADCAST
-        TCP_NODELAY IPTOS_LOWDELAY IPTOS_THROUGHPUT SO_SNDBUF SO_RCVBUF
-        SO_SNDLOWAT SO_RCVLOWAT' -- "$cur"))
+    _comp_compgen -- -W 'SO_KEEPALIVE SO_REUSEADDR SO_BROADCAST TCP_NODELAY
+        IPTOS_LOWDELAY IPTOS_THROUGHPUT SO_SNDBUF SO_RCVBUF SO_SNDLOWAT
+        SO_RCVLOWAT'
 }
 
 _comp_cmd_smbclient__signing()
@@ -52,8 +52,7 @@ _comp_cmd_smbclient()
             return
             ;;
         -${noargopts}t)
-            COMPREPLY=($(compgen -W 'SJIS EUC JIS7 JIS8 JUNET HEX CAP' \
-                -- "$cur"))
+            _comp_compgen -- -W 'SJIS EUC JIS7 JIS8 JUNET HEX CAP'
             return
             ;;
         --configfile | --authentication-file | -${noargopts}[sA])

--- a/completions/ss
+++ b/completions/ss
@@ -12,8 +12,7 @@ _comp_cmd_ss()
             return
             ;;
         --family | -${noargopts}f)
-            COMPREPLY=($(compgen -W 'unix inet inet6 link netlink' \
-                -- "$cur"))
+            _comp_compgen -- -W 'unix inet inet6 link netlink'
             return
             ;;
         --query | -${noargopts}A)
@@ -33,9 +32,9 @@ _comp_cmd_ss()
         _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ $prev == state ]]; then
-        COMPREPLY=($(compgen -W 'all connected synchronized bucket big
-            established syn-sent syn-recv fin-wait-{1,2} time-wait closed
-            close-wait last-ack listening closing' -- "$cur"))
+        _comp_compgen -- -W 'all connected synchronized bucket big established
+            syn-sent syn-recv fin-wait-{1,2} time-wait closed close-wait
+            last-ack listening closing'
     fi
 } &&
     complete -F _comp_cmd_ss ss

--- a/completions/ssh
+++ b/completions/ssh
@@ -153,8 +153,8 @@ _comp_cmd_ssh__suboption()
             _comp_compgen -- -W 'md5 sha256'
             ;;
         ipqos)
-            COMPREPLY=($(compgen -W 'af1{1..4} af2{2..3} af3{1..3} af4{1..3}
-                cs{0..7} ef lowdelay throughput reliability' -- "$cur"))
+            _comp_compgen -- -W 'af1{1..4} af2{2..3} af3{1..3} af4{1..3}
+                cs{0..7} ef lowdelay throughput reliability'
             ;;
         hostbasedkeytypes | hostkeyalgorithms)
             COMPREPLY=($(compgen -W '$(_comp_xfunc_ssh_query "$2" key)' -- "$cur"))
@@ -163,10 +163,7 @@ _comp_cmd_ssh__suboption()
             COMPREPLY=($(compgen -W '$(_comp_xfunc_ssh_query "$2" kex)' -- "$cur"))
             ;;
         loglevel)
-            COMPREPLY=($(
-                compgen -W 'QUIET FATAL ERROR INFO VERBOSE DEBUG{,1,2,3}' \
-                    -- "$cur"
-            ))
+            _comp_compgen -- -W 'QUIET FATAL ERROR INFO VERBOSE DEBUG{,1,2,3}'
             ;;
         macs)
             _comp_cmd_ssh__macs "$2"

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -60,8 +60,7 @@ _comp_cmd_ssh_keygen()
             ;;
         -*O)
             if [[ $cur != *=* ]]; then
-                COMPREPLY=($(compgen -W '
-                    clear critical: extension: force-command=
+                _comp_compgen -- -W 'clear critical: extension: force-command=
                     no-agent-forwarding no-port-forwarding no-pty no-user-rc
                     no-x11-forwarding permit-agent-forwarding
                     permit-port-forwarding permit-pty permit-user-rc
@@ -71,8 +70,8 @@ _comp_cmd_ssh_keygen()
                     lines= start-line= checkpoint= memory= start= generator=
 
                     application= challenge= device= no-touch-required resident
-                    user= write-attestation=
-                    ' -- "$cur"))
+                    user= write-attestation='
+
                 [[ ${COMPREPLY-} == *[:=] ]] && compopt -o nospace
                 _comp_ltrim_colon_completions "$cur"
             else
@@ -109,8 +108,7 @@ _comp_cmd_ssh_keygen()
             return
             ;;
         -*Y)
-            COMPREPLY=($(compgen -W 'find-principals check-novalidate sign
-                verify' -- "$cur"))
+            _comp_compgen -- -W 'find-principals check-novalidate sign verify'
             return
             ;;
     esac

--- a/completions/strace
+++ b/completions/strace
@@ -56,16 +56,16 @@ _comp_cmd_strace()
                                 done 2>/dev/null <$unistd
                             fi
 
-                            COMPREPLY=($(compgen -W '${syscalls[@]+"${!syscalls[@]}"} file
-                                process network signal ipc desc all none' \
-                                -- "$cur"))
+                            _comp_compgen -- -W \
+                                '${syscalls[@]+"${!syscalls[@]}"} file process
+                                network signal ipc desc all none'
                             return
                             ;;
                     esac
                 else
                     compopt -o nospace
-                    COMPREPLY=($(compgen -S"=" -W 'trace abbrev verbose raw
-                        signal read write' -- "$cur"))
+                    _comp_compgen -- -S"=" -W 'trace abbrev verbose raw signal
+                        read write'
                 fi
                 return
                 ;;

--- a/completions/svk
+++ b/completions/svk
@@ -176,18 +176,16 @@ _comp_cmd_svk()
         else
             case $command in
                 help | h | \?)
-                    COMPREPLY=($(compgen -W "$commands environment commands
-                        intro" -- "$cur"))
+                    _comp_compgen -- -W "$commands environment commands intro"
                     ;;
                 admin)
-                    COMPREPLY=($(compgen -W 'help deltify dump hotcopy
-                        list-dblogs list-unused-dblogs load lstxns recover
-                        rmtxns setlog verify rmcache' -- "$cur"))
+                    _comp_compgen -- -W 'help deltify dump hotcopy list-dblogs
+                        list-unused-dblogs load lstxns recover rmtxns setlog
+                        verify rmcache'
                     ;;
                 patch)
-                    COMPREPLY=($(compgen -W '--ls --list --cat --view
-                        --regen --regenerate --up --update --apply --rm
-                        --delete' -- "$cur"))
+                    _comp_compgen -- -W '--ls --list --cat --view --regen
+                        --regenerate --up --update --apply --rm --delete'
                     ;;
                 sync)
                     COMPREPLY=($(compgen -W "$("$1" mirror --list \

--- a/completions/sync_members
+++ b/completions/sync_members
@@ -19,8 +19,8 @@ _comp_cmd_sync_members()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--no-change --welcome-msg --goodbye-msg
-            --digest --notifyadmin --file --help' -- "$cur"))
+        _comp_compgen -- -W '--no-change --welcome-msg --goodbye-msg --digest
+            --notifyadmin --file --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -15,16 +15,14 @@ _comp_cmd_sysbench()
             return
             ;;
         --test)
-            COMPREPLY=($(compgen -W 'fileio cpu memory threads mutex oltp' \
-                -- "$cur"))
+            _comp_compgen -- -W 'fileio cpu memory threads mutex oltp'
             return
             ;;
         --cpu-max-prime)
             return
             ;;
         --file-test-mode)
-            COMPREPLY=($(compgen -W 'seqwr seqrewr seqrd rndrd rndwr rndrw' \
-                -- "$cur"))
+            _comp_compgen -- -W 'seqwr seqrewr seqrd rndrd rndwr rndrw'
             return
             ;;
         --file-io-mode)
@@ -68,8 +66,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --oltp-nontrx-mode)
-            COMPREPLY=($(compgen -W 'select update_key update_nokey insert
-                delete' -- "$cur"))
+            _comp_compgen -- -W 'select update_key update_nokey insert delete'
             return
             ;;
         --oltp-dist-type)
@@ -91,8 +88,7 @@ _comp_cmd_sysbench()
             return
             ;;
         --mysql-table-engine)
-            COMPREPLY=($(compgen -W 'myisam innodb bdb heap ndbcluster
-                federated' -- "$cur"))
+            _comp_compgen -- -W 'myisam innodb bdb heap ndbcluster federated'
             return
             ;;
         --mysql-engine-trx)

--- a/completions/tar
+++ b/completions/tar
@@ -586,20 +586,16 @@ _comp_cmd_tar__gnu()
                 break
                 ;;
             --format | -${noargopts}H)
-                COMPREPLY=($(compgen -W 'gnu oldgnu pax posix ustar v7' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'gnu oldgnu pax posix ustar v7'
                 break
                 ;;
             --quoting-style)
-                COMPREPLY=($(compgen -W 'literal shell shell-always
-                    shell-escape shell-escape-always c c-maybe escape locale
-                    clocale' -- "$cur"))
+                _comp_compgen -- -W 'literal shell shell-always shell-escape
+                    shell-escape-always c c-maybe escape locale clocale'
                 break
                 ;;
             --totals)
-                COMPREPLY=($(
-                    compgen -W 'SIGHUP SIGQUIT SIGINT SIGUSR1 SIGUSR2' -- "$cur"
-                ))
+                _comp_compgen -- -W 'SIGHUP SIGQUIT SIGINT SIGUSR1 SIGUSR2'
                 break
                 ;;
             --warning)

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -21,9 +21,8 @@ _comp_cmd_tcpdump()
             return
             ;;
         -${noargopts}T)
-            COMPREPLY=($(compgen -W 'aodv carp cnfp lmp pgm pgm_zmtp1 radius
-                resp rpc rtcp rtp rtcp snmp tftp vat vxlan wb zmtp1' \
-                -- "$cur"))
+            _comp_compgen -- -W 'aodv carp cnfp lmp pgm pgm_zmtp1 radius resp
+                rpc rtcp rtp rtcp snmp tftp vat vxlan wb zmtp1'
             return
             ;;
         -${noargopts}z)
@@ -39,8 +38,8 @@ _comp_cmd_tcpdump()
             return
             ;;
         --time-stamp-type | -${noargopts}j)
-            COMPREPLY=($(compgen -W 'host host_lowprec host_hiprec adapter
-                adapter_unsynced' -- "$cur"))
+            _comp_compgen -- -W 'host host_lowprec host_hiprec adapter
+                adapter_unsynced'
             return
             ;;
         --direction | -${noargopts}Q)

--- a/completions/tipc
+++ b/completions/tipc
@@ -94,9 +94,7 @@ _comp_cmd_tipc()
     esac
 
     if ((cword == 1)); then
-        COMPREPLY=($(
-            compgen -W 'bearer link media nametable node socket' -- "$cur"
-        ))
+        _comp_compgen -- -W 'bearer link media nametable node socket'
         return
     fi
 
@@ -105,9 +103,7 @@ _comp_cmd_tipc()
             ((optind++))
 
             if ((cword == optind)); then
-                COMPREPLY=(
-                    $(compgen -W 'enable disable set get list' -- "$cur")
-                )
+                _comp_compgen -- -W 'enable disable set get list'
                 return
             fi
 

--- a/completions/tshark
+++ b/completions/tshark
@@ -26,8 +26,8 @@ _comp_cmd_tshark()
                     _comp_cmd_tshark__prefs="$("$1" -G defaultprefs 2>/dev/null | command sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
                         tr '\n' ' ')"
                 : ${prefix:=}
-                COMPREPLY=($(compgen -P "$prefix" -W "$_comp_cmd_tshark__prefs" \
-                    -- "${cur:${#prefix}}"))
+                _comp_compgen -c "${cur:${#prefix}}" -- -P "$prefix" \
+                    -W "$_comp_cmd_tshark__prefs"
                 [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             fi
             return
@@ -103,8 +103,8 @@ _comp_cmd_tshark()
             if [[ ${cur:${#prefix}} == lua_script:* ]]; then
                 _comp_compgen -c "${cur#*:}" filedir lua
             else
-                COMPREPLY=($(compgen -P "$prefix" -W 'lua_script:' -- \
-                    "${cur:${#prefix}}"))
+                _comp_compgen -c "${cur:${#prefix}}" -- -P "$prefix" \
+                    -W 'lua_script:'
                 [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             fi
             return

--- a/completions/tshark
+++ b/completions/tshark
@@ -82,14 +82,12 @@ _comp_cmd_tshark()
             ;;
         -*T)
             # Parse from: tshark -T . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
-            COMPREPLY=($(compgen -W \
-                'pdml ps psml json jsonraw ek tabs text fields' -- "$cur"))
+            _comp_compgen -- -W 'pdml ps psml json jsonraw ek tabs text fields'
             return
             ;;
         -*t)
             # Parse from: tshark -t . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
-            COMPREPLY=($(compgen -W \
-                'a ad adoy d dd e r u ud udoy' -- "$cur"))
+            _comp_compgen -- -W 'a ad adoy d dd e r u ud udoy'
             return
             ;;
         -*u)

--- a/completions/tsig-keygen
+++ b/completions/tsig-keygen
@@ -10,9 +10,7 @@ _comp_cmd_tsig_keygen()
             return
             ;;
         -a)
-            COMPREPLY=($(
-                compgen -W 'hmac-{md5,sha{1,224,256,384,512}}' -- "$cur"
-            ))
+            _comp_compgen -- -W 'hmac-{md5,sha{1,224,256,384,512}}'
             return
             ;;
         -r)

--- a/completions/unpack200
+++ b/completions/unpack200
@@ -35,8 +35,8 @@ _comp_cmd_unpack200()
 
     if [[ ! $pack ]]; then
         if [[ $cur == -* ]]; then
-            COMPREPLY=($(compgen -W '--deflate-hint= --remove-pack-file
-                --verbose --quiet --log-file= --help --version' -- "$cur"))
+            _comp_compgen -- -W '--deflate-hint= --remove-pack-file --verbose
+                --quiet --log-file= --help --version'
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
             _comp_compgen_filedir 'pack?(.gz)'

--- a/completions/unrar
+++ b/completions/unrar
@@ -6,9 +6,9 @@ _comp_cmd_unrar()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-ad -ap -av- -c- -cfg- -cl -cu -dh -ep -f
-            -idp -ierr -inul -kb -o+ -o- -ow -p -p- -r -ta -tb -tn -to -u -v
-            -ver -vp -x -x@ -y' -- "$cur"))
+        _comp_compgen -- -W '-ad -ap -av- -c- -cfg- -cl -cu -dh -ep -f -idp
+            -ierr -inul -kb -o+ -o- -ow -p -p- -r -ta -tb -tn -to -u -v -ver
+            -vp -x -x@ -y'
     else
         if ((cword == 1)); then
             _comp_compgen -- -W 'e l lb lt p t v vb vt x'

--- a/completions/update-rc.d
+++ b/completions/update-rc.d
@@ -17,8 +17,8 @@ _comp_cmd_update_rc_d()
     options=(-f -n)
 
     if [[ $cword -eq 1 || $prev == -* ]]; then
-        COMPREPLY=($(compgen -W '"${options[@]}" ${services[@]+"${services[@]}"}' \
-            -X '$(tr " " "|" <<<${words[@]})' -- "$cur"))
+        _comp_compgen -- -W '"${options[@]}" ${services[@]+"${services[@]}"}' \
+            -X '$(tr " " "|" <<<${words[@]})'
     elif ((${#services[@]})) && [[ $prev == ?($(tr " " "|" <<<"${services[*]}")) ]]; then
         _comp_compgen -- -W 'remove defaults start stop'
     elif [[ $prev == defaults && $cur == [0-9] ]]; then

--- a/completions/upgradepkg
+++ b/completions/upgradepkg
@@ -6,8 +6,7 @@ _comp_cmd_upgradepkg()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--dry-run --install-new --reinstall
-            --verbose' -- "$cur"))
+        _comp_compgen -- -W '--dry-run --install-new --reinstall --verbose'
         return
     fi
 

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -58,8 +58,8 @@ _comp_cmd_valgrind()
             ;;
         # exp-dhat:
         --sort-by)
-            COMPREPLY=($(compgen -W 'max-bytes-live tot-bytes-allocd
-                max-blocks-live' -- "$cur"))
+            _comp_compgen -- -W 'max-bytes-live tot-bytes-allocd
+                max-blocks-live'
             return
             ;;
         # massif:
@@ -84,8 +84,7 @@ _comp_cmd_valgrind()
                     return
                     ;;
                 \<+([0-9])..+([0-9])\>)
-                    COMPREPLY=($(compgen -W "{${value:1:${#value}-2}}" \
-                        -- "$cur"))
+                    _comp_compgen -- -W "{${value:1:${#value}-2}}"
                     return
                     ;;
                 # "yes", "yes|no", etc (but not "string", "STR",

--- a/completions/vncviewer
+++ b/completions/vncviewer
@@ -28,8 +28,7 @@ _comp_cmd_tightvncviewer()
             return
             ;;
         -encodings)
-            COMPREPLY=($(compgen -W 'copyrect tight hextile zlib corre rre
-                raw' -- "$cur"))
+            _comp_compgen -- -W 'copyrect tight hextile zlib corre rre raw'
             return
             ;;
         -via)
@@ -39,10 +38,10 @@ _comp_cmd_tightvncviewer()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '-help -listen -via -shared -noshared
-            -viewonly -fullscreen -noraiseonbeep -passwd -encodings -bgr233
-            -owncmap -truecolour -truecolor -depth -compresslevel -quality
-            -nojpeg -nocursorshape -x11cursor' -- "$cur"))
+        _comp_compgen -- -W '-help -listen -via -shared -noshared -viewonly
+            -fullscreen -noraiseonbeep -passwd -encodings -bgr233 -owncmap
+            -truecolour -truecolor -depth -compresslevel -quality -nojpeg
+            -nocursorshape -x11cursor'
     else
         _known_hosts_real -- "$cur"
     fi

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -21,8 +21,7 @@ _vpnc()
             return
             ;;
         --natt-mode)
-            COMPREPLY=($(compgen -W 'natt none force-natt cisco-udp' \
-                -- "$cur"))
+            _comp_compgen -- -W 'natt none force-natt cisco-udp'
             return
             ;;
         --script | --pid-file | --ca-file)

--- a/completions/wget
+++ b/completions/wget
@@ -49,9 +49,9 @@ _comp_cmd_wget()
             local lastopt=${cur/*,/} prevopt=
             [[ $cur == *,* ]] && prevopt=${cur%,*},
 
-            COMPREPLY=($(compgen -P "$prevopt" -X "@($excludes_str)" \
-                -W 'unix windows nocontrol ascii lowercase uppercase' \
-                -- "$lastopt"))
+            _comp_compgen -c "$lastopt" -- -P "$prevopt" \
+                -X "@($excludes_str)" \
+                -W 'unix windows nocontrol ascii lowercase uppercase'
 
             # +o nospace when no more valid option is possible (= append a space)
             local opt_as_arr=(${COMPREPLY[0]//,/ })
@@ -89,15 +89,15 @@ _comp_cmd_wget()
             local lastopt=${cur/*,/} prevopt=
             [[ $cur == *,* ]] && prevopt=${cur%,*},
 
-            COMPREPLY=($(compgen -P "$prevopt" -W 'a abbr acronym address
-                applet area b base basefont bdo big blockquote body br button
-                caption center cite code col colgroup dd del dir div dfn dl dt
-                em fieldset font form frame frameset h6 head hr html i iframe
-                img input ins isindex kbd label legend li link map menu meta
-                noframes noscript object ol optgroup option p param pre q s
-                samp script select small span strike strong style sub sup table
-                tbody td textarea tfoot th thead title tr tt u ul var xmp' \
-                -- "$lastopt"))
+            _comp_compgen -c "$lastopt" -- -P "$prevopt" -W 'a abbr acronym
+                address applet area b base basefont bdo big blockquote body br
+                button caption center cite code col colgroup dd del dir div dfn
+                dl dt em fieldset font form frame frameset h6 head hr html i
+                iframe img input ins isindex kbd label legend li link map menu
+                meta noframes noscript object ol optgroup option p param pre q
+                s samp script select small span strike strong style sub sup
+                table tbody td textarea tfoot th thead title tr tt u ul var
+                xmp'
             return
             ;;
         --tries | --timeout | --dns-timeout | --connect-timeout | \

--- a/completions/wget
+++ b/completions/wget
@@ -128,7 +128,7 @@ _comp_cmd_wget()
             return
             ;;
         --header)
-            COMPREPLY=($(compgen -W 'Accept Accept-Charset Accept-Encoding
+            _comp_compgen -- -W 'Accept Accept-Charset Accept-Encoding
                 Accept-Language Accept-Ranges Age Allow Authorization
                 Cache-Control Connection Content-Encoding Content-Language
                 Content-Length Content-Location Content-MD5 Content-Range
@@ -137,7 +137,7 @@ _comp_cmd_wget()
                 Last-Modified Location Max-Forwards Pragma Proxy-Authenticate
                 Proxy-Authorization Range Referer Retry-After Server TE Trailer
                 Transfer-Encoding Upgrade User-Agent Vary Via Warning
-                WWW-Authenticate' -- "$cur"))
+                WWW-Authenticate'
             compopt -o nospace
             return
             ;;

--- a/completions/withlist
+++ b/completions/withlist
@@ -6,8 +6,7 @@ _comp_cmd_withlist()
     _comp_initialize -- "$@" || return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--lock --interactive --run --all --quiet
-            --help' -- "$cur"))
+        _comp_compgen -- -W '--lock --interactive --run --all --quiet --help'
     else
         _comp_xfunc list_lists mailman_lists
     fi

--- a/completions/wodim
+++ b/completions/wodim
@@ -16,8 +16,8 @@ _comp_cmd_wodim()
                 _comp_compgen_filedir
                 ;;
             blank)
-                COMPREPLY=($(compgen -W 'help all fast track unreserve trtail
-                    unclose session' -- "$cur"))
+                _comp_compgen -- -W 'help all fast track unreserve trtail
+                    unclose session'
                 ;;
             driveropts)
                 if [[ $cur == *=* ]]; then
@@ -28,18 +28,17 @@ _comp_cmd_wodim()
                             _comp_compgen -- -W "-2 -1 0 1 2"
                             ;;
                         gigarec)
-                            COMPREPLY=($(compgen -W "0.6 0.7 0.8 1.0 1.2 1.3
-                                1.4" -- "$cur"))
+                            _comp_compgen -- -W "0.6 0.7 0.8 1.0 1.2 1.3 1.4"
                             ;;
                         tattoofile)
                             _comp_compgen_filedir
                             ;;
                     esac
                 else
-                    COMPREPLY=($(compgen -W 'burnfree noburnfree varirec=
-                        gigarec= audiomaster forcespeed noforcespeed speedread
+                    _comp_compgen -- -W 'burnfree noburnfree varirec= gigarec=
+                        audiomaster forcespeed noforcespeed speedread
                         nospeedread singlesession nosinglesession hidecdr
-                        nohidecdr tattooinfo tattoofile=' -- "$cur"))
+                        nohidecdr tattooinfo tattoofile='
                     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
                 fi
                 ;;

--- a/completions/xdg-mime
+++ b/completions/xdg-mime
@@ -36,8 +36,7 @@ _comp_cmd_xdg_mime()
             _comp_compgen -- -W '--help --manual --version'
             return
         fi
-        COMPREPLY=($(compgen -W \
-            'query default install uninstall' -- "$cur"))
+        _comp_compgen -- -W 'query default install uninstall'
         return
     fi
 

--- a/completions/xev
+++ b/completions/xev
@@ -14,12 +14,9 @@ _comp_cmd_xev()
             return
             ;;
         -event)
-            COMPREPLY=($(
-                compgen -W '
-                    keyboard mouse expose visibility structure substructure
-                    focus property colormap owner_grab_button randr button
-                ' -- "$cur"
-            ))
+            _comp_compgen -- -W 'keyboard mouse expose visibility structure
+                substructure focus property colormap owner_grab_button randr
+                button'
             return
             ;;
     esac

--- a/completions/xgamma
+++ b/completions/xgamma
@@ -33,8 +33,7 @@ _comp_cmd_xgamma()
                 local t screens=$(xrandr --query 2>/dev/null | command sed -ne \
                     '/^Screen /s|^Screen \{1,\}\(.*\):.*$|\1|p' 2>/dev/null)
                 t="${cur#:}"
-                COMPREPLY=($(compgen -P "${t%.*}." -W '$screens' -- \
-                    "${cur##*.}"))
+                _comp_compgen -c "${cur##*.}" -- -P "${t%.*}." -W '$screens'
             elif [[ $cur != *:* ]]; then
                 # complete hostnames
                 _known_hosts_real -c -- "$cur"

--- a/completions/xmlwf
+++ b/completions/xmlwf
@@ -11,8 +11,7 @@ _comp_cmd_xmlwf()
             return
             ;;
         -*e)
-            COMPREPLY=($(compgen -W 'US-ASCII UTF-8 UTF-16 ISO-8859-1' \
-                -- "$cur"))
+            _comp_compgen -- -W 'US-ASCII UTF-8 UTF-16 ISO-8859-1'
             return
             ;;
         -*[abv])

--- a/completions/xrandr
+++ b/completions/xrandr
@@ -87,9 +87,7 @@ _comp_cmd_xrandr()
             return
             ;;
         -o | --orientation)
-            COMPREPLY=($(
-                compgen -W 'normal inverted left right 0 1 2 3' -- "$cur"
-            ))
+            _comp_compgen -- -W 'normal inverted left right 0 1 2 3'
             return
             ;;
         --reflect)


### PR DESCRIPTION
This is another round for `_comp_compgen`.

Also, word lists are re-folded on column 80 to fit the lines within 79 characters.