### PR TITLE
feat(_comp_compgen_split): use `_comp_compgen_split` for `-W '$(...)'`

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1524,23 +1524,23 @@ _configured_interfaces()
         # Debian system
         _comp_expand_glob files '/etc/network/interfaces /etc/network/interfaces.d/*'
         ((${#files[@]})) || return 0
-        _comp_compgen -- -W "$(command sed -ne 's|^iface \([^ ]\{1,\}\).*$|\1|p' \
-            "${files[@]}" 2>/dev/null)"
+        _comp_compgen_split -- "$(command sed -ne \
+            's|^iface \([^ ]\{1,\}\).*$|\1|p' "${files[@]}" 2>/dev/null)"
     elif [[ -f /etc/SuSE-release ]]; then
         # SuSE system
         _comp_expand_glob files '/etc/sysconfig/network/ifcfg-*'
         ((${#files[@]})) || return 0
-        _comp_compgen -- -W "$(printf '%s\n' "${files[@]}" |
+        _comp_compgen_split -- "$(printf '%s\n' "${files[@]}" |
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')"
     elif [[ -f /etc/pld-release ]]; then
         # PLD Linux
-        _comp_compgen -- -W "$(command ls -B /etc/sysconfig/interfaces |
+        _comp_compgen_split -- "$(command ls -B /etc/sysconfig/interfaces |
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')"
     else
         # Assume Red Hat
         _comp_expand_glob files '/etc/sysconfig/network-scripts/ifcfg-*'
         ((${#files[@]})) || return 0
-        _comp_compgen -- -W "$(printf '%s\n' "${files[@]}" |
+        _comp_compgen_split -- "$(printf '%s\n' "${files[@]}" |
             command sed -ne 's|.*ifcfg-\([^*].*\)$|\1|p')"
     fi
 }
@@ -1889,7 +1889,7 @@ _modules()
 {
     local modpath
     modpath=/lib/modules/$1
-    _comp_compgen -- -W "$(command ls -RL "$modpath" 2>/dev/null |
+    _comp_compgen_split -- "$(command ls -RL "$modpath" 2>/dev/null |
         command sed -ne 's/^\(.*\)\.k\{0,1\}o\(\.[gx]z\)\{0,1\}$/\1/p' \
             -e 's/^\(.*\)\.ko\.zst$/\1/p')"
 }
@@ -1899,7 +1899,7 @@ _modules()
 # TODO:API: rename per conventions (+ include "kernel" in the name)
 _installed_modules()
 {
-    _comp_compgen -c "$1" -- -W "$(PATH="$PATH:/sbin" lsmod |
+    _comp_compgen -c "$1" split -- "$(PATH="$PATH:/sbin" lsmod |
         awk '{if (NR != 1) print $1}')"
 }
 
@@ -1961,8 +1961,8 @@ _allowed_users()
     if _complete_as_root; then
         _comp_compgen -c "${1:-$cur}" -- -u
     else
-        _comp_compgen -c "${1:-$cur}" -- -W \
-            "$(id -un 2>/dev/null || whoami 2>/dev/null)"
+        _comp_compgen -c "${1:-$cur}" split -- "$(id -un 2>/dev/null ||
+            whoami 2>/dev/null)"
     fi
 }
 
@@ -1972,8 +1972,8 @@ _allowed_groups()
     if _complete_as_root; then
         _comp_compgen -c "$1" -- -g
     else
-        _comp_compgen -c "$1" -- -W \
-            "$(id -Gn 2>/dev/null || groups 2>/dev/null)"
+        _comp_compgen -c "$1" split -- "$(id -Gn 2>/dev/null ||
+            groups 2>/dev/null)"
     fi
 }
 
@@ -2107,7 +2107,8 @@ _count_args()
 # TODO:API: rename per conventions
 _pci_ids()
 {
-    _comp_compgen -a -- -W "$(PATH="$PATH:/sbin" lspci -n | awk '{print $3}')"
+    _comp_compgen -a split -- "$(PATH="$PATH:/sbin" lspci -n |
+        awk '{print $3}')"
 }
 
 # This function completes on USB IDs
@@ -2115,7 +2116,7 @@ _pci_ids()
 # TODO:API: rename per conventions
 _usb_ids()
 {
-    _comp_compgen -a -- -W "$(PATH="$PATH:/sbin" lsusb | awk '{print $6}')"
+    _comp_compgen -a split -- "$(PATH="$PATH:/sbin" lsusb | awk '{print $6}')"
 }
 
 # CD device names
@@ -2136,7 +2137,7 @@ _dvd_devices()
 # TODO:API: rename per conventions
 _terms()
 {
-    _comp_compgen -a -- -W "$({
+    _comp_compgen -a split -- "$({
         command sed -ne 's/^\([^[:space:]#|]\{2,\}\)|.*/\1/p' /etc/termcap
         {
             toe -a || toe
@@ -2694,7 +2695,7 @@ _comp_longopt()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen -- -W "$(LC_ALL=C $1 --help 2>&1 |
+        _comp_compgen_split -- "$(LC_ALL=C $1 --help 2>&1 |
             while read -r line; do
                 [[ $line =~ --[A-Za-z0-9]+([-_][A-Za-z0-9]+)*=? ]] &&
                     printf '%s\n' "${BASH_REMATCH[0]}"

--- a/bash_completion
+++ b/bash_completion
@@ -633,6 +633,46 @@ _comp_compgen_set()
     eval -- "$_var${_append:++}=(\"\$@\")"
 }
 
+# Simply split the text and generate completions.  This function should be used
+# instead of `_comp_compgen -- -W "$(command)"`, which is vulnerable because
+# option -W evaluates the shell expansions included in the option argument.
+# Options:
+#   -F sep  Specify the separators. The default is $' \t\n'
+#   -l      The same as -F $'\n'
+#   -X arg  The same as the compgen option -X.
+#   -S arg  The same as the compgen option -S.
+#   -P arg  The same as the compgen option -P.
+#   -o arg  The same as the compgen option -o.
+# @param $1 String to split
+# @since 2.12
+_comp_compgen_split()
+{
+    local _ifs=$' \t\n'
+    local -a _compgen_options=()
+
+    local OPTIND=1 OPTARG="" OPTERR=0 _opt
+    while getopts ':lF:X:S:P:o:' _opt "$@"; do
+        case $_opt in
+            l) _ifs=$'\n' ;;
+            F) _ifs=$OPTARG ;;
+            [XSPo]) _compgen_options+=("-$_opt" "$OPTARG") ;;
+            *)
+                printf 'bash_completion: usage: %s [-l|-F sep] [--] str\n' "$FUNCNAME" >&2
+                return 2
+                ;;
+        esac
+    done
+    shift "$((OPTIND - 1))"
+    if (($# != 1)); then
+        printf 'bash_completion: %s: unexpected number of arguments.\n' "$FUNCNAME" >&2
+        printf 'usage: %s [-l|-F sep] [--] str' "$FUNCNAME" >&2
+        return 2
+    fi
+
+    local _split_input=$1
+    _comp_compgen -F "$_ifs" -- "${_compgen_options[@]}" -W '$_split_input'
+}
+
 # Check if the argument looks like a path.
 # @param $1 thing to check
 # @return True (0) if it does, False (> 0) otherwise

--- a/bash_completion
+++ b/bash_completion
@@ -669,8 +669,8 @@ _comp_compgen_split()
         return 2
     fi
 
-    local _split_input=$1
-    _comp_compgen -F "$_ifs" -- "${_compgen_options[@]}" -W '$_split_input'
+    local _split_input=$1 IFS=$' \t\n'
+    _comp_compgen -F "$_ifs" -- ${_compgen_options[@]+"${_compgen_options[@]}"} -W '$_split_input'
 }
 
 # Check if the argument looks like a path.

--- a/bash_completion
+++ b/bash_completion
@@ -1824,7 +1824,7 @@ _service()
         _comp_sysvdirs
         _comp_compgen -l -- -W '$(command sed -e "y/|/ /" \
             -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
-            ${sysvdirs[0]}/${prev##*/} 2>/dev/null) start stop'
+            "${sysvdirs[0]}/${prev##*/}" 2>/dev/null) start stop'
     fi
 } &&
     complete -F _service service

--- a/bash_completion
+++ b/bash_completion
@@ -1183,7 +1183,7 @@ _comp_variable_assignments()
             _terms
             ;;
         LANG | LC_*)
-            _comp_compgen -- -W '$(locale -a 2>/dev/null)'
+            _comp_compgen_split -- "$(locale -a 2>/dev/null)"
             ;;
         LANGUAGE)
             _comp_delimited : -W '$(locale -a 2>/dev/null)'
@@ -1576,7 +1576,7 @@ _ip_addresses()
 # TODO:API: rename per conventions
 _kernel_versions()
 {
-    _comp_compgen -- -W '$(command ls /lib/modules)'
+    _comp_compgen_split -- "$(command ls /lib/modules)"
 }
 
 # This function completes on all available network interfaces
@@ -1694,26 +1694,26 @@ if [[ $OSTYPE == *@(solaris|aix)* ]]; then
     # This function completes on process IDs.
     _pids()
     {
-        _comp_compgen -- -W '$(command ps -efo pid | command sed 1d)'
+        _comp_compgen_split -- "$(command ps -efo pid | command sed 1d)"
     }
 
     _pgids()
     {
-        _comp_compgen -- -W '$(command ps -efo pgid | command sed 1d)'
+        _comp_compgen_split -- "$(command ps -efo pgid | command sed 1d)"
     }
     _pnames()
     {
-        _comp_compgen -- -X '<defunct>' -W '$(command ps -efo comm | \
-            command sed -e 1d -e "s:.*/::" -e "s/^-//" | sort -u)'
+        _comp_compgen_split -X '<defunct>' -- "$(command ps -efo comm |
+            command sed -e 1d -e 's:.*/::' -e 's/^-//' | sort -u)"
     }
 else
     _pids()
     {
-        _comp_compgen -- -W '$(command ps ax -o pid=)'
+        _comp_compgen_split -- "$(command ps ax -o pid=)"
     }
     _pgids()
     {
-        _comp_compgen -- -W '$(command ps ax -o pgid=)'
+        _comp_compgen_split -- "$(command ps ax -o pgid=)"
     }
     # @param $1 if -s, don't try to avoid truncated command names
     _pnames()
@@ -1772,12 +1772,12 @@ fi
 _uids()
 {
     if type getent &>/dev/null; then
-        _comp_compgen -- -W '$(getent passwd | cut -d: -f3)'
+        _comp_compgen_split -- "$(getent passwd | cut -d: -f3)"
     elif type perl &>/dev/null; then
-        _comp_compgen -- -W '$(perl -e '"'"'while (($uid) = (getpwent)[2]) { print $uid . "\n" }'"'"')'
+        _comp_compgen_split -- "$(perl -e 'while (($uid) = (getpwent)[2]) { print $uid . "\n" }')"
     else
         # make do with /etc/passwd
-        _comp_compgen -- -W '$(cut -d: -f3 /etc/passwd)'
+        _comp_compgen_split -- "$(cut -d: -f3 /etc/passwd)"
     fi
 }
 
@@ -1787,12 +1787,12 @@ _uids()
 _gids()
 {
     if type getent &>/dev/null; then
-        _comp_compgen -- -W '$(getent group | cut -d: -f3)'
+        _comp_compgen_split -- "$(getent group | cut -d: -f3)"
     elif type perl &>/dev/null; then
-        _comp_compgen -- -W '$(perl -e '"'"'while (($gid) = (getgrent)[2]) { print $gid . "\n" }'"'"')'
+        _comp_compgen_split -- "$(perl -e 'while (($gid) = (getgrent)[2]) { print $gid . "\n" }')"
     else
         # make do with /etc/group
-        _comp_compgen -- -W '$(cut -d: -f3 /etc/group)'
+        _comp_compgen_split -- "$(cut -d: -f3 /etc/group)"
     fi
 }
 
@@ -1862,9 +1862,9 @@ _service()
     else
         local sysvdirs
         _comp_sysvdirs
-        _comp_compgen -l -- -W '$(command sed -e "y/|/ /" \
-            -ne "s/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p" \
-            "${sysvdirs[0]}/${prev##*/}" 2>/dev/null) start stop'
+        _comp_compgen_split -l -- "$(command sed -e 'y/|/ /' \
+            -ne 's/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p' \
+            "${sysvdirs[0]}/${prev##*/}" 2>/dev/null) start stop"
     fi
 } &&
     complete -F _service service
@@ -1980,9 +1980,8 @@ _allowed_groups()
 # @since 2.12
 _comp_selinux_users()
 {
-    _comp_compgen -a -- -W '$(
-        semanage user -nl 2>/dev/null | awk "{ print \$1 }"
-    )'
+    _comp_compgen -a split -- "$(semanage user -nl 2>/dev/null |
+        awk '{ print $1 }')"
 }
 
 # This function completes on valid shells

--- a/completions/2to3
+++ b/completions/2to3
@@ -10,8 +10,9 @@ _comp_cmd_2to3()
             return
             ;;
         -f | --fix | -x | --nofix)
-            COMPREPLY=($(compgen -W \
-                "$("$1" --list-fixes 2>/dev/null | command sed -e 1d)" -- "$cur"))
+            _comp_compgen_split -- "$(
+                "$1" --list-fixes 2>/dev/null | command sed -e 1d
+            )"
             return
             ;;
         -j | --processes)

--- a/completions/7z
+++ b/completions/7z
@@ -101,10 +101,10 @@ _comp_cmd_7z()
             _comp_compgen -a filedir '@(7z?(.001)|arj|bz2|cab|cb7|chm|cpio|deb|dmg|flv|gem|img|iso|lz[ah]|lzma?(86)|msi|pmd|[rx]ar|rpm|sw[fm]|?(g)tar|taz|?(t)[bglx]z|tb?(z)2|vhd|wim|Z)'
     else
         if [[ ${words[1]} == d ]]; then
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -W "$("$1" l "${words[2]}" \
-                -slt 2>/dev/null | command sed -n '/^Path =/s/^Path = \(.*\)$/\1/p' \
-                2>/dev/null | tail -n+2)" -- "$cur"))
+            _comp_compgen_split -l -- "$(
+                "$1" l "${words[2]}" -slt 2>/dev/null | command sed -n \
+                    '/^Path =/s/^Path = \(.*\)$/\1/p' 2>/dev/null | tail -n+2
+            )"
             compopt -o filenames
         else
             _comp_compgen_filedir

--- a/completions/_look
+++ b/completions/_look
@@ -9,7 +9,7 @@ _comp_cmd_look()
     _comp_initialize -- "$@" || return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W '$(look "$cur" 2>/dev/null)' -- "$cur"))
+        _comp_compgen_split -- "$(look "$cur" 2>/dev/null)"
     fi
 } &&
     complete -F _comp_cmd_look -o default look

--- a/completions/_mock
+++ b/completions/_mock
@@ -27,7 +27,7 @@ _comp_cmd_mock()
             return
             ;;
         -r | --root)
-            COMPREPLY=($(compgen -W "$(command ls "$cfgdir")" -- "$cur"))
+            _comp_compgen_split -- "$(command ls "$cfgdir")"
             COMPREPLY=(${COMPREPLY[@]/%.cfg/})
             return
             ;;
@@ -44,9 +44,8 @@ _comp_cmd_mock()
             # (e.g. ix86 chroot builds in x86_64 mock host)
             # This would actually depend on what the target root
             # can be used to build for...
-            COMPREPLY=($(compgen -W "$(command rpm --showrc |
-                command sed -ne 's/^\s*compatible\s\s*archs\s*:\s*\(.*\)/\1/i p')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$(command rpm --showrc | command sed -ne \
+                's/^\s*compatible\s\s*archs\s*:\s*\(.*\)/\1/i p')"
             return
             ;;
         --enable-plugin | --disable-plugin)

--- a/completions/_mount
+++ b/completions/_mount
@@ -33,8 +33,9 @@ _comp_cmd_mount()
     if [[ $cur == *:* ]]; then
         for sm in "$(type -P showmount)" {,/usr}/{,s}bin/showmount; do
             [[ -x $sm ]] || continue
-            COMPREPLY=($(compgen -W "$("$sm" -e ${cur%%:*} |
-                awk 'NR>1 {print $1}')" -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" split -- "$(
+                "$sm" -e ${cur%%:*} | awk 'NR>1 {print $1}'
+            )"
             return
         done
     fi
