### PR TITLE
feat: no empty command completion if `no_empty_cmd_completion` is on

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2708,7 +2708,7 @@ _complete_as_root()
 _comp_compgen_commands()
 {
     [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return
-    _comp_compgen -- -c
+    _comp_compgen -- -c -o plusdirs
     # for e.g. spaces in paths to and in command names
     ((${#COMPREPLY[@]} == 0)) || compopt -o filenames
 }

--- a/bash_completion
+++ b/bash_completion
@@ -2706,7 +2706,7 @@ _complete_as_root()
 # @since 2.12
 _comp_compgen_commands()
 {
-    [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return
+    [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return 1
     # -o filenames for e.g. spaces in paths to and in command names
     _comp_compgen -- -c -o plusdirs && compopt -o filenames
 }

--- a/bash_completion
+++ b/bash_completion
@@ -2702,6 +2702,15 @@ _complete_as_root()
     [[ $EUID -eq 0 || ${root_command-} ]]
 }
 
+# Complete on available commands, subject to `no_empty_cmd_completion`.
+#
+# @since 2.12
+_comp_compgen_commands()
+{
+    [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return
+    _comp_compgen -- -c
+}
+
 # @since 2.12
 _comp_longopt()
 {

--- a/bash_completion
+++ b/bash_completion
@@ -2709,6 +2709,8 @@ _comp_compgen_commands()
 {
     [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return
     _comp_compgen -- -c
+    # for e.g. spaces in paths to and in command names
+    ((${#COMPREPLY[@]} == 0)) || compopt -o filenames
 }
 
 # @since 2.12

--- a/bash_completion
+++ b/bash_completion
@@ -2707,9 +2707,8 @@ _complete_as_root()
 _comp_compgen_commands()
 {
     [[ ! ${cur-} ]] && shopt -q no_empty_cmd_completion && return
-    _comp_compgen -- -c -o plusdirs
-    # for e.g. spaces in paths to and in command names
-    ((${#COMPREPLY[@]} == 0)) || compopt -o filenames
+    # -o filenames for e.g. spaces in paths to and in command names
+    _comp_compgen -- -c -o plusdirs && compopt -o filenames
 }
 
 # @since 2.12

--- a/bash_completion
+++ b/bash_completion
@@ -2702,6 +2702,9 @@ _complete_as_root()
 }
 
 # Complete on available commands, subject to `no_empty_cmd_completion`.
+# @return True (0) if one or more completions are generated, or otherwise False
+# (1).  Note that it returns 1 even when the completion generation is canceled
+# by `shopt -s no_empty_cmd_completion`.
 #
 # @since 2.12
 _comp_compgen_commands()

--- a/bash_completion
+++ b/bash_completion
@@ -2581,8 +2581,7 @@ _comp_command_offset()
     _comp_get_words cur
 
     if ((COMP_CWORD == 0)); then
-        compopt -o filenames
-        _comp_compgen -- -d -c
+        _comp_compgen_commands
     else
         _comp_dequote "${COMP_WORDS[0]}" || ret=${COMP_WORDS[0]}
         local cmd=$ret compcmd=$ret

--- a/completions/_su
+++ b/completions/_su
@@ -19,8 +19,7 @@ _comp_cmd_su()
             return
             ;;
         -c | --command | --session-command)
-            compopt -o filenames
-            _comp_compgen -- -d -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/_svn
+++ b/completions/_svn
@@ -38,7 +38,6 @@ _comp_cmd_svn()
                 return
                 ;;
             --editor-cmd | --diff-cmd | --diff3-cmd)
-                compopt -o filenames
                 _comp_compgen_commands
                 return
                 ;;

--- a/completions/_svn
+++ b/completions/_svn
@@ -39,7 +39,7 @@ _comp_cmd_svn()
                 ;;
             --editor-cmd | --diff-cmd | --diff3-cmd)
                 compopt -o filenames
-                _comp_compgen -- -c
+                _comp_compgen_commands
                 return
                 ;;
         esac

--- a/completions/cpio
+++ b/completions/cpio
@@ -22,7 +22,6 @@ _comp_cmd_cpio()
             return
             ;;
         --rsh-command)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/cpio
+++ b/completions/cpio
@@ -23,7 +23,7 @@ _comp_cmd_cpio()
             ;;
         --rsh-command)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -130,7 +130,7 @@ _comp_cmd_dpkg()
             return
             ;;
         --status-logger)
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --verify-format)

--- a/completions/fio
+++ b/completions/fio
@@ -75,7 +75,7 @@ _comp_cmd_fio()
             ;;
         --trigger | --trigger-remote)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --aux-path)
@@ -88,7 +88,7 @@ _comp_cmd_fio()
             return
             ;;
         --exec_postrun | --exec_prerun)
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --uid)

--- a/completions/fio
+++ b/completions/fio
@@ -74,7 +74,6 @@ _comp_cmd_fio()
             return
             ;;
         --trigger | --trigger-remote)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/firefox
+++ b/completions/firefox
@@ -33,7 +33,7 @@ _comp_cmd_firefox()
             return
             ;;
         --debugger | -d)
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/gdb
+++ b/completions/gdb
@@ -20,7 +20,7 @@ _comp_cmd_gdb()
         if _comp_looks_like_path "$cur"; then
             # compgen -c works as expected if $cur contains any slashes.
             local PATH="$PATH:."
