### PR TITLE
fix: add misc fixes before `_comp_compgen_split`

### DIFF
--- a/completions/7z
+++ b/completions/7z
@@ -102,9 +102,9 @@ _comp_cmd_7z()
     else
         if [[ ${words[1]} == d ]]; then
             local IFS=$'\n'
-            COMPREPLY=($(compgen -W "$(printf '%s\n' "$("$1" l "${words[2]}" \
+            COMPREPLY=($(compgen -W "$("$1" l "${words[2]}" \
                 -slt 2>/dev/null | command sed -n '/^Path =/s/^Path = \(.*\)$/\1/p' \
-                2>/dev/null | tail -n+2)")" -- "$cur"))
+                2>/dev/null | tail -n+2)" -- "$cur"))
             compopt -o filenames
         else
             _comp_compgen_filedir

--- a/completions/curl
+++ b/completions/curl
@@ -156,8 +156,7 @@ _comp_cmd_curl()
 
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- --help all
-        [[ ${COMPREPLY-} ]] ||
-            COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        [[ ${COMPREPLY-} ]] || _comp_compgen_help
     fi
 } &&
     complete -F _comp_cmd_curl curl

--- a/completions/koji
+++ b/completions/koji
@@ -235,7 +235,7 @@ _comp_cmd_koji()
     fi
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$(_parse_help "$1")' -- "$cur"))
+        _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ ! $has_command ]]; then
         COMPREPLY=($(compgen -W '$("$1" --help-commands 2>/dev/null | \

--- a/completions/lspci
+++ b/completions/lspci
@@ -18,12 +18,12 @@ _comp_cmd_lspci()
             return
             ;;
         -*A)
-            COMPREPLY+=($(compgen -W '$("$1" -A help | command grep -vF :)' \
+            COMPREPLY=($(compgen -W '$("$1" -A help | command grep -vF :)' \
                 -- "$cur"))
             return
             ;;
         -*H)
-            _comp_compgen -a -- -W "1 2"
+            _comp_compgen -- -W "1 2"
             return
             ;;
         -*F)

--- a/completions/medusa
+++ b/completions/medusa
@@ -16,7 +16,7 @@ _comp_cmd_medusa()
             ;;
         -*M)
             COMPREPLY=($(compgen -W "$("$1" -d | awk '/^ +\+/ {print $2}' |
-                command sed -e 's/\.mod$//')"))
+                command sed -e 's/\.mod$//')" -- "$cur"))
             return
             ;;
     esac

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -37,7 +37,7 @@ _comp_cmd_pgrep()
             ;;
         --nslist)
             COMPREPLY=(
-                $(IFS="$IFS," compgen -W '$("$1" --help 2>&1 |
+                $(IFS=$' \t\n,' compgen -W '$("$1" --help 2>&1 |
                     command sed -ne \
                         "s/^[[:space:]]*Available namespaces://p")' \
                     -- "${cur##*,}"))

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -33,7 +33,7 @@ _comp_cmd_pydoc()
     COMPREPLY+=($(compgen -W \
         '$("$1" keywords topics | command sed -e /^Here/d)' -- "$cur"))
 
-    _comp_compgen_filedir py
+    _comp_compgen -a filedir py
 } &&
     complete -F _comp_cmd_pydoc pydoc pydoc3
 

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -30,7 +30,7 @@ _comp_cmd_reportbug()
             return
             ;;
         --tag | --ui | --interface | --type | --bts | --severity | --mode | -${noargopts}[TutBS])
-            COMPREPLY+=($(
+            COMPREPLY=($(
                 compgen -W \
                     '$("$1" "$prev" help 2>&1 | sed -ne "/^[[:space:]]/p")' \
                     -- "$cur"

--- a/completions/tar
+++ b/completions/tar
@@ -437,7 +437,7 @@ _comp_cmd_tar__try_list_archive()
                 while read -r line; do
                     printf "%q\n" "$(printf %q"\n" "$line")"
                 done
-        )" -- "$(printf "%q\n" "$cur")"))
+        )" -- "$(printf %q "$cur")"))
         return 0
     fi
 }


### PR DESCRIPTION
Before applying `_comp_compgen_split` mentioned in https://github.com/scop/bash-completion/issues/958#issuecomment-1537214890, I would like to add the following fixes that are overlapping with it.