### PR TITLE
test(dpkg-query): xfail if `apt-cache show` fails

### DIFF
--- a/test/t/test_dpkg_query.py
+++ b/test/t/test_dpkg_query.py
@@ -13,6 +13,10 @@ class TestDpkgQuery:
         not os.path.exists("/etc/debian_version"),
         reason="Likely fails on systems not based on Debian",
     )
-    @pytest.mark.complete("dpkg-query -W dpk", require_cmd=True)
+    @pytest.mark.complete(
+        "dpkg-query -W dpk",
+        require_cmd=True,
+        xfail="! apt-cache show &>/dev/null",  # empty cache?
+    )
     def test_show(self, completion):
         assert "dpkg" in completion


### PR DESCRIPTION
For example with an empty cache it does.