@@ -43,21 +44,27 @@ _comp_cmd_mount()
         host=${cur#//}
         host=${host%%/*}
         if [[ $host ]]; then
-            COMPREPLY=($(compgen -P "//$host" -W \
-                "$(smbclient -d 0 -NL "$host" 2>/dev/null |
+            _comp_compgen -c "${cur#//"$host"}" split -P "//$host" -- "$(
+                smbclient -d 0 -NL "$host" 2>/dev/null |
                     command sed -ne '/^[[:blank:]]*Sharename/,/^$/p' |
-                    command sed -ne '3,$s|^[^A-Za-z]*\([^[:blank:]]*\).*$|/\1|p')" \
-                -- "${cur#//"$host"}"))
+                    command sed -ne '3,$s|^[^A-Za-z]*\([^[:blank:]]*\).*$|/\1|p'
+            )"
         fi
     elif [[ -r /etc/vfstab ]]; then
         # Solaris
-        COMPREPLY=($(compgen -W "$(awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}' /etc/vfstab)" -- "$cur"))
+        _comp_compgen_split -- "$(
+            awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}' /etc/vfstab
+        )"
     elif [[ ! -e /etc/fstab ]]; then
         # probably Cygwin
-        COMPREPLY=($(compgen -W "$("$1" | awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}')" -- "$cur"))
+        _comp_compgen_split -- "$(
+            "$1" | awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}'
+        )"
     else
         # probably BSD
-        COMPREPLY=($(compgen -W "$(awk '! /^[ \t]*#/ {if ($2 ~ /\//) print $2}' /etc/fstab)" -- "$cur"))
+        _comp_compgen_split -- "$(
+            awk '! /^[ \t]*#/ {if ($2 ~ /\//) print $2}' /etc/fstab
+        )"
     fi
 } &&
     complete -F _comp_cmd_mount -o default -o dirnames mount

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -223,8 +223,9 @@ _comp_cmd_mount()
     if [[ $cur == *:* ]]; then
         for sm in "$(type -P showmount)" {,/usr}/{,s}bin/showmount; do
             [[ -x $sm ]] || continue
-            COMPREPLY=($(compgen -W "$("$sm" -e ${cur%%:*} |
-                awk 'NR>1 {print $1}')" -- "${cur#*:}"))
+            _comp_compgen -c "${cur#*:}" split -- "$(
+                "$sm" -e ${cur%%:*} | awk 'NR>1 {print $1}'
+            )"
             return
         done
     fi
@@ -233,11 +234,11 @@ _comp_cmd_mount()
         host=${cur#//}
         host=${host%%/*}
         if [[ $host ]]; then
-            COMPREPLY=($(compgen -P "//$host" -W \
-                "$(smbclient -d 0 -NL "$host" 2>/dev/null |
+            _comp_compgen -c "${cur#//"$host"}" split -P "//$host" -- "$(
+                smbclient -d 0 -NL "$host" 2>/dev/null |
                     command sed -ne '/^[[:blank:]]*Sharename/,/^$/p' |
-                    command sed -ne '3,$s|^[^A-Za-z]*\([^[:blank:]]*\).*$|/\1|p')" \
-                -- "${cur#//"$host"}"))
+                    command sed -ne '3,$s|^[^A-Za-z]*\([^[:blank:]]*\).*$|/\1|p'
+            )"
         fi
     fi
 

--- a/completions/_nmcli
+++ b/completions/_nmcli
@@ -3,11 +3,6 @@
 # Use of this file is deprecated.  Upstream completion is available in
 # NetworkManager >= 0.9.8.0, use that instead.
 
-_comp_cmd_nmcli__list()
-{
-    _comp_compgen -- -W '$1'
-}
-
 _comp_cmd_nmcli__con_id()
 {
     local IFS=$'\n'
@@ -49,7 +44,7 @@ _comp_cmd_nmcli()
             return
             ;;
         -e | --escape)
-            _comp_cmd_nmcli__list "yes no"
+            _comp_compgen -- -W "yes no"
             return
             ;;
         id)
@@ -69,7 +64,7 @@ _comp_cmd_nmcli()
             return
             ;;
         wep-key-type)
-            _comp_cmd_nmcli__list "key phrase"
+            _comp_compgen -- -W "key phrase"
             return
             ;;
     esac
@@ -89,23 +84,23 @@ _comp_cmd_nmcli()
             nm)
                 case $command in
                     enable)
-                        _comp_cmd_nmcli__list "true false"
+                        _comp_compgen -- -W "true false"
                         return
                         ;;
                     sleep)
-                        _comp_cmd_nmcli__list "true false"
+                        _comp_compgen -- -W "true false"
                         return
                         ;;
                     wifi)
-                        _comp_cmd_nmcli__list "on off"
+                        _comp_compgen -- -W "on off"
                         return
                         ;;
                     wwan)
-                        _comp_cmd_nmcli__list "on off"
+                        _comp_compgen -- -W "on off"
                         return
                         ;;
                     wimax)
-                        _comp_cmd_nmcli__list "on off"
+                        _comp_compgen -- -W "on off"
                         return
                         ;;
                 esac

--- a/completions/_nmcli
+++ b/completions/_nmcli
@@ -5,28 +5,26 @@
 
 _comp_cmd_nmcli__con_id()
 {
-    local IFS=$'\n'
-    COMPREPLY=($(compgen -W "$(nmcli con list 2>/dev/null |
-        tail -n +2 | awk -F ' {2,}' '{print $1 }')" -- "$cur"))
+    _comp_compgen_split -l -- "$(nmcli con list 2>/dev/null |
+        tail -n +2 | awk -F ' {2,}' '{print $1 }')"
 }
 
 _comp_cmd_nmcli__con_uuid()
 {
-    COMPREPLY=($(compgen -W "$(nmcli con list 2>/dev/null |
-        tail -n +2 | awk -F ' {2,}' '{print $2}')" -- "$cur"))
+    _comp_compgen_split -- "$(nmcli con list 2>/dev/null |
+        tail -n +2 | awk -F ' {2,}' '{print $2}')"
 }
 
 _comp_cmd_nmcli__ap_ssid()
 {
-    local IFS=$'\n'
-    COMPREPLY=($(compgen -W "$(nmcli dev wifi list 2>/dev/null |
-        tail -n +2 | awk -F ' {2,}' '{print $1}')" -- "$cur"))
+    _comp_compgen_split -l -- "$(nmcli dev wifi list 2>/dev/null |
+        tail -n +2 | awk -F ' {2,}' '{print $1}')"
 }
 
 _comp_cmd_nmcli__ap_bssid()
 {
-    COMPREPLY=($(compgen -W "$(nmcli dev wifi list 2>/dev/null |
-        tail -n +2 | awk -F ' {2,}' '{print $2}')" -- "$cur"))
+    _comp_compgen_split -- "$(nmcli dev wifi list 2>/dev/null |
+        tail -n +2 | awk -F ' {2,}' '{print $2}')"
 }
 
 _comp_cmd_nmcli()

--- a/completions/_rfkill
+++ b/completions/_rfkill
@@ -17,9 +17,9 @@ _comp_cmd_rfkill()
                 ;;
             2)
                 if [[ $prev == block || $prev == unblock ]]; then
-                    COMPREPLY=($(compgen -W "$("$1" list | awk -F: \
-                        '/^[0-9]/ {print $1}') all wifi bluetooth uwb wimax \
-                        wwan gps" -- "$cur"))
+                    _comp_compgen_split -- "$("$1" list |
+                        awk -F: '/^[0-9]/ {print $1}') all wifi bluetooth uwb
+                        wimax wwan gps"
                 fi
                 ;;
         esac

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -58,8 +58,8 @@ _comp_cmd_udevadm()
                 _comp_compgen -- -W '--help --version --debug'
                 ;;
             *)
-                COMPREPLY=($(compgen -W "$("$1" --help 2>/dev/null |
-                    awk '/^[ \t]/ { print $1 }')" -- "$cur"))
+                _comp_compgen_split -- "$("$1" --help 2>/dev/null |
+                    awk '/^[ \t]/ { print $1 }')"
                 ;;
         esac
         return

--- a/completions/_umount
+++ b/completions/_umount
@@ -16,8 +16,7 @@ _comp_cmd_umount()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local IFS=$'\n'
-    COMPREPLY=($(compgen -W '$(mount | cut -d" " -f 3)' -- "$cur"))
+    _comp_compgen_split -l -- "$(mount | cut -d" " -f 3)"
 } &&
     complete -F _comp_cmd_umount -o dirnames umount
 

--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -130,8 +130,7 @@ _comp_cmd_umount()
         # unmounting usb devices with pretty names.
         _comp_cmd_umount__linux_fstab </proc/mounts
     else
-        local IFS=$'\n'
-        COMPREPLY=($(compgen -W '$(mount | cut -d" " -f 3)' -- "$cur"))
+        _comp_compgen_split -l -- "$(mount | cut -d" " -f 3)"
     fi
 } &&
     complete -F _comp_cmd_umount -o dirnames umount

--- a/completions/_xm
+++ b/completions/_xm
@@ -6,8 +6,8 @@
 
 _comp_cmd_xm__domain_names()
 {
-    COMPREPLY=($(compgen -W "$(xm list 2>/dev/null |
-        awk '!/Name|Domain-0/ { print $1 }')" -- "$cur"))
+    _comp_compgen_split -- "$(xm list 2>/dev/null |
+        awk '!/Name|Domain-0/ { print $1 }')"
 }
 
 _comp_cmd_xm()
@@ -146,9 +146,8 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         3)
-                            COMPREPLY=($(compgen -W "$(xm block-list "$prev" \
-                                2>/dev/null | awk '!/Vdev/ { print $1 }')" \
-                                -- "$cur"))
+                            _comp_compgen_split -- "$(xm block-list "$prev" \
+                                2>/dev/null | awk '!/Vdev/ { print $1 }')"
                             ;;
                     esac
                     ;;
@@ -171,9 +170,8 @@ _comp_cmd_xm()
                             _comp_cmd_xm__domain_names
                             ;;
                         3)
-                            COMPREPLY=($(compgen -W "$(xm network-list "$prev" \
-                                2>/dev/null | awk '!/Idx/ { print $1 }')" \
-                                -- "$cur"))
+                            _comp_compgen_split -- "$(xm network-list "$prev" \
+                                2>/dev/null | awk '!/Idx/ { print $1 }')"
                             ;;
                     esac
                     ;;

--- a/completions/_xm
+++ b/completions/_xm
@@ -185,9 +185,9 @@ _comp_cmd_xm()
                     ;;
                 create)
                     _comp_compgen_filedir
-                    COMPREPLY+=(
-                        $(compgen -W '$(command ls /etc/xen 2>/dev/null)' \
-                            -- "$cur"))
+                    _comp_compgen -a split -- "$(
+                        command ls /etc/xen 2>/dev/null
+                    )"
                     ;;
                 new)
                     case $prev in

--- a/completions/_yum
+++ b/completions/_yum
@@ -105,17 +105,16 @@ _comp_cmd_yum()
             _comp_compgen_filedir -d
             ;;
         --enablerepo)
-            COMPREPLY=($(compgen -W '$(_yum_repolist disabled)' -- "$cur"))
+            _comp_compgen_split -- "$(_yum_repolist disabled)"
             ;;
         --disablerepo)
-            COMPREPLY=($(compgen -W '$(_yum_repolist enabled)' -- "$cur"))
+            _comp_compgen_split -- "$(_yum_repolist enabled)"
             ;;
         --disableexcludes)
-            COMPREPLY=($(compgen -W '$(_yum_repolist all) all main' \
-                -- "$cur"))
+            _comp_compgen_split -- "$(_yum_repolist all) all main"
             ;;
         --enableplugin | --disableplugin)
-            COMPREPLY=($(compgen -W '$(_yum_plugins)' -- "$cur"))
+            _comp_compgen_split -- "$(_yum_plugins)"
             ;;
         --color)
             _comp_compgen -- -W 'always auto never'

--- a/completions/abook
+++ b/completions/abook
@@ -22,14 +22,12 @@ _comp_cmd_abook()
 
     case $prev in
         --informat)
-            COMPREPLY=($(compgen -W "$("$1" --formats |
-                command sed -n -e 's/^'$'\t''\([a-z]*\).*/\1/p' -e '/^$/q')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --formats |
+                command sed -n -e 's/^'$'\t''\([a-z]*\).*/\1/p' -e '/^$/q')"
             ;;
         --outformat)
-            COMPREPLY=($(compgen -W "$("$1" --formats |
-                command sed -n -e '/^$/,$s/^'$'\t''\([a-z]*\).*/\1/p')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --formats |
+                command sed -n -e '/^$/,$s/^'$'\t''\([a-z]*\).*/\1/p')"
             ;;
         --infile)
             _comp_compgen -- -W stdin

--- a/completions/appdata-validate
+++ b/completions/appdata-validate
@@ -10,9 +10,8 @@ _comp_cmd_appdata_validate()
             return
             ;;
         --output-format)
-            COMPREPLY=($(compgen -W "$("$1" --help |
-                command sed -ne 's/--output-format.*\[\(.*\)\]/\1/' -e 's/|/ /gp')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --help | command sed -ne \
+                's/--output-format.*\[\(.*\)\]/\1/' -e 's/|/ /gp')"
             return
             ;;
     esac

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -25,8 +25,10 @@ _comp_xfunc_apt_cache_sources()
 # TODO:API: rework to use vars rather than outputting
 _comp_cmd_apt_cache__sources()
 {
-    compgen -W "$("$1" dumpavail |
-        awk '$1 == "Source:" { print $2 }' | sort -u)" -- "$2"
+    local ret
+    _comp_compgen -c "$2" -v ret split -- "$("$1" dumpavail |
+        awk '$1 == "Source:" { print $2 }' | sort -u)" &&
+        printf '%s\n' "${ret[@]}"
 }
 
 # List APT source packages

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -36,7 +36,10 @@ _comp_cmd_apt_cache__sources()
 # @since 2.12
 _comp_xfunc_apt_cache_src_packages()
 {
-    compgen -W '$(_comp_cmd_apt_cache__sources apt-cache "$cur")' -- "$cur"
+    local ret
+    _comp_compgen -v ret split -- \
+        "$(_comp_cmd_apt_cache__sources apt-cache "$cur")" &&
+        printf '%s\n' "${ret[@]}"
 }
 
 _comp_deprecate_func 2.12 _apt_cache_packages _comp_xfunc_apt_cache_packages

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -37,9 +37,9 @@ _comp_cmd_apt_get()
                 # Prefer `apt-cache` in the same dir as command
                 local pathcmd
                 pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
-                COMPREPLY=($(_comp_xfunc apt-cache packages)
-                $(compgen -W "$(apt-cache dumpavail |
-                    awk '$1 == "Source:" { print $2 }' | sort -u)" -- "$cur"))
+                COMPREPLY=($(_comp_xfunc apt-cache packages))
+                _comp_compgen -a split -- "$(apt-cache dumpavail |
+                    awk '$1 == "Source:" { print $2 }' | sort -u)"
                 ;;
             install | reinstall)
                 if _comp_looks_like_path "$cur"; then
@@ -48,13 +48,12 @@ _comp_cmd_apt_get()
                 elif [[ $cur == *=* ]]; then
                     package="${cur%%=*}"
                     cur="${cur#*=}"
-                    COMPREPLY=($(IFS=$'\n' compgen -W "$(
+                    _comp_compgen_split -l -- "$(
                         apt-cache --no-generate madison "$package" 2>/dev/null |
                             while IFS=' |' read -r _ version _; do
                                 echo "$version"
                             done
-                    )" \
-                        -- "$cur"))
+                    )"
                     _comp_ltrim_colon_completions "$cur"
                     return
                 fi
@@ -84,9 +83,8 @@ _comp_cmd_apt_get()
             # Prefer `apt-cache` in the same dir as command
             local pathcmd
             pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
-            COMPREPLY=($(compgen -W "$(apt-cache policy | command sed -ne \
-                's/^ *release.*[ ,]o=\(Debian\|Ubuntu\),a=\(\w*\).*/\2/p')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$(apt-cache policy | command sed -ne \
+                's/^ *release.*[ ,]o=\(Debian\|Ubuntu\),a=\(\w*\).*/\2/p')"
             return
             ;;
     esac

--- a/completions/apt-mark
+++ b/completions/apt-mark
@@ -18,9 +18,7 @@ _comp_cmd_apt_mark()
             auto | manual | unhold)
                 local -A showcmds=([auto]=manual [manual]=auto [unhold]=hold)
                 local showcmd=${showcmds[$special]}
-                COMPREPLY=($(
-                    compgen -W "$("$1" "show$showcmd" 2>/dev/null)" -- "$cur"
-                ))
+                _comp_compgen_split -- "$("$1" "show$showcmd" 2>/dev/null)"
                 return
                 ;;
             minimize-manual)

--- a/completions/aspell
+++ b/completions/aspell
@@ -35,8 +35,8 @@ _comp_cmd_aspell()
             return
             ;;
         --mode)
-            COMPREPLY=($(compgen -W "$("$1" modes 2>/dev/null |
-                awk '{ print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" modes 2>/dev/null |
+                awk '{ print $1 }')"
             return
             ;;
         --sug-mode)
@@ -52,8 +52,8 @@ _comp_cmd_aspell()
             return
             ;;
         --add-filter | --rem-filter)
-            COMPREPLY=($(compgen -W "$("$1" filters 2>/dev/null |
-                awk '{ print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" filters 2>/dev/null |
+                awk '{ print $1 }')"
             return
             ;;
     esac

--- a/completions/avahi-browse
+++ b/completions/avahi-browse
@@ -34,7 +34,7 @@ _comp_cmd_avahi_browse()
                 ;;
         esac
     done
-    COMPREPLY=($(compgen -W '$("$1" --dump-db --no-db-lookup)' -- "$cur"))
+    _comp_compgen_split -- "$("$1" --dump-db --no-db-lookup)"
 
 } &&
     complete -F _comp_cmd_avahi_browse avahi-browse avahi-browse-domains

--- a/completions/bind
+++ b/completions/bind
@@ -19,7 +19,7 @@ _comp_cmd_bind()
             return
             ;;
         -*[qu])
-            COMPREPLY=($(compgen -W '$("$1" -l)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" -l)"
             return
             ;;
     esac

--- a/completions/brctl
+++ b/completions/brctl
@@ -18,8 +18,8 @@ _comp_cmd_brctl()
                 show) ;;
 
                 *)
-                    COMPREPLY=($(compgen -W "$("$1" show |
-                        awk 'NR>1 {print $1}')" -- "$cur"))
+                    _comp_compgen_split -- "$("$1" show |
+                        awk 'NR>1 {print $1}')"
                     ;;
             esac
             ;;