-            _comp_compgen -- -d -c
+            _comp_compgen_commands
         else
             # otherwise compgen -c contains Bash's built-in commands,
             # functions and aliases. Thus we need to retrieve the program

--- a/completions/man
+++ b/completions/man
@@ -29,7 +29,6 @@ _comp_cmd_man()
             return
             ;;
         --pager | -${noargopts}P)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/man
+++ b/completions/man
@@ -30,7 +30,7 @@ _comp_cmd_man()
             ;;
         --pager | -${noargopts}P)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --preprocessor | -${noargopts}p)

--- a/completions/mr
+++ b/completions/mr
@@ -55,7 +55,7 @@ _comp_cmd_mr()
                 return
                 ;;
             run)
-                _comp_compgen -- -c
+                _comp_compgen_commands
                 return
                 ;;
             *)

--- a/completions/mussh
+++ b/completions/mussh
@@ -39,7 +39,7 @@ _comp_cmd_mussh()
             ;;
         -c)
             compopt -o filenames
-            _comp_compgen -a -- -c
+            _comp_compgen -a commands
             return
             ;;
     esac

--- a/completions/mypy
+++ b/completions/mypy
@@ -25,7 +25,7 @@ _comp_cmd_mypy()
             return
             ;;
         --python-executable)
-            _comp_compgen -c "${cur:-py}" -- -c
+            _comp_compgen -c "${cur:-py}" commands
             return
             ;;
         --*-dir | --*-report)

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -32,7 +32,7 @@ _comp_cmd_perlcritic()
             ;;
         --pager)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -31,7 +31,6 @@ _comp_cmd_perlcritic()
             return
             ;;
         --pager)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/protoc
+++ b/completions/protoc
@@ -20,7 +20,7 @@ _comp_cmd_protoc()
         --plugin)
             if [[ $cur != *=* ]]; then
                 compopt -o filenames
-                _comp_compgen -- -c
+                _comp_compgen_commands
             fi
             return
             ;;

--- a/completions/protoc
+++ b/completions/protoc
@@ -18,10 +18,7 @@ _comp_cmd_protoc()
             return
             ;;
         --plugin)
-            if [[ $cur != *=* ]]; then
-                compopt -o filenames
-                _comp_compgen_commands
-            fi
+            [[ $cur == *=* ]] || _comp_compgen_commands
             return
             ;;
         --proto_path | --*_out)

--- a/completions/querybts
+++ b/completions/querybts
@@ -17,7 +17,6 @@ _comp_cmd_querybts()
             return
             ;;
         --mbox-reader-cmd)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/querybts
+++ b/completions/querybts
@@ -18,7 +18,7 @@ _comp_cmd_querybts()
             ;;
         --mbox-reader-cmd)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -38,7 +38,7 @@ _comp_cmd_reportbug()
             ;;
         --editor | --mua | --mbox-reader-cmd | -${noargopts}e)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --from-buildd)

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -37,7 +37,6 @@ _comp_cmd_reportbug()
             return
             ;;
         --editor | --mua | --mbox-reader-cmd | -${noargopts}e)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/rpm
+++ b/completions/rpm
@@ -90,7 +90,7 @@ _comp_cmd_rpm()
             ;;
         --pipe)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --rcfile)

--- a/completions/rpm
+++ b/completions/rpm
@@ -89,7 +89,6 @@ _comp_cmd_rpm()
             return
             ;;
         --pipe)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/sqlite3
