### PR TITLE
test(dcop): skip if basic invocation errors out

### DIFF
--- a/test/t/test_dcop.py
+++ b/test/t/test_dcop.py
@@ -2,6 +2,8 @@ import pytest
 
 
 class TestDcop:
-    @pytest.mark.complete("dcop ", require_cmd=True)
+    @pytest.mark.complete(
+        "dcop ", require_cmd=True, skipif="! dcop &>/dev/null"
+    )
     def test_1(self, completion):
         assert completion


### PR DESCRIPTION
It's highly unlikely that a DCOP server would be running in containers.