--- a/completions/bts
+++ b/completions/bts
@@ -18,7 +18,8 @@ _comp_cmd_bts__cached_bugs()
 _comp_cmd_bts__src_packages_with_prefix()
 {
     local ppn=${cur:4} # partial package name, after stripping "src:"
-    _comp_compgen -ac "$ppn" -- -P "src:" -W '$(_comp_xfunc apt-cache sources "$ppn")'
+    _comp_compgen -ac "$ppn" split -P "src:" -- \
+        "$(_comp_xfunc apt-cache sources "$ppn")"
 }
 
 _comp_cmd_bts()

--- a/completions/cancel
+++ b/completions/cancel
@@ -19,8 +19,7 @@ _comp_cmd_cancel()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W \
-        "$(lpstat 2>/dev/null | cut -d' ' -f1)" -- "$cur"))
+    _comp_compgen_split -- "$(lpstat 2>/dev/null | cut -d' ' -f1)"
 } &&
     complete -F _comp_cmd_cancel cancel
 

--- a/completions/ccache
+++ b/completions/ccache
@@ -22,8 +22,8 @@ _comp_cmd_ccache()
             ;;
         --set-config | -${noargopts}o)
             if [[ $cur != *=* ]]; then
-                COMPREPLY=($(compgen -S = -W "$("$1" -p 2>/dev/null |
-                    awk '$3 = "=" { print $2 }')" -- "$cur"))
+                _comp_compgen_split -S = -- "$("$1" -p 2>/dev/null |
+                    awk '$3 = "=" { print $2 }')"
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             fi
             return

--- a/completions/ccze
+++ b/completions/ccze
@@ -29,9 +29,8 @@ _comp_cmd_ccze()
             return
             ;;
         --plugin | -${noargopts}p)
-            COMPREPLY=($(compgen -W '$("$1" --list-plugins | command \
-                sed -ne "s/^\([a-z0-9]\{1,\}\)[[:space:]]\{1,\}|.*/\1/p")' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-plugins | command \
+                sed -ne 's/^\([a-z0-9]\{1,\}\)[[:space:]]\{1,\}|.*/\1/p')"
             return
             ;;
     esac

--- a/completions/cfrun
+++ b/completions/cfrun
@@ -33,8 +33,8 @@ _comp_cmd_cfrun()
                 done
                 [[ ! -f $hostfile ]] && return
 
-                COMPREPLY=($(compgen -W "$(command grep -v \
-                    -E '(=|^$|^#)' "$hostfile")" -- "$cur"))
+                _comp_compgen_split -- "$(command grep -v -E '(=|^$|^#)' \
+                    "$hostfile")"
             fi
             ;;
         2)

--- a/completions/checksec
+++ b/completions/checksec
@@ -26,18 +26,12 @@ _comp_cmd_checksec()
             return
             ;;
         --format)
-            COMPREPLY=($(compgen -W '$("$1" --help 2>/dev/null |
-                command sed \
-                     -e "s/[{,}]/ /g" \
-                    -ne "s/^[[:space:]]*--format=//p"
-                )' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --help 2>/dev/null |
+                command sed -ne 's/[{,}]/ /g;s/^[[:space:]]*--format=//p')"
             ;;
         --output)
-            COMPREPLY=($(compgen -W '$("$1" --help 2>/dev/null |
-                command sed \
-                     -e "s/[{,}]/ /g" \
-                    -ne "s/^[[:space:]]*--output=//p"
-                )' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --help 2>/dev/null |
+                command sed -ne 's/[{,}]/ /g;s/^[[:space:]]*--output=//p')"
             ;;
     esac
 

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -42,9 +42,8 @@ _comp_cmd_chronyc()
 
     case $args in
         0)
-            COMPREPLY=($(compgen -W "$("$1" help 2>/dev/null |
-                awk '!/(^ |: *$)/ { sub("\\|", " ", $1); print $1 }')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" help 2>/dev/null |
+                awk '!/(^ |: *$)/ { sub("\\|", " ", $1); print $1 }')"
             ;;
         1)
             _comp_cmd_chronyc__command_args "$1"

--- a/completions/configure
+++ b/completions/configure
@@ -28,10 +28,9 @@ _comp_cmd_configure()
     # if $BASH_COMPLETION_CMD_CONFIGURE_HINTS is not null, then completions of
     # the form --option=SETTING will include 'SETTING' as a contextual hint
     if [[ ${BASH_COMPLETION_CMD_CONFIGURE_HINTS-${COMP_CONFIGURE_HINTS-}} ]]; then
-        COMPREPLY=($(compgen -W "$("$1" --help 2>&1 |
+        _comp_compgen_split -- "$("$1" --help 2>&1 |
             awk '/^  --[A-Za-z]/ { print $1; \
-            if ($2 ~ /--[A-Za-z]/) print $2 }' | command sed -e 's/[[,].*//g')" \
-            -- "$cur"))
+            if ($2 ~ /--[A-Za-z]/) print $2 }' | command sed -e 's/[[,].*//g')"
         [[ ${COMPREPLY-} == *=* ]] && compopt -o nospace
     else
         _comp_compgen_help

--- a/completions/convert
+++ b/completions/convert
@@ -49,9 +49,8 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -format)
-            COMPREPLY=($(compgen -W "$(convert -list format | awk \
-                '/ [r-][w-][+-] / { sub("[*]$","",$1); print tolower($1) }')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$(convert -list format | awk \
+                '/ [r-][w-][+-] / { sub("[*]$","",$1); print tolower($1) }')"
             return
             ;;
         -gravity)

--- a/completions/cowsay
+++ b/completions/cowsay
@@ -7,8 +7,7 @@ _comp_cmd_cowsay()
 
     case $prev in
         -f)
-            COMPREPLY=($(compgen -W \
-                '$(cowsay -l 2>/dev/null | tail -n +2)' -- "$cur"))
+            _comp_compgen_split -- "$(cowsay -l 2>/dev/null | tail -n +2)"
             return
             ;;
     esac

--- a/completions/cpan2dist
+++ b/completions/cpan2dist
@@ -8,9 +8,8 @@ _comp_cmd_cpan2dist()
     case $prev in
         --format)
             # should remove ":" from COMP_WORDBREAKS, but doesn't work (?)
-            COMPREPLY=($(compgen -W '$(perl -MCPANPLUS::Dist -e \
-                "print map { \"\$_\n\" } CPANPLUS::Dist->dist_types")' \
-                -- "$cur"))
+            _comp_compgen_split -- "$(perl -MCPANPLUS::Dist -e \
+                'print map { "$_n" } CPANPLUS::Dist->dist_types')"
             return
             ;;
         --banlist | --ignorelist | --modulelist | --logfile)

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -2,7 +2,7 @@
 
 _comp_cmd_cryptsetup__name()
 {
-    COMPREPLY=($(compgen -X control -W '$(command ls /dev/mapper)' -- "$cur"))
+    _comp_compgen_split -X control -- "$(command ls /dev/mapper)"
 }
 
 _comp_cmd_cryptsetup__device()

--- a/completions/cvs
+++ b/completions/cvs
@@ -409,8 +409,8 @@ _comp_cmd_cvs()
             esac
 
             _comp_compgen_help -- --help-options
-            _comp_compgen -a -- -W '$(_cvs_commands) --help
-                --help-commands --help-options --version'
+            _comp_compgen -a split -- "$(_cvs_commands) --help
+                --help-commands --help-options --version"
             ;;
     esac
 

--- a/completions/cvs
+++ b/completions/cvs
@@ -70,7 +70,7 @@ _comp_cmd_cvs()
             # shellcheck disable=SC2254
             case $i in
                 --help | -${noargopts}H)
-                    COMPREPLY=($(compgen -W "$(_cvs_commands)" -- "$cur"))
+                    _comp_compgen_split -- "$(_cvs_commands)"
                     return
                     ;;
                 -${noargopts}d)

--- a/completions/cvsps
+++ b/completions/cvsps
@@ -10,23 +10,23 @@ _comp_cmd_cvsps()
             return
             ;;
         -s)
-            COMPREPLY=($(compgen -W "$("$1" 2>/dev/null |
-                awk '/^PatchSet:?[ \t]/ { print $2 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" 2>/dev/null |
+                awk '/^PatchSet:?[ \t]/ { print $2 }')"
             return
             ;;
         -a)
-            COMPREPLY=($(compgen -W "$("$1" 2>/dev/null |
-                awk '/^Author:[ \t]/ { print $2 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" 2>/dev/null |
+                awk '/^Author:[ \t]/ { print $2 }')"
             return
             ;;
         -b)
-            COMPREPLY=($(compgen -W "$("$1" 2>/dev/null |
-                awk '/^Branch:[ \t]/ { print $2 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" 2>/dev/null |
+                awk '/^Branch:[ \t]/ { print $2 }')"
             return
             ;;
         -r)
-            COMPREPLY=($(compgen -W "$("$1" 2>/dev/null |
-                awk '/^Tag:[ \t]+[^(]/ { print $2 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" 2>/dev/null |
+                awk '/^Tag:[ \t]+[^(]/ { print $2 }')"
             return
             ;;
         -p)

--- a/completions/dict
+++ b/completions/dict
@@ -42,11 +42,11 @@ _comp_cmd_dict()
     # shellcheck disable=SC2254
     case $prev in
         --database | -info | -${noargopts}[di])
-            COMPREPLY=($(compgen -W '$(_dictdata -D)' -- "$cur"))
+            _comp_compgen_split -- "$(_dictdata -D)"
             return
             ;;
         --strategy | -${noargopts}s)
-            COMPREPLY=($(compgen -W '$(_dictdata -S)' -- "$cur"))
+            _comp_compgen_split -- "$(_dictdata -S)"
             return
             ;;
     esac
@@ -57,10 +57,11 @@ _comp_cmd_dict()
         # it down with grep if $cur looks like something that's safe to embed
         # in a pattern instead.
         if [[ $cur == +([-A-Za-z0-9/.]) ]]; then
-            COMPREPLY=($(compgen -W \
-                '$(command grep "^${cur//./\\.}" "$dictfile")' -- "$cur"))
+            _comp_compgen_split -- "$(
+                command grep "^${cur//./\\.}" "$dictfile"
+            )"
         else
-            COMPREPLY=($(compgen -W '$(cat "$dictfile")' -- "$cur"))
+            _comp_compgen_split -- "$(cat "$dictfile")"
         fi
     fi
 } &&

--- a/completions/ebtables
+++ b/completions/ebtables
@@ -16,30 +16,29 @@ _comp_cmd_ebtables()
     # shellcheck disable=SC2254
     case $prev in
         -${noargopts}[AIDPFXLZ])
-            COMPREPLY=($(compgen -W '`"$1" ${table:+-t "$table"} -L 2>/dev/null | \
-                command sed -ne "$chain"`' -- "$cur"))
+            _comp_compgen_split -- "$(
+                "$1" ${table:+-t "$table"} -L 2>/dev/null |
+                    command sed -ne "$chain"
+            )"
             ;;
         -${noargopts}t)
             _comp_compgen -- -W 'nat filter broute'
             ;;
         -${noargopts}j)
             if [[ $table == "filter" || ! $table ]]; then
-                COMPREPLY=($(compgen -W '$targets
-                $("$1" ${table:+-t "$table"} -L 2>/dev/null | \
-                  command sed -n -e "s/INPUT\|OUTPUT\|FORWARD//" \
-                                 -e "$chain")' \
-                    -- "$cur"))
+                _comp_compgen -- -W '$targets'
+                _comp_compgen -a split -- "$("$1" ${table:+-t "$table"} -L \
+                    2>/dev/null | command sed -n -e \
+                    "s/INPUT\|OUTPUT\|FORWARD//" -e "$chain")"
             elif [[ $table == "nat" ]]; then
-                COMPREPLY=($(compgen -W '$targets
-                $("$1" -t "$table" -L 2>/dev/null | \
-                  command sed -n -e "s/OUTPUT|PREROUTING|POSTROUTING//" \
-                                 -e "$chain")' \
-                    -- "$cur"))
+                _comp_compgen -- -W '$targets'
+                _comp_compgen -a split -- "$("$1" -t "$table" -L 2>/dev/null |
+                    command sed -n -e "s/OUTPUT|PREROUTING|POSTROUTING//" \
+                        -e "$chain")"
             elif [[ $table == "broute" ]]; then
-                COMPREPLY=($(compgen -W 'ACCEPT DROP
-                $("$1" -t "$table" -L 2>/dev/null | \
-                  command sed -n -e "s/BROUTING//" -e "$chain")' \
-                    -- "$cur"))
+                _comp_compgen -- -W 'ACCEPT DROP'
+                _comp_compgen -a split -- "$("$1" -t "$table" -L 2>/dev/null |
+                    command sed -n -e "s/BROUTING//" -e "$chain")"
             fi
             ;;
         *)

--- a/completions/fbgs
+++ b/completions/fbgs
@@ -7,14 +7,13 @@ _comp_cmd_fbgs()
 
     case "$prev" in
         -f | --font)
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -W '$(fc-list 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -l -- "$(fc-list 2>/dev/null)"
             return
             ;;
         -m | --mode)
-            COMPREPLY=($(compgen -W '$(command sed \
-                -n "/^mode/{s/^mode \{1,\}\"\([^\"]\{1,\}\)\"/\1/g;p}" \
-                /etc/fb.modes 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -- "$(command sed \
+                -n '/^mode/{s/^mode \{1,\}"\([^"]\{1,\}\)"/\1/g;p}' \
+                /etc/fb.modes 2>/dev/null)"
             return
             ;;
         -d | --device)

--- a/completions/fbi
+++ b/completions/fbi
@@ -15,14 +15,13 @@ _comp_cmd_fbi()
             return
             ;;
         -f | --font)
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -W '$(fc-list 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -l -- "$(fc-list 2>/dev/null)"
             return
             ;;
         -m | --mode)
-            COMPREPLY=($(compgen -W '$(command sed \
-                -n "/^mode/{s/^mode \{1,\}\"\([^\"]\{1,\}\)\"/\1/g;p}" \
-                /etc/fb.modes 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -- "$(command sed \
+                -n '/^mode/{s/^mode \{1,\}"\([^"]\{1,\}\)"/\1/g;p}' \
+                /etc/fb.modes 2>/dev/null)"
             return
             ;;
         -d | --device)

--- a/completions/fio
+++ b/completions/fio
@@ -32,7 +32,7 @@ _comp_cmd_fio()
             return
             ;;
         --crctest)
-            COMPREPLY=($(compgen -W '$("$1" --crctest=nonexistent 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --crctest=nonexistent 2>/dev/null)"
             return
             ;;
         --cmdhelp)

--- a/completions/fio
+++ b/completions/fio
@@ -141,9 +141,8 @@ _comp_cmd_fio()
 
     if [[ $cur == -* ]]; then
         _comp_compgen_help
-        local stdout=$("$1" --cmdhelp=all 2>/dev/null |
-            awk '{printf "--%s=\n", $1}')
-        _comp_compgen -a -- -W '$stdout'
+        _comp_compgen -a split -- "$("$1" --cmdhelp=all 2>/dev/null |
+            awk '{printf "--%s=\n", $1}')"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/firefox
+++ b/completions/firefox
@@ -14,10 +14,10 @@ _comp_cmd_firefox()
             return
             ;;
         -P)
-            COMPREPLY=($(compgen -W "$(
+            _comp_compgen_split -- "$(
                 awk -F= '$1 == "Name" { print $2 }' \
                     ~/.mozilla/firefox/profiles.ini 2>/dev/null
-            )" -- "$cur"))
+            )"
             return
             ;;
         --profile | --screenshot)

--- a/completions/fusermount
+++ b/completions/fusermount
@@ -10,9 +10,8 @@ _comp_cmd_fusermount()
             return
             ;;
         -*u)
-            COMPREPLY=($(compgen -W "$(awk \
-                '{ if ($3 ~ /^fuse(\.|$)/) print $2 }' /etc/mtab \
-                2>/dev/null)" -- "$cur"))
+            _comp_compgen_split -- "$(awk \
+                '{ if ($3 ~ /^fuse(\.|$)/) print $2 }' /etc/mtab 2>/dev/null)"
             return
             ;;
     esac

--- a/completions/gcc
+++ b/completions/gcc
@@ -11,9 +11,8 @@ _comp_cmd_gcc()
         if [[ $cur == -* ]]; then
             local cc=$("$1" -print-prog-name=cc1 2>/dev/null)
             [[ $cc ]] || return
-            COMPREPLY=($(compgen -W "$("$cc" --help 2>/dev/null | tr '\t' ' ' |
-                command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$cc" --help 2>/dev/null | tr '\t' ' ' |
+                command sed -e '/^  *-/!d' -e 's/ *-\([^][ <>]*\).*/-\1/')"
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         else
             _comp_compgen_filedir

--- a/completions/gdb
+++ b/completions/gdb
@@ -35,8 +35,8 @@ _comp_cmd_gdb()
                 -printf "%f\\n" 2>/dev/null)' -- "$cur"))
         fi
     elif ((cword == 2)); then
-        COMPREPLY=($(compgen -W "$(command ps axo comm,pid |
-            awk '{if ($1 ~ /^'"${prev##*/}"'/) print $2}')" -- "$cur"))
+        _comp_compgen_split -- "$(command ps axo comm,pid |
+            awk '{if ($1 ~ /^'"${prev##*/}"'/) print $2}')"
         compopt -o filenames
         _comp_compgen -a -- -f -X '!?(*/)core?(.?*)' -o plusdirs
     fi