+++ b/completions/sqlite3
@@ -18,7 +18,7 @@ _comp_cmd_sqlite3()
             ;;
         -cmd)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/sqlite3
+++ b/completions/sqlite3
@@ -17,7 +17,6 @@ _comp_cmd_sqlite3()
             return
             ;;
         -cmd)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/ssh
+++ b/completions/ssh
@@ -196,7 +196,7 @@ _comp_cmd_ssh__suboption()
             _known_hosts_real -a ${configfile:+-F "$configfile"} -- "$cur"
             ;;
         proxycommand | remotecommand | localcommand)
-            _comp_compgen -- -c
+            _comp_compgen_commands
             ;;
         pubkeyacceptedalgorithms | pubkeyacceptedkeytypes)
             _comp_compgen_split -- "$(_comp_cmd_ssh__query "$1" key)"
@@ -371,7 +371,7 @@ _comp_cmd_ssh()
         _count_args "=" "-*[BbcDeLpRWEFSIiJlmOoQw]"
         if ((args > 1)); then
             compopt -o filenames
-            _comp_compgen -a -- -c
+            _comp_compgen -a commands
         else
             _known_hosts_real ${ipvx-} -a ${configfile:+-F "$configfile"} \
                 -- "$cur"
@@ -425,7 +425,7 @@ _comp_cmd_sftp()
             ;;
         -*S)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         -*4*)
@@ -575,7 +575,7 @@ _comp_cmd_scp()
             ;;
         -*S)
             compopt +o nospace -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         -*4*)

--- a/completions/ssh
+++ b/completions/ssh
@@ -424,7 +424,6 @@ _comp_cmd_sftp()
             return
             ;;
         -*S)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;
@@ -574,7 +573,7 @@ _comp_cmd_scp()
             return
             ;;
         -*S)
-            compopt +o nospace -o filenames
+            compopt +o nospace
             _comp_compgen_commands
             return
             ;;

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -78,7 +78,7 @@ _comp_cmd_ssh_keygen()
                 case $cur in
                     force-command=*)
                         compopt -o filenames
-                        _comp_compgen -c "${cur#*=}" -- -c
+                        _comp_compgen -c "${cur#*=}" commands
                         ;;
                     checkpoint=* | challenge=* | write-attestation=*)
                         _comp_compgen -c "${cur#*=}" filedir

--- a/completions/strace
+++ b/completions/strace
@@ -90,7 +90,7 @@ _comp_cmd_strace()
         if [[ $cur == -* ]]; then
             _comp_compgen_help -- -h
         else
-            _comp_compgen -- -c
+            _comp_compgen_commands
         fi
     fi
 } &&

--- a/completions/tar
+++ b/completions/tar
@@ -560,7 +560,6 @@ _comp_cmd_tar__gnu()
             --to-command | --info-script | --new-volume-script | \
                 --rmt-command | --rsh-command | --use-compress-program | \
                 -${noargopts}[FI])
-                compopt -o filenames
                 _comp_compgen_commands
                 break
                 ;;

--- a/completions/tar
+++ b/completions/tar
@@ -561,7 +561,7 @@ _comp_cmd_tar__gnu()
                 --rmt-command | --rsh-command | --use-compress-program | \
                 -${noargopts}[FI])
                 compopt -o filenames
-                _comp_compgen -- -c
+                _comp_compgen_commands
                 break
                 ;;
             --atime-preserve)

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -26,7 +26,6 @@ _comp_cmd_tcpdump()
             return
             ;;
         -${noargopts}z)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/completions/tcpdump
+++ b/completions/tcpdump
@@ -27,7 +27,7 @@ _comp_cmd_tcpdump()
             ;;
         -${noargopts}z)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
         --relinquish-privileges | -${noargopts}Z)

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -82,7 +82,7 @@ _comp_cmd_valgrind()
                     ;;
                 \<command\>)
                     compopt -o filenames
-                    _comp_compgen -- -c
+                    _comp_compgen_commands
                     return
                     ;;
                 \<+([0-9])..+([0-9])\>)

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -81,7 +81,6 @@ _comp_cmd_valgrind()
                     return
                     ;;
                 \<command\>)
-                    compopt -o filenames
                     _comp_compgen_commands
                     return
                     ;;

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -54,7 +54,7 @@ _vpnc()
             ;;
         --password-helper)
             compopt -o filenames
