### PR TITLE
fix(pytest): do not filter underscores from parsed option arg choices

### DIFF
--- a/completions/pytest
+++ b/completions/pytest
@@ -3,7 +3,7 @@
 _comp_cmd_pytest__option_choice_args()
 {
     local modes=$("$1" "$2=bash-completion-nonexistent" 2>&1 |
-        command sed -e 's/[^[:space:][:alnum:]-]\{1,\}//g' \
+        command sed -e 's/[^[:space:][:alnum:]_-]\{1,\}//g' \
             -ne 's/.*choose from //p')
     _comp_compgen -a -- -W '$modes'
 }


### PR DESCRIPTION
For example, one of `--vcr-record`'s arg choices is `new_episodes`.