--- a/completions/gdb
+++ b/completions/gdb
@@ -29,10 +29,11 @@ _comp_cmd_gdb()
             local path_array=($(
                 command sed -e 's/:\{2,\}/:/g' -e 's/^://' -e 's/:$//' <<<"$PATH"
             ))
-            IFS=$'\n'
-            COMPREPLY=($(compgen -d -W '$(find ${path_array[@]+"${path_array[@]}"} . \
-                -mindepth 1 -maxdepth 1 -not -type d -executable \
-                -printf "%f\\n" 2>/dev/null)' -- "$cur"))
+            _comp_compgen_split -o plusdirs -- "$(
+                find ${path_array[@]+"${path_array[@]}"} . -mindepth 1 \
+                    -maxdepth 1 -not -type d -executable -printf '%f\n' \
+                    2>/dev/null
+            )"
         fi
     elif ((cword == 2)); then
         _comp_compgen_split -- "$(command ps axo comm,pid |

--- a/completions/genisoimage
+++ b/completions/genisoimage
@@ -12,8 +12,8 @@ _comp_cmd_mkisofs()
             return
             ;;
         -*-charset)
-            COMPREPLY=($(compgen -W '$(mkisofs -input-charset \
-                    help 2>&1 | tail -n +3)' -- "$cur"))
+            _comp_compgen_split -- "$(mkisofs -input-charset help 2>&1 |
+                tail -n +3)"
             return
             ;;
         -uid)

--- a/completions/getconf
+++ b/completions/getconf
@@ -11,9 +11,9 @@ _comp_cmd_getconf()
             return
             ;;
         -v)
-            COMPREPLY=($(compgen -W \
-                '$("$1" -a 2>/dev/null | awk "{ print \$1 }")' -- \
-                "${cur:-POSIX_V}"))
+            _comp_compgen -c "${cur:-POSIX_V}" split -- "$(
+                "$1" -a 2>/dev/null | awk '{ print $1 }'
+            )"
             return
             ;;
     esac
@@ -23,8 +23,9 @@ _comp_cmd_getconf()
     elif [[ $cur == -* ]]; then
         _comp_compgen -- -W '-a -v'
     else
-        COMPREPLY=($(compgen -W \
-            '$("$1" -a 2>/dev/null | awk "{ print \$1 }")' -- "$cur"))
+        _comp_compgen_split -- "$(
+            "$1" -a 2>/dev/null | awk '{ print $1 }'
+        )"
     fi
 } &&
     complete -F _comp_cmd_getconf getconf

--- a/completions/getent
+++ b/completions/getent
@@ -45,12 +45,11 @@ _comp_cmd_getent()
             return
             ;;
         protocols | networks | ahosts | ahostsv4 | ahostsv6 | rpc)
-            COMPREPLY=($(compgen -W "$("$1" "$db" |
-                awk '{ print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" "$db" | awk '{ print $1 }')"
             return
             ;;
         aliases | shadow | gshadow)
-            COMPREPLY=($(compgen -W "$("$1" "$db" | cut -d: -f1)" -- "$cur"))
+            _comp_compgen_split -- "$("$1" "$db" | cut -d: -f1)"
             return
             ;;
         ethers | netgroup)

--- a/completions/gm
+++ b/completions/gm
@@ -2,8 +2,8 @@
 
 _comp_cmd_gm__commands()
 {
-    COMPREPLY+=($(compgen -W '$("$1" help |
-        awk "/^ +[^ ]+ +- / { print \$1 }")' -- "$cur"))
+    _comp_compgen -a split -- "$("$1" help |
+        awk '/^ +[^ ]+ +- / { print $1 }')"
 }
 
 _comp_cmd_gm()

--- a/completions/gnokii
+++ b/completions/gnokii
@@ -24,9 +24,8 @@ _comp_cmd_gnokii()
                 [[ -f $config_file ]] && break
             done
             [[ ! -f $config_file ]] && return
-            COMPREPLY=($(compgen -W \
-                "$(command sed -n 's/^\[phone_\(.*\)\]/\1/p' "$config_file")" \
-                -- "$cur"))
+            _comp_compgen_split -- "$(command sed -n \
+                's/^\[phone_\(.*\)\]/\1/p' "$config_file")"
             return
             ;;
         --help)

--- a/completions/gpg
+++ b/completions/gpg
@@ -19,26 +19,26 @@ _comp_cmd_gpg()
             --search-keys | --edit-key | --sign-key | --lsign-key | \
             --nrsign-key | --nrlsign-key | --try-secret-key | -${noargopts}k)
             # return list of public keys
-            COMPREPLY=($(compgen -W "$("$1" --list-keys 2>/dev/null |
+            _comp_compgen_split -- "$("$1" --list-keys 2>/dev/null |
                 command sed -ne \
                     's@^pub.*/\([^ ]*\).*$@\1@p' -ne \
-                    's@^.*\(<\([^>]*\)>\).*$@\2@p')" -- "$cur"))
+                    's@^.*\(<\([^>]*\)>\).*$@\2@p')"
             return
             ;;
         --list-secret-keys | --delete-secret-keys | --export-secret-keys | \
             --export-secret-subkeys | -${noargopts}K)
             # return list of secret keys
-            COMPREPLY=($(compgen -W "$("$1" --list-secret-keys 2>/dev/null |
-                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-secret-keys 2>/dev/null |
+                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')"
             return
             ;;
         --recipient | -${noargopts}r)
-            COMPREPLY=($(compgen -W "$("$1" --list-keys 2>/dev/null |
-                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-keys 2>/dev/null |
+                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')"
             if [[ -e ~/.gnupg/gpg.conf ]]; then
-                COMPREPLY+=($(compgen -W "$(command sed -ne \
+                _comp_compgen -a split -- "$(command sed -ne \
                     's@^[ \t]*group[ \t][ \t]*\([^=]*\).*$@\1@p' \
-                    ~/.gnupg/gpg.conf)" -- "$cur"))
+                    ~/.gnupg/gpg.conf)"
             fi
             return
             ;;

--- a/completions/gpg
+++ b/completions/gpg
@@ -45,7 +45,7 @@ _comp_cmd_gpg()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$("$1" --dump-options)' -- "$cur"))
+        _comp_compgen_split -- "$("$1" --dump-options)"
     fi
 } &&
     complete -F _comp_cmd_gpg -o default gpg

--- a/completions/gpg2
+++ b/completions/gpg2
@@ -39,7 +39,7 @@ _comp_cmd_gpg2()
     esac
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '$("$1" --dump-options)' -- "$cur"))
+        _comp_compgen_split -- "$("$1" --dump-options)"
     fi
 } &&
     complete -F _comp_cmd_gpg2 -o default gpg2

--- a/completions/gpg2
+++ b/completions/gpg2
@@ -20,19 +20,19 @@ _comp_cmd_gpg2()
             --edit-key | --delete-keys | --delete-secret-and-public-keys | \
             --locate-keys | --refresh-keys)
             # return list of public keys
-            COMPREPLY=($(compgen -W "$("$1" --list-keys 2>/dev/null |
+            _comp_compgen_split -- "$("$1" --list-keys 2>/dev/null |
                 command sed -ne \
                     's@^pub.*/\([^ ]*\).*$@\1@p' -ne \
-                    's@^.*\(<\([^>]*\)>\).*$@\2@p')" -- "$cur"))
+                    's@^.*\(<\([^>]*\)>\).*$@\2@p')"
             return
             ;;
         --recipient | -${noargopts}r)
-            COMPREPLY=($(compgen -W "$("$1" --list-keys 2>/dev/null |
-                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-keys 2>/dev/null |
+                command sed -ne 's@^.*<\([^>]*\)>.*$@\1@p')"
             if [[ -e ~/.gnupg/gpg.conf ]]; then
-                COMPREPLY+=($(compgen -W "$(command sed -ne \
+                _comp_compgen -a split -- "$(command sed -ne \
                     's@^[ \t]*group[ \t][ \t]*\([^=]*\).*$@\1@p' \
-                    ~/.gnupg/gpg.conf)" -- "$cur"))
+                    ~/.gnupg/gpg.conf)"
             fi
             return
             ;;

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -23,21 +23,18 @@ _comp_cmd_gphoto2()
             return
             ;;
         --port)
-            COMPREPLY=($(compgen -W "$("$1" --list-ports 2>/dev/null |
-                awk 'NR>3 { print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-ports 2>/dev/null |
+                awk 'NR>3 { print $1 }')"
             _comp_ltrim_colon_completions "$cur"
             return
             ;;
         --camera)
-            local IFS=$'\n'
-            COMPREPLY=($(compgen -W "$("$1" --list-cameras 2>/dev/null |
-                awk -F'"' 'NR>2 { print $2 }')" -- "$cur"))
+            _comp_compgen_split -l -- "$("$1" --list-cameras 2>/dev/null |
+                awk -F'"' 'NR>2 { print $2 }')"
             return
             ;;
         --get-config | --set-config | --set-config-index | --set-config-value)
-            COMPREPLY=($(compgen -W "$(
-                $1 --list-config 2>/dev/null
-            )" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-config 2>/dev/null)"
             return
             ;;
     esac

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -3,15 +3,13 @@
 _comp_cmd_hcitool__bluetooth_addresses()
 {
     if [[ ${COMP_BLUETOOTH_SCAN-} ]]; then
-        COMPREPLY+=($(compgen -W "$(hcitool scan |
-            awk '/^\t/{print $1}')" -- "$cur"))
+        _comp_compgen -a split -- "$(hcitool scan | awk '/^\t/{print $1}')"
     fi
 }
 
 _comp_cmd_hcitool__bluetooth_devices()
 {
-    COMPREPLY+=($(compgen -W "$(hcitool dev |
-        awk '/^\t/{print $1}')" -- "$cur"))
+    _comp_compgen -a split -- "$(hcitool dev | awk '/^\t/{print $1}')"
 }
 
 _comp_cmd_hcitool__bluetooth_services()

--- a/completions/htop
+++ b/completions/htop
@@ -9,7 +9,7 @@ _comp_cmd_htop()
     # shellcheck disable=SC2254
     case "$prev" in
         --sort-key | -${noargopts}s)
-            COMPREPLY=($(compgen -W '$("$1" -s help)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" -s help)"
             return
             ;;
         --user | -${noargopts}u)

--- a/completions/htpasswd
+++ b/completions/htpasswd
@@ -27,8 +27,7 @@ _comp_cmd_htpasswd()
 
     elif ((o == cword - 1)); then
         # Username (second non-option argument)
-        COMPREPLY=($(compgen -W \
-            '$(cut -d: -f1 "${words[o]}" 2>/dev/null)' -- "$cur"))
+        _comp_compgen_split -- "$(cut -d: -f1 "${words[o]}" 2>/dev/null)"
     fi
 } &&
     complete -F _comp_cmd_htpasswd htpasswd

--- a/completions/iconv
+++ b/completions/iconv
@@ -14,8 +14,8 @@ _iconv_charsets()
 
 _comp_cmd_iconv__charsets()
 {
-    COMPREPLY+=($(compgen -X ... -W '$("$1" -l | \
-        command sed -e "s@/*\$@@" -e "s/[,()]//g")' -- "$cur"))
+    _comp_compgen -a split -X ... -- "$("$1" -l |
+        command sed -e 's@/*$@@' -e 's/[,()]//g')"
 }
 
 _comp_cmd_iconv()

--- a/completions/ifstat
+++ b/completions/ifstat
@@ -23,8 +23,8 @@ _comp_cmd_ifstat()
                 "$1" --help 2>&1 || :
             } |
                 command grep -q -- '-d.*--scan'; then
-                COMPREPLY=($(compgen -W '$("$1" -v | command \
-                    sed -e "s/[,.]//g" -ne "s/^.*drivers://p")' -- "$cur"))
+                _comp_compgen_split -- "$("$1" -v | command sed -e 's/[,.]//g' \
+                    -ne 's/^.*drivers://p')"
             fi
             return
             ;;
@@ -49,9 +49,8 @@ _comp_cmd_ifstat()
             ;;
         --extended | -${noargopts}x)
             # iproute2: parse xstat types
-            COMPREPLY=($(compgen -W '$("$1" -x nonexistent-xstat 2>&1 |
-                awk "found { print \$1 } /supported xstats:/ { found=1 }")' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" -x nonexistent-xstat 2>&1 |
+                awk 'found { print $1 } /supported xstats:/ { found=1 }')"
             return
             ;;
     esac

--- a/completions/inotifywait
+++ b/completions/inotifywait
@@ -5,10 +5,9 @@ _comp_cmd_inotifywait__events()
     # Expecting line with "Events:", followed by ones starting with one
     # tab. Word following the tab is event name, others are line
     # wrapped explanations.
-    COMPREPLY+=($(compgen -W "$("$1" --help 2>/dev/null |
+    _comp_compgen -a split -- "$("$1" --help 2>/dev/null |
         command sed -e '/^Events:/,/^[^'$'\t'']/!d' \
-            -ne 's/^'$'\t''\([^ '$'\t'']\{1,\}\)[ '$'\t''].*/\1/p')" \
-        -- "$cur"))
+            -ne 's/^'$'\t''\([^ '$'\t'']\{1,\}\)[ '$'\t''].*/\1/p')"
 }
 
 _comp_cmd_inotifywait()

--- a/completions/insmod
+++ b/completions/insmod
@@ -9,8 +9,8 @@ _comp_cmd_insmod()
     if ((cword == 1)); then
         _comp_compgen_filedir '@(?(k)o?(.[gx]z|.zst))'
     else # do module parameter completion
-        COMPREPLY=($(compgen -W "$(PATH="$PATH:/sbin" modinfo \
-            -p "${words[1]}" 2>/dev/null | cut -d: -f1)" -- "$cur"))
+        _comp_compgen_split -- "$(PATH="$PATH:/sbin" modinfo \
+            -p "${words[1]}" 2>/dev/null | cut -d: -f1)"
     fi
 } &&
     complete -F _comp_cmd_insmod insmod insmod.static

--- a/completions/invoke-rc.d
+++ b/completions/invoke-rc.d
@@ -28,9 +28,9 @@ _comp_cmd_invoke_rc_d()
         ((${#COMPREPLY[@]})) &&
             _comp_compgen -- -W '"${COMPREPLY[@]}"'
     elif [[ -x $sysvdir/$prev ]]; then
-        COMPREPLY=($(compgen -W '`command sed -e "y/|/ /" \
-            -ne "s/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}\"]*\).*$/\1/p" \
-            "$sysvdir/$prev"`' -- "$cur"))
+        _comp_compgen_split -- "$(command sed -e 'y/|/ /' \
+            -ne 's/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}"]*\).*$/\1/p' \
+            "$sysvdir/$prev")"
     else
         COMPREPLY=()
     fi

--- a/completions/ip
+++ b/completions/ip
@@ -2,18 +2,17 @@
 
 _comp_cmd_ip__iproute2_etc()
 {
-    COMPREPLY+=($(compgen -W \
-        "$(awk '!/#/ { print $2 }' "/etc/iproute2/$1" 2>/dev/null)" \
-        -- "$cur"))
+    _comp_compgen -a split -- "$(awk '!/#/ { print $2 }' "/etc/iproute2/$1" \
+        2>/dev/null)"
 }
 
 _comp_cmd_ip__netns()
 {
-    COMPREPLY=($(compgen -W "$(
+    _comp_compgen_split -- "$(
         {
             ${1-ip} -c=never netns list 2>/dev/null || ${1-ip} netns list
         } | awk '{print $1}'
-    )" -- "$cur"))
+    )"
 }
 
 _comp_cmd_ip()
@@ -65,7 +64,7 @@ _comp_cmd_ip()
                 )"
                 ;;
             *)
-                COMPREPLY=($(compgen -W "help $(
+                _comp_compgen_split -- "help $(
                     {
                         $1 -c=never help || $1 help
                     } 2>&1 | command sed -e \
@@ -73,7 +72,7 @@ _comp_cmd_ip()
                         's/.*{//' -e \
                         's/}.*//' -e \
                         's/|//g'
-                )" -- "$cur"))
+                )"
                 ;;
         esac
         return
@@ -210,16 +209,18 @@ _comp_cmd_ip()
                     ;;
                 a | add | d | del | change | append | r | replace | monitor)
                     if [[ $prev == via ]]; then
-                        COMPREPLY=($(compgen -W "$(
+                        _comp_compgen_split -- "$(
                             {
                                 $1 -c=never r 2>/dev/null || $1 r
                             } | command sed -ne \
                                 's/.*via \([0-9.]*\).*/\1/p'
-                        )" -- "$cur"))
+                        )"
                     elif [[ $prev == "$subcmd" ]]; then
-                        COMPREPLY=($(compgen -W "table default $({
-                            $1 -c=never r 2>/dev/null || $1 r
-                        } | cut -d ' ' -f 1)" -- "$cur"))
+                        _comp_compgen_split -- "table default $(
+                            {
+                                $1 -c=never r 2>/dev/null || $1 r
+                            } | cut -d ' ' -f 1
+                        )"
                     elif [[ $prev == dev ]]; then
                         _available_interfaces -a
                     elif [[ $prev == table ]]; then

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -2,8 +2,8 @@
 
 _comp_cmd_ipmitool__singleline_help()
 {
-    COMPREPLY=($(compgen -W "$("$1" "$2" 2>&1 |
-        command sed -ne 's/[,\r]//g' -e 's/^.*[Cc]ommands://p')" -- "$cur"))
+    _comp_compgen_split -- "$("$1" "$2" 2>&1 |
+        command sed -ne 's/[,\r]//g' -e 's/^.*[Cc]ommands://p')"
 }
 
 _comp_cmd_ipmitool()