-            _comp_compgen -- -c
+            _comp_compgen_commands
             return
             ;;
     esac

--- a/completions/vpnc
+++ b/completions/vpnc
@@ -53,7 +53,6 @@ _vpnc()
             return
             ;;
         --password-helper)
-            compopt -o filenames
             _comp_compgen_commands
             return
             ;;

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -137,3 +137,13 @@ to have completion for their contents, so the default is unset.
 
 Available since version 2.12.
 Deprecated alias: `COMP_TAR_INTERNAL_PATHS`
+
+## Shell options
+
+### `no_empty_cmd_completion`
+
+If on, completions producing command names do not do anything if the command to
+be completed is empty. This can be useful on systems where generating the
+entire list of commands takes a long time.
+
+Available since version 2.12.

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -2,6 +2,7 @@ EXTRA_DIST = \
 	test_unit_abspath.py \
 	test_unit_command_offset.py \
 	test_unit_compgen.py \
+	test_unit_compgen_commands.py \
 	test_unit_count_args.py \
 	test_unit_delimited.py \
 	test_unit_deprecate_func.py \

--- a/test/t/unit/test_unit_compgen_commands.py
+++ b/test/t/unit/test_unit_compgen_commands.py
@@ -1,0 +1,34 @@
+import pytest
+
+from conftest import assert_bash_exec, bash_env_saved
+
+
+@pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+COMPREPLY=")
+class TestUtilCompgenCommands:
+    @pytest.fixture(scope="class")
+    def functions(self, request, bash):
+        assert_bash_exec(
+            bash,
+            r"_comp_compgen_commands__test() {"
+            r"    local COMPREPLY=() cur=${1-};"
+            r"    _comp_compgen_commands;"
+            r'    printf "%s\n" "${COMPREPLY[@]}";'
+            r"}",
+        )
+
+    def test_basic(self, bash, functions):
+        output = assert_bash_exec(
+            bash, "_comp_compgen_commands__test sh", want_output=True
+        )
+        assert output.strip()
+
+    @pytest.mark.parametrize(
+        "shopt_no_empty,result_empty", ((True, True), (False, False))
+    )
+    def test_empty(self, bash, functions, shopt_no_empty, result_empty):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("no_empty_cmd_completion", shopt_no_empty)
+            output = assert_bash_exec(
+                bash, "_comp_compgen_commands__test", want_output=True
+            )
+        assert (output.strip() == "") == result_empty

--- a/test/t/unit/test_unit_compgen_commands.py
+++ b/test/t/unit/test_unit_compgen_commands.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import assert_bash_exec, bash_env_saved
+from conftest import assert_bash_exec, assert_complete, bash_env_saved
 
 
 @pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+COMPREPLY=")
@@ -14,6 +14,15 @@ class TestUtilCompgenCommands:
             r"    _comp_compgen_commands;"
             r'    printf "%s\n" "${COMPREPLY[@]}";'
             r"}",
+        )
+        assert_bash_exec(
+            bash,
+            "_comp_cmd_ccc() {"
+            "    local cur;"
+            "    _comp_get_words cur;"
+            "     unset -v COMPREPLY;"
+            "    _comp_compgen_commands;"
+            "}; complete -F _comp_cmd_ccc ccc",
         )
 
     def test_basic(self, bash, functions):
@@ -32,3 +41,7 @@ class TestUtilCompgenCommands:
                 bash, "_comp_compgen_commands__test", want_output=True
             )
         assert (output.strip() == "") == result_empty
+
+    def test_spaces(self, bash, functions):
+        completion = assert_complete(bash, "ccc shared/default/bar")
+        assert completion == r"\ bar.d/"

--- a/test/t/unit/test_unit_compgen_commands.py
+++ b/test/t/unit/test_unit_compgen_commands.py
@@ -12,7 +12,7 @@ class TestUtilCompgenCommands:
             r"_comp_compgen_commands__test() {"
             r"    local COMPREPLY=() cur=${1-};"
             r"    _comp_compgen_commands;"
-            r'    printf "%s\n" "${COMPREPLY[@]}";'
+            r'    printf "%s\n" "${COMPREPLY[@]-}";'
             r"}",
         )
         assert_bash_exec(


### PR DESCRIPTION
On some systems, generating the entire list of available commands takes a long time. `no_empty_cmd_completion` is semantically close enough to piggyback on it here.

Closes https://github.com/scop/bash-completion/issues/926