### PR TITLE
fix(scp): `nounset` mode error on unknown suboption, bash 4.2

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -515,7 +515,7 @@ _comp_cmd_scp()
     _comp_cmd_ssh__configfile
 
     _comp_xfunc_ssh_suboption_check && {
-        COMPREPLY=("${COMPREPLY[@]/%/ }")
+        ((${#COMPREPLY[@]})) && COMPREPLY=("${COMPREPLY[@]/%/ }")
         return
     }
 


### PR DESCRIPTION
Another issue uncovered by work on #979 