@@ -23,10 +23,9 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*I)
-            COMPREPLY=($(compgen -W "$("$1" -h 2>&1 |
+            _comp_compgen_split -- "$("$1" -h 2>&1 |
                 command sed -e '/^Interfaces:/,/^[[:space:]]*$/!d' \
-                    -ne 's/^[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p')" \
-                -- "$cur"))
+                    -ne 's/^[[:space:]]\{1,\}\([^[:space:]]\{1,\}\).*/\1/p')"
             return
             ;;
         -*H)
@@ -50,8 +49,8 @@ _comp_cmd_ipmitool()
             return
             ;;
         -*o)
-            COMPREPLY=($(compgen -W "$("$1" -o list 2>&1 |
-                awk '/^[ \t]+/ { print $1 }') list" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -o list 2>&1 |
+                awk '/^[ \t]+/ { print $1 }') list"
             return
             ;;
     esac

--- a/completions/iptables
+++ b/completions/iptables
@@ -6,6 +6,7 @@ _comp_cmd_iptables()
     _comp_initialize -s -- "$@" || return
 
     local table="" chain='s/^Chain \([^ ]\{1,\}\).*$/\1/p'
+    local targets='ACCEPT DROP LOG ULOG REJECT'
 
     local IFS=$' \t\n' # for ${table:+-t "$table"}
     [[ ${words[*]} =~ [[:space:]]-(t|-table=?)[[:space:]]*([^[:space:]]+) ]] &&
@@ -13,28 +14,30 @@ _comp_cmd_iptables()
 
     case $prev in
         -*[AIDRPFXLZ])
-            COMPREPLY=($(compgen -W '`"$1" ${table:+-t "$table"} -nL 2>/dev/null | \
-                command sed -ne "s/^Chain \([^ ]\{1,\}\).*$/\1/p"`' -- "$cur"))
+            _comp_compgen_split -- "$(
+                "$1" ${table:+-t "$table"} -nL 2>/dev/null |
+                    command sed -ne 's/^Chain \([^ ]\{1,\}\).*$/\1/p'
+            )"
             ;;
         -*t)
             _comp_compgen -- -W 'nat filter mangle'
             ;;
         -j)
             if [[ $table == "filter" || ! $table ]]; then
-                COMPREPLY=($(compgen -W 'ACCEPT DROP LOG ULOG REJECT
-                `"$1" ${table:+-t "$table"} -nL 2>/dev/null | command sed -ne "$chain" \
-                -e "s/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//"`' -- \
-                    "$cur"))
+                _comp_compgen -- -W '$targets'
+                _comp_compgen -a split -- "$("$1" ${table:+-t "$table"} -nL \
+                    2>/dev/null | command sed -ne "$chain" \
+                    -e 's/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//')"
             elif [[ $table == "nat" ]]; then
-                COMPREPLY=($(compgen -W 'ACCEPT DROP LOG ULOG REJECT MIRROR SNAT
-                DNAT MASQUERADE `"$1" -t "$table" -nL 2>/dev/null | \
-                command sed -ne "$chain" -e "s/OUTPUT|PREROUTING|POSTROUTING//"`' \
-                    -- "$cur"))
+                _comp_compgen -- -W '$targets MIRROR SNAT DNAT MASQUERADE'
+                _comp_compgen -a split -- "$("$1" -t "$table" -nL 2>/dev/null |
+                    command sed -ne "$chain" \
+                        -e 's/OUTPUT|PREROUTING|POSTROUTING//')"
             elif [[ $table == "mangle" ]]; then
-                COMPREPLY=($(compgen -W 'ACCEPT DROP LOG ULOG REJECT MARK TOS
-                `"$1" -t "$table" -nL 2>/dev/null | command sed -ne "$chain" \
-                -e "s/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//"`' -- \
-                    "$cur"))
+                _comp_compgen -- -W '$targets MARK TOS'
+                _comp_compgen -a split -- "$("$1" -t "$table" -nL 2>/dev/null |
+                    command sed -ne "$chain" \
+                        -e 's/INPUT|OUTPUT|FORWARD|PREROUTING|POSTROUTING//')"
             fi
             ;;
         *)

--- a/completions/ipv6calc
+++ b/completions/ipv6calc
@@ -13,9 +13,8 @@ _comp_cmd_ipv6calc()
             ;;
         --in | --out | --action | -${noargopts}[IOA])
             # With ipv6calc < 0.73.0, -m does nothing here, so use sed instead.
-            COMPREPLY=($(compgen -W "$("$1" "$prev" -h 2>&1 |
-                command sed -ne 's/^[[:space:]]\{1,\}\([^[:space:]:]\{1,\}\)[[:space:]]*:.*/\1/p')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" "$prev" -h 2>&1 |
+                command sed -ne 's/^[[:space:]]\{1,\}\([^[:space:]:]\{1,\}\)[[:space:]]*:.*/\1/p')"
             return
             ;;
         --db-geoip | --db-ip2location-ipv4 | --db-ip2location-ipv6)

--- a/completions/iwconfig
+++ b/completions/iwconfig
@@ -14,9 +14,8 @@ _comp_cmd_iwconfig()
         essid)
             _comp_compgen -- -W 'on off any'
             if [[ ${BASH_COMPLETION_CMD_IWCONFIG_SCAN-${COMP_IWLIST_SCAN-}} ]]; then
-                COMPREPLY+=($(compgen -W \
-                    "$(iwlist "${words[1]}" scan |
-                        awk -F'\"' '/ESSID/ {print $2}')" -- "$cur"))
+                _comp_compgen -a split -- "$(iwlist "${words[1]}" scan |
+                    awk -F'\"' '/ESSID/ {print $2}')"
             fi
             return
             ;;
@@ -25,30 +24,28 @@ _comp_cmd_iwconfig()
             return
             ;;
         channel)
-            COMPREPLY=($(compgen -W "$(iwlist "${words[1]}" channel |
-                awk '/^[ \t]*Channel/ {print $2}')" -- "$cur"))
+            _comp_compgen_split -- "$(iwlist "${words[1]}" channel |
+                awk '/^[ \t]*Channel/ {print $2}')"
             return
             ;;
 
         freq)
-            COMPREPLY=($(compgen -W "$(iwlist "${words[1]}" channel |
-                awk '/^[ \t]*Channel/ {print $4"G"}')" -- "$cur"))
+            _comp_compgen_split -- "$(iwlist "${words[1]}" channel |
+                awk '/^[ \t]*Channel/ {print $4"G"}')"
             return
             ;;
         ap)
             _comp_compgen -- -W 'on off any'
             if [[ ${BASH_COMPLETION_CMD_IWCONFIG_SCAN-${COMP_IWLIST_SCAN-}} ]]; then
-                COMPREPLY+=($(compgen -W \
-                    "$(iwlist "${words[1]}" scan |
-                        awk -F ': ' '/Address/ {print $2}')" -- "$cur"))
+                _comp_compgen -a split -- "$(iwlist "${words[1]}" scan |
+                    awk -F ': ' '/Address/ {print $2}')"
             fi
             return
             ;;
         rate)
             _comp_compgen -- -W 'auto fixed'
-            COMPREPLY+=($(compgen -W \
-                "$(iwlist "${words[1]}" rate |
-                    awk '/^[ \t]*[0-9]/ {print $1"M"}')" -- "$cur"))
+            _comp_compgen -a split -- "$(iwlist "${words[1]}" rate |
+                awk '/^[ \t]*[0-9]/ {print $1"M"}')"
             return
             ;;
         rts | frag)

--- a/completions/kldunload
+++ b/completions/kldunload
@@ -7,7 +7,7 @@ _comp_cmd_kldunload()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W '$(kldstat)' -X '!*.ko' -- "$cur"))
+    _comp_compgen_split -X '!*.ko' -- "$(kldstat)"
     COMPREPLY=(${COMPREPLY[@]%.ko})
 } &&
     complete -F _comp_cmd_kldunload kldunload

--- a/completions/kldunload
+++ b/completions/kldunload
@@ -7,7 +7,7 @@ _comp_cmd_kldunload()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W '$(kldstat)' -X 'kernel' -X '!*.ko' -- "$cur"))
+    COMPREPLY=($(compgen -W '$(kldstat)' -X '!*.ko' -- "$cur"))
     COMPREPLY=(${COMPREPLY[@]%.ko})
 } &&
     complete -F _comp_cmd_kldunload kldunload

--- a/completions/koji
+++ b/completions/koji
@@ -2,8 +2,7 @@
 
 _comp_cmd_koji__search()
 {
-    COMPREPLY+=($(compgen -W \
-        '$("$1" -q search "$2" "$cur*" 2>/dev/null)' -- "$cur"))
+    _comp_compgen -a split -- "$("$1" -q search "$2" "$cur*" 2>/dev/null)"
 }
 
 _comp_cmd_koji__build()
@@ -23,13 +22,13 @@ _comp_cmd_koji__user()
 
 _comp_cmd_koji__tag()
 {
-    COMPREPLY+=($(compgen -W '$("$1" -q list-tags 2>/dev/null)' -- "$cur"))
+    _comp_compgen -a split -- "$("$1" -q list-tags 2>/dev/null)"
 }
 
 _comp_cmd_koji__target()
 {
-    COMPREPLY+=($(compgen -W '$("$1" -q list-targets 2>/dev/null |
-        awk "{ print \$1 }")' -- "$cur"))
+    _comp_compgen -a split -- "$("$1" -q list-targets 2>/dev/null |
+        awk '{ print $1 }')"
 }
 
 _comp_cmd_koji()
@@ -238,8 +237,8 @@ _comp_cmd_koji()
         _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ ! $has_command ]]; then
-        COMPREPLY=($(compgen -W '$("$1" --help-commands 2>/dev/null | \
-            awk "/^(  +|\t)/ { print \$1 }")' -- "$cur"))
+        _comp_compgen_split -- "$("$1" --help-commands 2>/dev/null |
+            awk '/^(  +|\t)/ { print $1 }')"
     fi
 } &&
     complete -F _comp_cmd_koji koji arm-koji ppc-koji s390-koji sparc-koji

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -2,14 +2,14 @@
 
 _comp_cmd_ktutil__heimdal_principals()
 {
-    COMPREPLY=($(compgen -W "$(kadmin -l dump 2>/dev/null |
-        awk '{print $1}')" -- "$cur"))
+    _comp_compgen_split -- "$(kadmin -l dump 2>/dev/null |
+        awk '{print $1}')"
 }
 
 _comp_cmd_ktutil__heimdal_realms()
 {
-    COMPREPLY=($(compgen -W "$(kadmin -l dump 2>/dev/null |
-        awk '{print $1}' | awk -F@ '{print $2}')" -- "$cur"))
+    _comp_compgen_split -- "$(kadmin -l dump 2>/dev/null |
+        awk '{print $1}' | awk -F@ '{print $2}')"
 }
 
 _comp_cmd_ktutil__heimdal_encodings()

--- a/completions/lftp
+++ b/completions/lftp
@@ -22,7 +22,7 @@ _comp_cmd_lftp()
         return
     fi
 
-    COMPREPLY=($(compgen -W '$("$1" -c "bookmark list" 2>/dev/null)' -- "$cur"))
+    _comp_compgen_split -- "$("$1" -c "bookmark list" 2>/dev/null)"
     _known_hosts_real -- "$cur"
 } &&
     complete -F _comp_cmd_lftp lftp

--- a/completions/lilo
+++ b/completions/lilo
@@ -2,9 +2,8 @@
 
 _comp_cmd_lilo__labels()
 {
-    COMPREPLY=($(compgen -W "$(awk -F= '$1 ~ /^[ \t]*label$/ {print $2}' \
-        "${1:-/etc/lilo.conf}" 2>/dev/null | command sed -e 's/\"//g')" \
-        -- "$cur"))
+    _comp_compgen_split -- "$(awk -F= '$1 ~ /^[ \t]*label$/ {print $2}' \
+        "${1:-/etc/lilo.conf}" 2>/dev/null | command sed -e 's/\"//g')"
 }
 
 _comp_cmd_lilo()

--- a/completions/links
+++ b/completions/links
@@ -88,7 +88,7 @@ _comp_cmd_links()
     local dir
     for dir in .links .links2; do
         if [[ -r ~/$dir/links.his ]]; then
-            COMPREPLY+=($(compgen -W '$(cat ~/$dir/links.his)' -- "$cur"))
+            _comp_compgen -a split -- "$(cat ~/$dir/links.his)"
             _comp_ltrim_colon_completions "$cur"
         fi
     done

--- a/completions/list_lists
+++ b/completions/list_lists
@@ -3,7 +3,7 @@
 # @since 2.12
 _comp_xfunc_list_lists_mailman_lists()
 {
-    COMPREPLY=($(compgen -W '$(list_lists -b 2>/dev/null)' -- "$cur"))
+    _comp_compgen_split -- "$(list_lists -b 2>/dev/null)"
 }
 
 _comp_deprecate_func 2.12 _mailman_lists _comp_xfunc_list_lists_mailman_lists

--- a/completions/locale-gen
+++ b/completions/locale-gen
@@ -23,9 +23,9 @@ _comp_cmd_locale_gen()
         return
     fi
 
-    COMPREPLY=($(compgen -W \
-        '$(awk "{ print \$1 }" /usr/share/i18n/SUPPORTED 2>/dev/null)' \
-        -- "$cur"))
+    _comp_compgen_split -- "$(
+        awk '{ print $1 }' /usr/share/i18n/SUPPORTED 2>/dev/null
+    )"
 } &&
     complete -F _comp_cmd_locale_gen locale-gen
 

--- a/completions/lpq
+++ b/completions/lpq
@@ -7,7 +7,7 @@ _comp_cmd_lpq()
 
     case $prev in
         -P)
-            COMPREPLY=($(compgen -W "$(lpstat -a 2>/dev/null | cut -d' ' -f1)" -- "$cur"))
+            _comp_compgen_split -- "$(lpstat -a 2>/dev/null | cut -d' ' -f1)"
             return
             ;;
         -U)

--- a/completions/lpr
+++ b/completions/lpr
@@ -7,7 +7,7 @@ _comp_cmd_lpr()
 
     case $prev in
         -P)
-            COMPREPLY=($(compgen -W "$(lpstat -a 2>/dev/null | cut -d' ' -f1)" -- "$cur"))
+            _comp_compgen_split -- "$(lpstat -a 2>/dev/null | cut -d' ' -f1)"
             return
             ;;
         -U)

--- a/completions/lspci
+++ b/completions/lspci
@@ -18,8 +18,7 @@ _comp_cmd_lspci()
             return
             ;;
         -*A)
-            COMPREPLY=($(compgen -W '$("$1" -A help | command grep -vF :)' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" -A help | command grep -vF :)"
             return
             ;;
         -*H)

--- a/completions/lvm
+++ b/completions/lvm
@@ -7,26 +7,26 @@ _comp_cmd_lvm__filedir()
 
 _comp_cmd_lvm__volumegroups()
 {
-    COMPREPLY=($(compgen -W "$(vgscan 2>/dev/null |
-        command sed -n -e 's|.*Found.*"\(.*\)".*$|\1|p')" -- "$cur"))
+    _comp_compgen_split -- "$(vgscan 2>/dev/null |
+        command sed -n -e 's|.*Found.*"\(.*\)".*$|\1|p')"
 }
 
 _comp_cmd_lvm__physicalvolumes_all()
 {
-    COMPREPLY=($(compgen -W "$(pvscan 2>/dev/null |
-        command sed -n -e 's|^.*PV \([^ ]*\) .*|\1|p')" -- "$cur"))
+    _comp_compgen_split -- "$(pvscan 2>/dev/null |
+        command sed -n -e 's|^.*PV \([^ ]*\) .*|\1|p')"
 }
 
 _comp_cmd_lvm__physicalvolumes()
 {
-    COMPREPLY=($(compgen -W "$(pvscan 2>/dev/null |
-        command sed -n -e 's|^.*PV \(.*\) VG.*$|\1|p')" -- "$cur"))
+    _comp_compgen_split -- "$(pvscan 2>/dev/null |
+        command sed -n -e 's|^.*PV \(.*\) VG.*$|\1|p')"
 }
 
 _comp_cmd_lvm__logicalvolumes()
 {
-    COMPREPLY=($(compgen -W "$(lvscan 2>/dev/null |
-        command sed -n -e "s|^.*'\(.*\)'.*$|\1|p")" -- "$cur"))
+    _comp_compgen_split -- "$(lvscan 2>/dev/null |
+        command sed -n -e "s|^.*'\(.*\)'.*$|\1|p")"
     if [[ $cur == /dev/mapper/* ]]; then
         _comp_compgen -a filedir
         local i

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -12,8 +12,7 @@ _comp_cmd_mcrypt()
             return
             ;;
         -o | --keymode)
-            COMPREPLY=($(compgen -W '$("$1" --list-keymodes 2>/dev/null )' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-keymodes 2>/dev/null)"
             return
             ;;
         -m | --mode)
@@ -26,8 +25,8 @@ _comp_cmd_mcrypt()
             return
             ;;
         -h | --hash)
-            COMPREPLY=($(compgen -W '$("$1" --list-hash 2>/dev/null | \
-                command sed -e 1d)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-hash 2>/dev/null |
+                command sed -e 1d)"
             return
             ;;
         -k | -s | --key | --keysize)

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -17,13 +17,12 @@ _comp_cmd_mcrypt()
             return
             ;;
         -m | --mode)
-            COMPREPLY=($(compgen -W "$("$1" --list 2>/dev/null | cut -d: -f2-)" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list 2>/dev/null | cut -d: -f2-)"
             return
             ;;
         -a | --algorithm)
-            COMPREPLY=($(compgen -W "$("$1" --list 2>/dev/null |
-                awk '{print $1}')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list 2>/dev/null |
+                awk '{print $1}')"
             return
             ;;
         -h | --hash)

--- a/completions/medusa
+++ b/completions/medusa
@@ -15,8 +15,8 @@ _comp_cmd_medusa()
             return
             ;;
         -*M)
-            COMPREPLY=($(compgen -W "$("$1" -d | awk '/^ +\+/ {print $2}' |
-                command sed -e 's/\.mod$//')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -d | awk '/^ +\+/ {print $2}' |
+                command sed -e 's/\.mod$//')"
             return
             ;;
     esac

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -96,9 +96,9 @@ _comp_cmd_modprobe()
                         _comp_compgen -- -W "$choices"
                     fi
                 else
-                    COMPREPLY=($(compgen -S = -W "$(PATH="$PATH:/sbin" \
+                    _comp_compgen_split -S = -- "$(PATH="$PATH:/sbin" \
                         modinfo -p "$module" 2>/dev/null |
-                        awk -F: '!/^[ \t]/ { print $1 }')" -- "$cur"))
+                        awk -F: '!/^[ \t]/ { print $1 }')"
                     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
                 fi
             else

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -35,8 +35,7 @@ _comp_cmd_mplayer()
             else
                 _comp_compgen_filedir ttf
             fi
-            local IFS=$'\n'
-            COMPREPLY+=($(compgen -W '$(fc-list 2>/dev/null)' -- "$cur"))
+            _comp_compgen -a split -l -- "$(fc-list 2>/dev/null)"
             return
             ;;
         -sub | -sub-file)
@@ -268,10 +267,10 @@ _comp_cmd_mplayer()
 
     case $cur in
         -*)
-            COMPREPLY=($(compgen -W '$("$cmd" -noconfig all -list-options 2>/dev/null | \
+            _comp_compgen_split -- "$("$cmd" -noconfig all -list-options 2>/dev/null |
                 command sed -ne "1,/^[[:space:]]*Name/d" \
                     -e "s/^[[:space:]]*/-/" -e "s/[[:space:]:].*//" \
-                    -e "/^-\(Total\|.*\*\)\{0,1\}$/!p")' -- "$cur"))
+                    -e "/^-\(Total\|.*\*\)\{0,1\}$/!p")"
             ;;
         *)
             _comp_compgen_filedir '@(m?(j)p?(e)g|M?(J)P?(E)G|wm[av]|WM[AV]|avi|AVI|asf|ASF|vob|VOB|bin|BIN|dat|DAT|vcd|VCD|ps|PS|pes|PES|fl[iv]|FL[IV]|fxm|FXM|viv|VIV|rm?(j)|RM?(J)|ra?(m)|RA?(M)|yuv|YUV|mov|MOV|qt|QT|mp[234]|MP[234]|m?(p)4[av]|M?(P)4[AV]|og[gmavx]|OG[GMAVX]|w?(a)v|W?(A)V|dump|DUMP|mk[av]|MK[AV]|aac|AAC|m2v|M2V|dv|DV|rmvb|RMVB|mid|MID|t[ps]|T[PS]|3g[p2]|3gpp?(2)|mpc|MPC|flac|FLAC|vro|VRO|divx|DIVX|aif?(f)|AIF?(F)|m2t?(s)|M2T?(S)|mts|MTS|vdr|VDR|xvid|XVID|ape|APE|gif|GIF|nut|NUT|bik|BIK|web[am]|WEB[AM]|amr|AMR|awb|AWB|iso|ISO|opus|OPUS|m[eo]d|M[EO]D|xm|XM|it|IT|s[t3]m|S[T3]M|mtm|MTM|w64|W64)?(.@(crdownload|part))'

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -3,9 +3,9 @@
 _comp_cmd_mplayer__options()
 {
     cur=${cur%\\}
-    COMPREPLY=($(compgen -W "$("$1" -noconfig all "$2" help 2>/dev/null |
+    _comp_compgen_split -- "$("$1" -noconfig all "$2" help 2>/dev/null |
         command sed -e '/^Available/,/^$/!d' -e '/^Available/d' | awk '{print $1}' |
-        command sed -e 's/:$//' -e 's/^'"${2#-}"'$//' -e 's/<.*//')" -- "$cur"))
+        command sed -e 's/:$//' -e 's/^'"${2#-}"'$//' -e 's/<.*//')"
 }
 
 _comp_cmd_mplayer()

--- a/completions/msynctool
+++ b/completions/msynctool
@@ -7,9 +7,8 @@ _comp_cmd_msynctool()
 
     case $words in
         --configure)
-            COMPREPLY=($(compgen -W "$("$1" --showgroup \
-                "$prev" | awk '/^Member/ {print $2}' | command sed \
-                -e 's/:$//')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" --showgroup "$prev" |
+                awk '/^Member/ {print $2}' | command sed -e 's/:$//')"
             return
             ;;
         --addmember)

--- a/completions/msynctool
+++ b/completions/msynctool
@@ -12,21 +12,18 @@ _comp_cmd_msynctool()
             return
             ;;
         --addmember)
-            COMPREPLY=($(compgen -W '$("$1" --listplugins \
-                | command sed -e 1d)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --listplugins | command sed -e 1d)"
             return
             ;;
     esac
 
     case $prev in
         --configure | --addgroup | --delgroup | --showgroup | --sync | --addmember)
-            COMPREPLY=($(compgen -W '$("$1" --listgroups \
-                | command sed -e 1d)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --listgroups | command sed -e 1d)"
             return
             ;;
         --showformats | --filter-objtype | --slow-sync)
-            COMPREPLY=($(compgen -W '$("$1" --listobjects \
-                | command sed -e 1d)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --listobjects | command sed -e 1d)"
             return
             ;;
     esac

--- a/completions/munin-run
+++ b/completions/munin-run
@@ -19,8 +19,7 @@ _comp_cmd_munin_run()
     if [[ $cur == -* ]]; then
         _comp_compgen_help
     else
-        COMPREPLY=($(compgen -W \
-            '$(command ls /etc/munin/plugins 2>/dev/null)' -- "$cur"))
+        _comp_compgen_split -- "$(command ls /etc/munin/plugins 2>/dev/null)"
     fi
 } &&
     complete -F _comp_cmd_munin_run munin-run

--- a/completions/munindoc
+++ b/completions/munindoc
@@ -5,8 +5,7 @@ _comp_cmd_munindoc()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    COMPREPLY=($(compgen -W \
-        '$(command ls /usr/share/munin/plugins 2>/dev/null)' -- "$cur"))
+    _comp_compgen_split -- "$(command ls /usr/share/munin/plugins 2>/dev/null)"
 } &&
     complete -F _comp_cmd_munindoc munindoc
 

--- a/completions/mysql
+++ b/completions/mysql
@@ -30,7 +30,8 @@ _comp_cmd_mysql()
             return
             ;;
         --database | -${noargopts}D)
-            COMPREPLY=($(compgen -W "$(mysqlshow 2>/dev/null | command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" -- "$cur"))
+            _comp_compgen_split -- "$(mysqlshow 2>/dev/null |
+                command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')"
             return
             ;;
 
@@ -96,9 +97,8 @@ _comp_cmd_mysql()
             ;;
     esac
 
-    COMPREPLY=($(compgen -W \
-        "$(mysqlshow 2>/dev/null | command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')" \
-        -- "$cur"))
+    _comp_compgen_split -- "$(mysqlshow 2>/dev/null |
+        command sed -ne '2d' -e 's/^|.\([^|]*\)|.*/\1/p')"
 } &&
     complete -F _comp_cmd_mysql mysql
 

--- a/completions/ncftp
+++ b/completions/ncftp
@@ -17,8 +17,8 @@ _comp_cmd_ncftp()
     fi
 
     if [[ $cword -eq 1 && -f ~/.ncftp/bookmarks ]]; then
-        COMPREPLY=($(compgen -W '$(command sed -ne "s/^\([^,]\{1,\}\),.*$/\1/p" \
-            ~/.ncftp/bookmarks)' -- "$cur"))
+        _comp_compgen_split -- "$(command sed -ne \
+            's/^\([^,]\{1,\}\),.*$/\1/p' ~/.ncftp/bookmarks)"
     fi
 
 } &&

--- a/completions/nmap
+++ b/completions/nmap
@@ -35,7 +35,7 @@ _comp_cmd_nmap()
         # expand --foo/bar to --foo --bar
         # strip everything following a non-option name or = char
         # TODO: should expand -T<0-5> to -T0 ... -T5
-        COMPREPLY=($(compgen -W "$(
+        _comp_compgen_split -- "$(
             "$1" --help 2>&1 | command sed \
                 -e "s/:.*$//" \
                 -e "s/=.*$/=/" \
@@ -44,8 +44,7 @@ _comp_cmd_nmap()
                 -e "/^[[:space:]]*-[^-]/s/\/\([^-]\)/ -\1/g" \
                 -e "/^[[:space:]]*--/s/\/\([^-]\)/ --\1/g" \
                 -e "s/[^[:space:]a-zA-Z0-9=-].*$//"
-        )" \
-            -- "$cur"))
+        )"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _known_hosts_real -- "$cur"

--- a/completions/openssl
+++ b/completions/openssl
@@ -22,7 +22,7 @@ _comp_cmd_openssl__sections()
 
     [[ ! -f $config ]] && return
 
-    COMPREPLY=($(compgen -W "$(awk '/\[.*\]/ {print $2}' "$config")" -- "$cur"))
+    _comp_compgen_split -- "$(awk '/\[.*\]/ {print $2}' "$config")"
 }
 
 # TODO:API: rename per conventions, rework to use vars rather than outputting
@@ -104,7 +104,7 @@ _comp_cmd_openssl()
                 return
                 ;;
             -cipher)
-                COMPREPLY=($(IFS=: compgen -W "$("$1" ciphers)" -- "$cur"))
+                _comp_compgen_split -F : -- "$("$1" ciphers)"
                 return
                 ;;
             -kdf)

--- a/completions/pdftotext
+++ b/completions/pdftotext
@@ -11,8 +11,8 @@ _comp_cmd_pdftotext()
             return
             ;;
         -enc)
-            COMPREPLY=($(compgen -W '$("$1" -listenc 2>/dev/null |
-                command sed -e 1d)' -- "$cur"))
+            _comp_compgen_split -- "$("$1" -listenc 2>/dev/null |
+                command sed -e 1d)"
             return
             ;;
         -eol)

--- a/completions/perl
+++ b/completions/perl
@@ -2,9 +2,8 @@
 
 _comp_cmd_perl__helper()
 {
-    COMPREPLY=($(compgen -P "$prefix" -W \
-        "$("${1:-perl}" "${BASH_SOURCE[0]%/*}/../helpers/perl" "$2" "$cur")" \
-        -- "$cur"))
+    _comp_compgen_split -P "$prefix" -- "$("${1:-perl}" \
+        "${BASH_SOURCE[0]%/*}/../helpers/perl" "$2" "$cur")"
     [[ $2 == functions ]] || _comp_ltrim_colon_completions "$prefix$cur"
 }
 

--- a/completions/perl
+++ b/completions/perl
@@ -47,10 +47,10 @@ _comp_cmd_perl()
                 if [[ $cur == :* ]]; then
                     temp="${cur##+(:)}"
                     prefix+=${cur%"$temp"}
-                    local IFS=$'\n'
-                    COMPREPLY=($(compgen -P "$prefix" -W \
-                        '$("$1" -MConfig -e "print join \"\\n\",
-                           keys %Config::Config" 2>/dev/null)' -- "$temp"))
+                    _comp_compgen -c "$temp" split -lP "$prefix" -- "$(
+                        "$1" -MConfig -e 'print join "\n",
+                           keys %Config::Config' 2>/dev/null
+                    )"
                     _comp_ltrim_colon_completions "$prefix$temp"
                 fi
                 return
@@ -130,11 +130,9 @@ _comp_cmd_perldoc()
         if [[ $cur != @(*/|[.~])* ]]; then
             _comp_cmd_perl__helper "" perldocs
             if [[ $cur == p* ]]; then
-                COMPREPLY+=($(compgen -W \
-                    '$(PERLDOC_PAGER=cat "$1" -u perl |  \
-                       command sed -ne "/perl.*Perl overview/,/perlwin32/p" | \
-                       awk "\$NF=2 && \$1 ~ /^perl/ { print \$1 }")' \
-                    -- "$cur"))
+                _comp_compgen -a split -- "$(PERLDOC_PAGER=cat "$1" -u perl |
+                    command sed -ne '/perl.*Perl overview/,/perlwin32/p' |
+                    awk '$NF=2 && $1 ~ /^perl/ { print $1 }')"
             fi
         fi
         _comp_compgen -a filedir 'p@([lm]|od)'

--- a/completions/perlcritic
+++ b/completions/perlcritic
@@ -19,8 +19,7 @@ _comp_cmd_perlcritic()
             return
             ;;
         --theme)
-            COMPREPLY=($(compgen -W '$("$1" --list-themes 2>/dev/null)' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --list-themes 2>/dev/null)"
             return
             ;;
         --profile-strictness)

--- a/completions/pgrep
+++ b/completions/pgrep
@@ -36,12 +36,10 @@ _comp_cmd_pgrep()
             return
             ;;
         --nslist)
-            COMPREPLY=(
-                $(IFS=$' \t\n,' compgen -W '$("$1" --help 2>&1 |
-                    command sed -ne \
-                        "s/^[[:space:]]*Available namespaces://p")' \
-                    -- "${cur##*,}"))
-            ((${#COMPREPLY[@]})) &&
+            _comp_compgen -c "${cur##*,}" split -F $' \t\n,' -- "$(
+                "$1" --help 2>&1 |
+                    command sed -ne 's/^[[:space:]]*Available namespaces://p'
+            )" &&
                 _comp_delimited , -W '"${COMPREPLY[@]}"'
             return
             ;;

--- a/completions/pine
+++ b/completions/pine
@@ -24,8 +24,7 @@ _comp_cmd_pine()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -h
     else
-        COMPREPLY=($(compgen -W '$(awk "{print \$1}" ~/.addressbook \
-            2>/dev/null)' -- "$cur"))
+        _comp_compgen_split -- "$(awk '{print $1}' ~/.addressbook 2>/dev/null)"
     fi
 } &&
     complete -F _comp_cmd_pine pine alpine

--- a/completions/pkg-config
+++ b/completions/pkg-config
@@ -15,9 +15,9 @@ _comp_cmd_pkg_config()
             local word
             for word in "${words[@]:1}"; do
                 if [[ $word != -* ]]; then
-                    COMPREPLY=($(compgen -W \
-                        '$("$1" "$word" --print-variables 2>/dev/null)' \
-                        -- "$cur"))
+                    _comp_compgen_split -- "$(
+                        "$1" "$word" --print-variables 2>/dev/null
+                    )"
                     break
                 fi
             done

--- a/completions/pkg-config
+++ b/completions/pkg-config
@@ -35,8 +35,8 @@ _comp_cmd_pkg_config()
         _comp_compgen_help
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
-        COMPREPLY=($(compgen -W "$("$1" --list-all \
-            2>/dev/null | awk '{print $1}')" -- "$cur"))
+        _comp_compgen_split -- "$("$1" --list-all 2>/dev/null |
+            awk '{print $1}')"
         _comp_compgen -a filedir pc
     fi
 } &&

--- a/completions/pkgrm
+++ b/completions/pkgrm
@@ -36,7 +36,7 @@ _comp_cmd_pkgrm()
                 local opts="-a -A -n -M -R -s -v -V -Y"
                 _comp_compgen -- -W "${opts}"
             else
-                COMPREPLY=($(compgen -W "$(/bin/ls -1 "$spool")" -- "${cur}"))
+                _comp_compgen_split -- "$(/bin/ls -1 "$spool")"
             fi
             ;;
     esac

--- a/completions/pngfix
+++ b/completions/pngfix
@@ -14,9 +14,8 @@ _comp_cmd_pngfix()
             return
             ;;
         --strip)
-            COMPREPLY=($(IFS='|' compgen -W '$("$1" --help 2>&1 |
-                command sed -ne "s/.*--strip=\[\([^]]*\)\].*/\1/p")' \
-                -- "$cur"))
+            _comp_compgen_split -F '|' -- "$("$1" --help 2>&1 |
+                command sed -ne 's/.*--strip=\[\([^]]*\)\].*/\1/p')"
             return
             ;;
     esac

--- a/completions/ps
+++ b/completions/ps
@@ -50,7 +50,8 @@ _comp_cmd_ps()
         --format | ?(-)[Oo] | [^-]*[Oo])
             # TODO: This doesn't work well when there are multiple options for
             # the non-first item (similarly to useradd --groups and others).
-            _comp_delimited , -W "$("$1" L | awk '{ print $1 }')"
+            local labels=$("$1" L | awk '{ print $1 }')
+            _comp_delimited , -W '$labels'
             return
             ;;
     esac

--- a/completions/psql
+++ b/completions/psql
@@ -4,15 +4,15 @@ _comp_cmd_psql__databases()
 {
     # -w was introduced in 8.4, https://launchpad.net/bugs/164772
     # "Access privileges" in output may contain linefeeds, hence the NF > 1
-    COMPREPLY=($(compgen -W "$(psql -XAtqwlF $'\t' 2>/dev/null |
-        awk 'NF > 1 { print $1 }')" -- "$cur"))
+    _comp_compgen_split -- "$(psql -XAtqwlF $'\t' 2>/dev/null |
+        awk 'NF > 1 { print $1 }')"
 }
 
 _comp_cmd_psql__users()
 {
     # -w was introduced in 8.4, https://launchpad.net/bugs/164772
-    COMPREPLY=($(compgen -W "$(psql -XAtqwc 'select usename from pg_user' \
-        template1 2>/dev/null)" -- "$cur"))
+    _comp_compgen_split -- "$(psql -XAtqwc 'select usename from pg_user' \
+        template1 2>/dev/null)"
     ((${#COMPREPLY[@]} == 0)) && _comp_compgen -- -u
 }
 

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -31,8 +31,8 @@ _comp_cmd_pydoc()
 
     # Note that we don't do "pydoc modules" as it is known to hang on
     # some systems; _comp_xfunc_python_modules tends to work better and faster.
-    COMPREPLY+=($(compgen -W \
-        '$("$1" keywords topics | command sed -e /^Here/d)' -- "$cur"))
+    _comp_compgen -a split -- "$("$1" keywords topics |
+        command sed -e '/^Here/d')"
 
     _comp_compgen -a filedir py
 } &&

--- a/completions/python
+++ b/completions/python
@@ -16,9 +16,8 @@ _python_modules()
 
 _comp_cmd_python__modules()
 {
-    COMPREPLY+=($(compgen -W \
-        "$("$1" "${BASH_SOURCE[0]%/*}/../helpers/python" "$cur" \
-            2>/dev/null)" -- "$cur"))
+    _comp_compgen -a split -- "$("$1" \
+        "${BASH_SOURCE[0]%/*}/../helpers/python" "$cur" 2>/dev/null)"
 }
 
 # @since 2.12
@@ -63,10 +62,10 @@ _comp_cmd_python()
             return
             ;;
         -${noargopts}X)
-            COMPREPLY=($(compgen -W "$("$1" -h 2>&1 |
+            _comp_compgen_split -- "$("$1" -h 2>&1 |
                 awk '$1 == "-X" && $2 ~ /:$/ {
                     sub(":$","",$2); sub("=.*","=",$2); print $2
-                }')" -- "$cur"))
+                }')"
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             return
             ;;

--- a/completions/qdbus
+++ b/completions/qdbus
@@ -5,9 +5,10 @@ _comp_cmd_qdbus()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    [[ $cur ]] && unset -v "words[$((${#words[@]} - 1))]"
-    COMPREPLY=($(compgen -W '$(command "${words[@]}" 2>/dev/null | \
-        command sed "s/(.*)//")' -- "$cur"))
+    _comp_compgen_split -- "$(
+        [[ $cur ]] && unset -v "words[$((${#words[@]} - 1))]"
+        command "${words[@]}" 2>/dev/null | command sed 's/(.*)//'
+    )"
 } &&
     complete -F _comp_cmd_qdbus qdbus dcop
 

--- a/completions/qemu
+++ b/completions/qemu
@@ -27,18 +27,17 @@ _comp_cmd_qemu()
             return
             ;;
         -soundhw)
-            COMPREPLY=($(compgen -W "$("$1" -soundhw help | awk \
-                '/^[[:lower:]]/ {print $1}') all" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -soundhw help |
+                awk '/^[[:lower:]]/ {print $1}') all"
             return
             ;;
         -machine | -M)
-            COMPREPLY=($(compgen -W "$("$1" "$prev" help | awk \
-                '/^[[:lower:]]/ {print $1}')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" "$prev" help | awk \
+                '/^[[:lower:]]/ {print $1}')"
             return
             ;;
         -cpu)
-            COMPREPLY=($(compgen -W "$("$1" -cpu help | awk '{print $2}')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" -cpu help | awk '{print $2}')"
             return
             ;;
         -usbdevice)
@@ -81,8 +80,8 @@ _comp_cmd_qemu()
             return
             ;;
         -watchdog)
-            COMPREPLY=($(compgen -W "$("$1" -watchdog help 2>&1 |
-                awk '{print $1}')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -watchdog help 2>&1 |
+                awk '{print $1}')"
             return
             ;;
         -watchdog-action)

--- a/completions/quota
+++ b/completions/quota
@@ -31,8 +31,7 @@ _comp_cmd_quota__filesystems()
 {
     #  Only list filesystems starting with "/", otherwise we also get
     #+ "binfmt_misc", "proc", "tmpfs", ...
-    COMPREPLY=($(compgen -W "$(awk '/^\// {print $1}' /etc/mtab)" \
-        -- "$cur"))
+    _comp_compgen_split -- "$(awk '/^\// {print $1}' /etc/mtab)"
 }
 
 _comp_cmd_quota()

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -21,20 +21,19 @@ _comp_cmd_reportbug()
             return
             ;;
         --keyid | -${noargopts}K)
-            COMPREPLY=($(compgen -W '$(IFS=: ; \
-                gpg --list-keys --with-colons 2>/dev/null \
-                | while read -ra row ; do
-                    [[ "${row[0]}" == [ps]ub && ${row[11]} == *s* ]] && \
-                        printf "%s\n" "${row[4]}"
-                done)' -- "$cur"))
+            _comp_compgen_split -- "$(
+                IFS=:
+                gpg --list-keys --with-colons 2>/dev/null |
+                    while read -ra row; do
+                        [[ ${row[0]} == [ps]ub && ${row[11]} == *s* ]] &&
+                            printf '%s\n' "${row[4]}"
+                    done
+            )"
             return
             ;;
         --tag | --ui | --interface | --type | --bts | --severity | --mode | -${noargopts}[TutBS])
-            COMPREPLY=($(
-                compgen -W \
-                    '$("$1" "$prev" help 2>&1 | sed -ne "/^[[:space:]]/p")' \
-                    -- "$cur"
-            ))
+            _comp_compgen_split -- "$("$1" "$prev" help 2>&1 |
+                sed -ne '/^[[:space:]]/p')"
             return
             ;;
         --editor | --mua | --mbox-reader-cmd | -${noargopts}e)
@@ -43,8 +42,8 @@ _comp_cmd_reportbug()
             return
             ;;
         --from-buildd)
-            COMPREPLY=($(compgen -S "_" -W '$(apt-cache dumpavail | \
-                command grep "^Source: $cur" | sort -u | cut -f2 -d" ")'))
+            _comp_compgen_split -S "_" -- "$(apt-cache dumpavail |
+                command grep "^Source: $cur" | sort -u | cut -f2 -d' ')"
             return
             ;;
         --smtphost)

--- a/completions/rpcdebug
+++ b/completions/rpcdebug
@@ -12,8 +12,8 @@ _comp_cmd_rpcdebug__flags()
     done
 
     if [[ $module ]]; then
-        COMPREPLY=($(compgen -W "$(rpcdebug -vh 2>&1 |
-            command sed -ne 's/^'"$module"'[[:space:]]\{1,\}//p')" -- "$cur"))
+        _comp_compgen_split -- "$(rpcdebug -vh 2>&1 |
+            command sed -ne 's/^'"$module"'[[:space:]]\{1,\}//p')"
     fi
 }
 

--- a/completions/rpm
+++ b/completions/rpm
@@ -18,7 +18,7 @@ _comp_cmd_rpm__installed_packages()
             /var/log/rpmpkgs)"
     elif type rpmqpack &>/dev/null; then
         # SUSE's rpmqpack is faster than rpm -qa
-        COMPREPLY=($(compgen -W '$(rpmqpack)' -- "$cur"))
+        _comp_compgen_split -- "$(rpmqpack)"
     else
         COMPREPLY=($("${1:-rpm}" -qa --nodigest --nosignature \
             --queryformat='%{NAME} ' "$cur*" 2>/dev/null))

--- a/completions/rpm
+++ b/completions/rpm
@@ -13,9 +13,9 @@ _comp_cmd_rpm__installed_packages()
     if [[ -r /var/log/rpmpkgs &&
         /var/log/rpmpkgs -nt /var/lib/rpm/Packages ]]; then
         # using RHL 7.2 or later - this is quicker than querying the DB
-        COMPREPLY=($(compgen -W "$(command sed -ne \
+        _comp_compgen_split -- "$(command sed -ne \
             's|^\([^[:space:]]\{1,\}\)-[^[:space:]-]\{1,\}-[^[:space:]-]\{1,\}\.rpm$|\1|p' \
-            /var/log/rpmpkgs)" -- "$cur"))
+            /var/log/rpmpkgs)"
     elif type rpmqpack &>/dev/null; then
         # SUSE's rpmqpack is faster than rpm -qa
         COMPREPLY=($(compgen -W '$(rpmqpack)' -- "$cur"))
@@ -31,24 +31,22 @@ _comp_deprecate_func 2.12 _rpm_installed_packages \
 _comp_cmd_rpm__groups()
 {
     local IFS=$'\n'
-    COMPREPLY=($(compgen -W "$("${1:-rpm}" -qa --nodigest --nosignature \
-        --queryformat='%{GROUP}\n' 2>/dev/null)" -- "$cur"))
+    _comp_compgen_split -- "$("${1:-rpm}" -qa --nodigest --nosignature \
+        --queryformat='%{GROUP}\n' 2>/dev/null)"
 }
 
 _comp_cmd_rpm__macros()
 {
     # get a list of macros
-    COMPREPLY=($(compgen -W "$("${1:-rpm}" --showrc | command sed -ne \
-        's/^-\{0,1\}[0-9]\{1,\}[:=][[:space:]]\{1,\}\([^[:space:](]\{3,\}\).*/%\1/p')" \
-        -- "$cur"))
+    _comp_compgen_split -- "$("${1:-rpm}" --showrc | command sed -ne \
+        's/^-\{0,1\}[0-9]\{1,\}[:=][[:space:]]\{1,\}\([^[:space:](]\{3,\}\).*/%\1/p')"
 }
 
 # shellcheck disable=SC2120
 _comp_cmd_rpm__buildarchs()
 {
-    COMPREPLY=($(compgen -W "$("${1:-rpm}" --showrc | command sed -ne \
-        's/^\s*compatible\s\s*build\s\s*archs\s*:\s*\(.*\)/\1/ p')" \
-        -- "$cur"))
+    _comp_compgen_split -- "$("${1:-rpm}" --showrc | command sed -ne \
+        's/^\s*compatible\s\s*build\s\s*archs\s*:\s*\(.*\)/\1/ p')"
 }
 
 # shellcheck disable=SC2120
@@ -120,9 +118,9 @@ _comp_cmd_rpm()
                     *suggests) fmt="%{SUGGESTNAME}" ;;
                     *supplements) fmt="%{SUPPLEMENTNAME}" ;;
                 esac
-                COMPREPLY=($(compgen -W "$("$1" -qa --nodigest --nosignature \
+                _comp_compgen_split -- "$("$1" -qa --nodigest --nosignature \
                     --queryformat=\"$fmt\\n\" 2>/dev/null |
-                    command grep -vF '(none)')" -- "$cur"))
+                    command grep -vF '(none)')"
             fi
             return
             ;;
@@ -282,8 +280,8 @@ _comp_cmd_rpmbuild()
             local cfgdir
             _comp_cmd_rpm__configdir
             if [[ $cfgdir ]]; then
-                COMPREPLY=($(compgen -W "$(command ls "$cfgdir" 2>/dev/null |
-                    command sed -ne 's/^brp-//p')" -- "$cur"))
+                _comp_compgen_split -- "$(command ls "$cfgdir" 2>/dev/null |
+                    command sed -ne 's/^brp-//p')"
             fi
             ;;
         --define | --with | --without | -${noargopts}D)

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -24,8 +24,7 @@ _comp_cmd_sbopkg()
             return
             ;;
         -V)
-            COMPREPLY=($(compgen -W "?
-                $(sbopkg -V '?' 2>&1 | cut -s -f1)" -- "$cur"))
+            _comp_compgen_split -- "? $(sbopkg -V '?' 2>&1 | cut -s -f1)"
             return
             ;;
         -i | -b) ;;

--- a/completions/scrub
+++ b/completions/scrub
@@ -13,9 +13,8 @@ _comp_cmd_scrub()
             return
             ;;
         --pattern | -${noargopts}p)
-            COMPREPLY=($(compgen -W '$("$1" --help 2>&1 |
-                awk "/^Available/{flag=1;next}/^ /&&flag{print \$1}")' \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" --help 2>&1 |
+                awk '/^Available/{flag=1;next}/^ /&&flag{print $1}')"
             return
             ;;
         --freespace | -${noargopts}X)

--- a/completions/sitecopy
+++ b/completions/sitecopy
@@ -43,8 +43,8 @@ _comp_cmd_sitecopy()
     esac
 
     if [[ -r ~/.sitecopyrc ]]; then
-        COMPREPLY=($(compgen -W "$("$1" -v |
-            command sed -n '/^Site:/s/Site: //p')" -- "$cur"))
+        _comp_compgen_split -- "$("$1" -v |
+            command sed -n '/^Site:/s/Site: //p')"
     fi
 } &&
     complete -F _comp_cmd_sitecopy -o default sitecopy

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -8,7 +8,7 @@ _comp_cmd_smbclient__resolve_order()
 _comp_cmd_smbclient__domains()
 {
     if [[ ${BASH_COMPLETION_CMD_SMBTREE_SCAN-${COMP_SAMBA_SCAN-}} ]]; then
-        COMPREPLY=($(compgen -W '$(smbtree -N -D)' -- "$cur"))
+        _comp_compgen_split -- "$(smbtree -N -D)"
     fi
 }
 

--- a/completions/smbclient
+++ b/completions/smbclient
@@ -15,10 +15,8 @@ _comp_cmd_smbclient__domains()
 _comp_cmd_smbclient__hosts()
 {
     if [[ ${BASH_COMPLETION_CMD_SMBTREE_SCAN-${COMP_SAMBA_SCAN-}} ]]; then
-        COMPREPLY=($(compgen -W "$(
-            smbtree -N -S |
-                command sed -ne 's/^[[:space:]]*\\\\*\([^[:space:]]*\).*/\1/p'
-        )" -- "$cur"))
+        _comp_compgen_split -- "$(smbtree -N -S |
+            command sed -ne 's/^[[:space:]]*\\\\*\([^[:space:]]*\).*/\1/p')"
     fi
 }
 

--- a/completions/ss
+++ b/completions/ss
@@ -16,8 +16,9 @@ _comp_cmd_ss()
             return
             ;;
         --query | -${noargopts}A)
-            _comp_delimited , -W "$("$1" --help |
-                command sed -e 's/|/ /g' -ne 's/.*QUERY := {\([^}]*\)}.*/\1/p')"
+            local queries=$("$1" --help |
+                command sed -e 's/|/ /g' -ne 's/.*QUERY := {\([^}]*\)}.*/\1/p')
+            _comp_delimited , -W '$queries'
             return
             ;;
         --diag | --filter | -${noargopts}[DF])

--- a/completions/ssh
+++ b/completions/ssh
@@ -145,7 +145,7 @@ _comp_cmd_ssh__suboption()
             _comp_compgen_filedir
             ;;
         casignaturealgorithms)
-            COMPREPLY=($(compgen -W '$(_comp_cmd_ssh__query "$1" sig)' -- "$cur"))
+            _comp_compgen_split -- "$(_comp_cmd_ssh__query "$1" sig)"
             ;;
         cipher)
             _comp_compgen -- -W 'blowfish des 3des'
@@ -167,10 +167,10 @@ _comp_cmd_ssh__suboption()
                 cs{0..7} ef lowdelay throughput reliability'
             ;;
         hostbasedkeytypes | hostkeyalgorithms)
-            COMPREPLY=($(compgen -W '$(_comp_cmd_ssh__query "$1" key)' -- "$cur"))
+            _comp_compgen_split -- "$(_comp_cmd_ssh__query "$1" key)"
             ;;
         kexalgorithms)
-            COMPREPLY=($(compgen -W '$(_comp_cmd_ssh__query "$1" kex)' -- "$cur"))
+            _comp_compgen_split -- "$(_comp_cmd_ssh__query "$1" kex)"
             ;;
         loglevel)
             _comp_compgen -- -W 'QUIET FATAL ERROR INFO VERBOSE DEBUG{,1,2,3}'
@@ -199,7 +199,7 @@ _comp_cmd_ssh__suboption()
             _comp_compgen -- -c
             ;;
         pubkeyacceptedalgorithms | pubkeyacceptedkeytypes)
-            COMPREPLY=($(compgen -W '$(_comp_cmd_ssh__query "$1" key)' -- "$cur"))
+            _comp_compgen_split -- "$(_comp_cmd_ssh__query "$1" key)"
             ;;
         requesttty)
             _comp_compgen -- -W 'no yes force auto'

--- a/completions/strings
+++ b/completions/strings
@@ -17,18 +17,13 @@ _comp_cmd_strings()
             return
             ;;
         --target | -${noargopts}T)
-            COMPREPLY=($(compgen -W '$(LC_ALL=C "$1" --help 2>/dev/null | \
-                command sed -ne "s/: supported targets: \(.*\)/\1/p")' \
-                -- "$cur"))
+            _comp_compgen_split -- "$(LC_ALL=C "$1" --help 2>/dev/null |
+                command sed -ne 's/: supported targets: \(.*\)/\1/p')"
             return
             ;;
         --encoding | -${noargopts}e)
-            COMPREPLY=($(
-                IFS=, compgen -W \
-                    '$(LC_ALL=C "$1" --help 2>/dev/null | \
-                         command sed -ne "s/.*--encoding={\([^}]*\)}.*/\1/p")' \
-                    -- "$cur"
-            ))
+            _comp_compgen_split -F , -- "$(LC_ALL=C "$1" --help 2>/dev/null |
+                command sed -ne 's/.*--encoding={\([^}]*\)}.*/\1/p')"
             return
             ;;
     esac

--- a/completions/svk
+++ b/completions/svk
@@ -188,8 +188,8 @@ _comp_cmd_svk()
                         --regenerate --up --update --apply --rm --delete'
                     ;;
                 sync)
-                    COMPREPLY=($(compgen -W "$("$1" mirror --list \
-                        2>/dev/null | awk '/^\//{print $1}')" -- "$cur"))
+                    _comp_compgen_split -- "$("$1" mirror --list \
+                        2>/dev/null | awk '/^\//{print $1}')"
                     ;;
                 co | checkout | push | pull)
                     if [[ $cur == //*/* ]]; then
@@ -197,8 +197,8 @@ _comp_cmd_svk()
                     else
                         path=//
                     fi
-                    COMPREPLY=($(compgen -W "$("$1" list "$path" 2>/dev/null |
-                        command sed -e 's|\(.*\)|'"$path"'\1|')" -- "$cur"))
+                    _comp_compgen_split -- "$("$1" list "$path" 2>/dev/null |
+                        command sed -e 's|\(.*\)|'"$path"'\1|')"
                     ;;
                 *)
                     _comp_compgen_filedir

--- a/completions/synclient
+++ b/completions/synclient
@@ -14,8 +14,8 @@ _comp_cmd_synclient()
     if [[ $cur == -* ]]; then
         _comp_compgen_usage
     elif [[ $cur != *=?* ]]; then
-        COMPREPLY=($(compgen -S = -W '$("$1" -l 2>/dev/null | \
-            awk "/^[ \t]/ { print \$1 }")' -- "$cur"))
+        _comp_compgen_split -S = -- "$("$1" -l 2>/dev/null |
+            awk '/^[ \t]/ { print $1 }')"
         compopt -o nospace
     fi
 } &&

--- a/completions/sysbench
+++ b/completions/sysbench
@@ -74,9 +74,9 @@ _comp_cmd_sysbench()
             return
             ;;
         --db-driver)
-            COMPREPLY=($(compgen -W "$("$1" --test=oltp help 2>/dev/null |
+            _comp_compgen_split -- "$("$1" --test=oltp help 2>/dev/null |
                 command sed -e '/^.*database drivers:/,/^$/!d' \
-                    -ne 's/^  *\([^ ]*\) .*/\1/p')" -- "$cur"))
+                    -ne 's/^  *\([^ ]*\) .*/\1/p')"
             return
             ;;
         --db-ps-mode)

--- a/completions/sysctl
+++ b/completions/sysctl
@@ -22,8 +22,9 @@ _comp_cmd_sysctl()
     else
         local suffix=
         [[ $prev == -w ]] && suffix="="
-        COMPREPLY=($(compgen -S "$suffix" -W \
-            "$(PATH="$PATH:/sbin" $1 -N -a 2>/dev/null)" -- "$cur"))
+        _comp_compgen_split -S "$suffix" -- "$(
+            PATH="$PATH:/sbin" $1 -N -a 2>/dev/null
+        )"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     fi
 } &&

--- a/completions/tar
+++ b/completions/tar
@@ -431,13 +431,12 @@ _comp_cmd_tar__try_list_archive()
         fi
     done
     if [[ $tarball ]]; then
-        local IFS=$'\n'
-        COMPREPLY=($(compgen -o filenames -W "$(
+        _comp_compgen -c "$(printf %q "$cur")" split -lo filenames -- "$(
             $tarbin $untar "$tarball" 2>/dev/null |
                 while read -r line; do
-                    printf "%q\n" "$(printf %q"\n" "$line")"
+                    printf "%q\n" "$line"
                 done
-        )" -- "$(printf %q "$cur")"))
+        )"
         return 0
     fi
 }
@@ -599,7 +598,7 @@ _comp_cmd_tar__gnu()
                 break
                 ;;
             --warning)
-                COMPREPLY=($(compgen -W "$(__gtar_parse_warnings)" -- "$cur"))
+                _comp_compgen_split -- "$(__gtar_parse_warnings)"
                 break
                 ;;
             --*)

--- a/completions/tshark
+++ b/completions/tshark
@@ -36,8 +36,7 @@ _comp_cmd_tshark()
             return
             ;;
         -*i)
-            COMPREPLY=($(compgen -W \
-                "$("$1" -D 2>/dev/null | awk '{print $2}')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -D 2>/dev/null | awk '{print $2}')"
             return
             ;;
         -*y)
@@ -49,8 +48,8 @@ _comp_cmd_tshark()
                 fi
             done
             # shellcheck disable=SC2086
-            COMPREPLY=($(compgen -W "$("$1" $opts -L 2>/dev/null |
-                awk '/^  / { print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" $opts -L 2>/dev/null |
+                awk '/^  / { print $1 }')"
             return
             ;;
         -*[ab])
@@ -69,8 +68,7 @@ _comp_cmd_tshark()
             return
             ;;
         -*F)
-            COMPREPLY=($(compgen -W "$("$1" -F 2>&1 |
-                awk '/^  / { print $1 }')" -- "$cur"))
+            _comp_compgen_split -- "$("$1" -F 2>&1 | awk '/^  / { print $1 }')"
             return
             ;;
         -*O)
@@ -110,10 +108,10 @@ _comp_cmd_tshark()
             return
             ;;
         -*G)
-            COMPREPLY=($(compgen -W "$("$1" -G \? 2>/dev/null |
-                awk '/^[ \t]*-G / \
-                    { sub("^[[]","",$2); sub("[]]$","",$2); print $2 }')" \
-                -- "$cur"))
+            _comp_compgen_split -- "$("$1" -G \? 2>/dev/null |
+                awk '/^[ \t]*-G / {
+                    sub("^[[]","",$2); sub("[]]$","",$2); print $2
+                }')"
             return
             ;;
 

--- a/completions/update-alternatives
+++ b/completions/update-alternatives
@@ -13,7 +13,7 @@ _comp_cmd_update_alternatives__installed()
             break
         fi
     done
-    COMPREPLY=($(compgen -W '$(command ls $admindir)' -- "$cur"))
+    COMPREPLY=($(compgen -W '$(command ls "$admindir")' -- "$cur"))
 }
 
 _comp_cmd_update_alternatives()

--- a/completions/update-alternatives
+++ b/completions/update-alternatives
@@ -13,7 +13,7 @@ _comp_cmd_update_alternatives__installed()
             break
         fi
     done
-    COMPREPLY=($(compgen -W '$(command ls "$admindir")' -- "$cur"))
+    _comp_compgen_split -- "$(command ls "$admindir")"
 }
 
 _comp_cmd_update_alternatives()

--- a/completions/valgrind
+++ b/completions/valgrind
@@ -30,12 +30,14 @@ _comp_cmd_valgrind()
             # we want to grab memcheck.
             local -a files
             _comp_expand_glob files '/usr{,/local}/lib{,64,exec}{/*-linux-gnu,}/valgrind/*'
-            ((${#files[@]})) &&
-                COMPREPLY=($(compgen -W '$(
+            if ((${#files[@]})); then
+                _comp_compgen_split -- "$(
                     for f in "${files[@]}"; do
                         [[ $f != *.so && -x $f && $f =~ ^.*/(.*)-[^-]+-[^-]+ ]] &&
-                            printf "%s\n" "${BASH_REMATCH[1]}"
-                    done)' -- "$cur"))
+                            printf '%s\n' "${BASH_REMATCH[1]}"
+                    done
+                )"
+            fi
             return
             ;;
         --sim-hints)

--- a/completions/wget
+++ b/completions/wget
@@ -122,9 +122,9 @@ _comp_cmd_wget()
             return
             ;;
         --user | --http-user | --proxy-user | --ftp-user)
-            COMPREPLY=($(compgen -W "$(command sed -n \
+            _comp_compgen_split -- "$(command sed -n \
                 '/^login/s/^[[:blank:]]*login[[:blank:]]//p' ~/.netrc \
-                2>/dev/null)" -- "$cur"))
+                2>/dev/null)"
             return
             ;;
         --header)

--- a/completions/wodim
+++ b/completions/wodim
@@ -43,8 +43,8 @@ _comp_cmd_wodim()
                 fi
                 ;;
             driver)
-                COMPREPLY=($(compgen -W "$("$1" driver=help 2>&1 |
-                    awk 'NR > 1 { print $1 }') help" -- "$cur"))
+                _comp_compgen_split -- "$("$1" driver=help 2>&1 |
+                    awk 'NR > 1 { print $1 }') help"
                 ;;
             minbuf)
                 _comp_compgen -- -W '{25..95}'

--- a/completions/wtf
+++ b/completions/wtf
@@ -37,8 +37,8 @@ _comp_cmd_wtf()
         [[ $has_db ]] || return
     fi
 
-    COMPREPLY=($(compgen -W "$(cut -f 1 -s "$db"* 2>/dev/null) $addf" \
-        -- "${cur^^}"))
+    _comp_compgen -c "${cur^^}" split \
+        -- "$(cut -f 1 -s "$db"* 2>/dev/null) $addf"
 } &&
     complete -F _comp_cmd_wtf wtf
 

--- a/completions/xdg-settings
+++ b/completions/xdg-settings
@@ -21,8 +21,7 @@ _comp_cmd_xdg_settings()
     if ((args == 1)); then
         _comp_compgen -- -W "get check set"
     elif ((args == 2)); then
-        COMPREPLY=($(compgen -W \
-            '$("$1" --list | awk "!/^Known/ { print \$1 }")' -- "$cur"))
+        _comp_compgen_split -- "$("$1" --list | awk '!/^Known/ { print $1 }')"
     fi
 } &&
     complete -F _comp_cmd_xdg_settings xdg-settings

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -7,8 +7,8 @@ _comp_cmd_xfreerdp()
 
     case $prev in
         -k)
-            COMPREPLY=($(compgen -W '$("$1" --kbd-list |
-                awk "/^0x/ { print \$1 }")' -- "$cur"))
+            _comp_compgen_split -- "$("$1" --kbd-list |
+                awk '/^0x/ { print $1 }')"
             return
             ;;
         -a)
@@ -30,8 +30,8 @@ _comp_cmd_xfreerdp()
 
     case $cur in
         /kbd:*)
-            COMPREPLY=($(compgen -W '$("$1" /kbd-list |
-                awk "/^0x/ { print \$1 }")' -- "${cur#/kbd:}"))
+            _comp_compgen -c "${cur#/kbd:}" split -- "$("$1" /kbd-list |
+                awk '/^0x/ { print $1 }')"
             return
             ;;
         /bpp:*)
@@ -45,17 +45,17 @@ _comp_cmd_xfreerdp()
 
     if [[ $cur == /* ]]; then
         _comp_compgen_filedir rdp
-        COMPREPLY+=($(compgen -W '$("$1" --help |
-            awk "\$1 ~ /^\\// && \$1 !~ /^.(flag\$|option:)/ { sub(\":.*\",\":\",\$1); print \$1 }")' \
-            -- "$cur"))
+        _comp_compgen -a split -- "$(
+            "$1" --help | awk '$1 ~ /^\// && $1 !~ /^.(flag$|option:)/ {
+                sub(":.*",":",$1); print $1 }'
+        )"
         [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
     elif [[ $cur == [+-]* ]]; then
         local char=${cur:0:1}
         local help="$("$1" --help)"
         if [[ $help == */help* ]]; then # new/slash syntax
-            COMPREPLY=($(compgen -W '$(awk "
-                \$1 ~ /^[+-]/ && \$1 !~ /^.toggle\$/ { sub(\"^.\",\"$char\",\$1); print \$1 }
-            " <<<"$help")' -- "$cur"))
+            _comp_compgen_split -- "$(awk '$1 ~ /^[+-]/ && $1 !~ /^.toggle$/ {
+                    sub("^.","'"$char"'",$1); print $1 }' <<<"$help")"
         else # old/dash syntax
             _comp_compgen -R help - <<<"$help"
             ((${#COMPREPLY[@]})) &&

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -63,8 +63,9 @@ _comp_cmd_xfreerdp()
         fi
     else
         _comp_compgen_filedir rdp
-        COMPREPLY+=($(compgen -W "$(awk '{print $1}' ~/.freerdp/known_hosts \
-            2>/dev/null)" -- "$cur"))
+        _comp_compgen -a split -- "$(
+            awk '{print $1}' ~/.freerdp/known_hosts 2>/dev/null
+        )"
     fi
 
 } &&

--- a/completions/xsltproc
+++ b/completions/xsltproc
@@ -16,8 +16,8 @@ _comp_cmd_xsltproc()
             ;;
         --encoding)
             # some aliases removed
-            COMPREPLY=($(compgen -X '@(UTF[1378]|8859|ISO[0-9_])*' \
-                -W "$(iconv -l | command sed -e 's/\/.*//')" -- "$cur"))
+            local encodings=$(iconv -l | command sed -e 's/\/.*//')
+            _comp_compgen -- -X '@(UTF[1378]|8859|ISO[0-9_])*' -W '$encodings'
             return
             ;;
         --param | --stringparam)

--- a/completions/ypmatch
+++ b/completions/ypmatch
@@ -12,13 +12,10 @@ _comp_cmd_ypmatch()
 
     if [[ $cmd == ypmatch && $cword -eq 1 && ${#words[@]} -eq 3 ]]; then
         map=${words[2]}
-        COMPREPLY=($(compgen -W '$(ypcat "$map" 2>/dev/null | \
-            cut -d':' -f 1)' -- "$cur"))
+        _comp_compgen_split -- "$(ypcat "$map" 2>/dev/null | cut -d':' -f 1)"
     else
         [[ $cmd == ypmatch && $cword -ne 2 ]] && return
-        COMPREPLY=($(compgen -W \
-            '$(printf "%s\n" $(ypcat -x 2>/dev/null | \
-               cut -d"\"" -f 2))' -- "$cur"))
+        _comp_compgen_split -- "$(ypcat -x 2>/dev/null | cut -d'"' -f 2)"
     fi
 } &&
     complete -F _comp_cmd_ypmatch ypmatch ypcat

--- a/test/t/unit/test_unit_compgen_split.py
+++ b/test/t/unit/test_unit_compgen_split.py
@@ -1,0 +1,102 @@
+import pytest
+
+from conftest import assert_bash_exec
+
+
+@pytest.mark.bashcomp(cmd=None)
+class TestUtilCompgenSplit:
+    @pytest.fixture
+    def functions(self, bash):
+        assert_bash_exec(
+            bash,
+            "_comp__test_dump() { ((${#arr[@]})) && printf '<%s>' \"${arr[@]}\"; echo; }",
+        )
+        assert_bash_exec(
+            bash,
+            '_comp__test_compgen() { local -a arr=(00); _comp_compgen -v arr "$@"; _comp__test_dump; }',
+        )
+
+        assert_bash_exec(
+            bash,
+            "_comp__test_cmd1() { echo foo bar; echo baz; }",
+        )
+        assert_bash_exec(
+            bash,
+            '_comp__test_attack() { echo "\\$(echo should_not_run >&2)"; }',
+        )
+
+    def test_1_basic(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "<foo><bar><baz>"
+
+    def test_2_attack(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -- "$(_comp__test_attack)"',
+            want_output=True,
+        )
+        assert output.strip() == "<$(echo><should_not_run><>&2)>"
+
+    def test_3_sep1(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -l -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "<foo bar><baz>"
+
+    def test_3_sep2(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            "_comp__test_compgen split -F $'b\\n' -- \"$(_comp__test_cmd1)\"",
+            want_output=True,
+        )
+        assert output.strip() == "<foo ><ar><az>"
+
+    def test_4_optionX(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -X bar -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "<foo><baz>"
+
+    def test_4_optionS(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -S .txt -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "<foo.txt><bar.txt><baz.txt>"
+
+    def test_4_optionP(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -P /tmp/ -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "</tmp/foo></tmp/bar></tmp/baz>"
+
+    def test_4_optionPS(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            '_comp__test_compgen split -P [ -S ] -- "$(_comp__test_cmd1)"',
+            want_output=True,
+        )
+        assert output.strip() == "<[foo]><[bar]><[baz]>"
+
+    def test_5_empty(self, bash, functions):
+        output = assert_bash_exec(
+            bash, '_comp__test_compgen split -- ""', want_output=True
+        )
+        assert output.strip() == ""
+
+    def test_5_empty2(self, bash, functions):
+        output = assert_bash_exec(
+            bash, '_comp__test_compgen split -- " "', want_output=True
+        )
+        assert output.strip() == ""


### PR DESCRIPTION
Resolve #958

This PR introduces a new generator `_comp_compgen_split` that splits the argument to generate words. The difference from the builtin `compgen -W` is that it is safe to pass command outputs to the argument because it doesn't evaluate the expansions in the argument. It was still possible with passing the command substitution with single quotes as `compgen -W '$(command)'`, but it requires excessive quoting and also is incompatible with `_comp_compgen` when the command contains positional parameters such as `$1`. In addition, the inside of the single-quoted command substitutions `'$(...)'` is not checked by `shellcheck`.

This is still a draft because I think I need to add tests for the new function `_comp_compgen_split`.