### PR TITLE
fix: use `_comp_compgen` for the remaining cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,15 +117,21 @@ Also, please bear the following coding guidelines in mind:
   variables are set (e.g. with `[[ -v varname ]]`) or use default
   expansion (e.g. `${varname-}`).
 
-- Prefer `compgen -W '...' -- $cur` over embedding `$cur` in external
-  command arguments (often e.g. sed, grep etc) unless there's a good
-  reason to embed it. Embedding user input in command lines can result
-  in syntax errors and other undesired behavior, or messy quoting
-  requirements when the input contains unusual characters. Good
-  reasons for embedding include functionality (if the thing does not
-  sanely work otherwise) or performance (if it makes a big difference
-  in speed), but all embedding cases should be documented with
-  rationale in comments in the code.
+- Prefer `_comp_compgen_split -- "$(...)"` over embedding `$cur` in external
+  command arguments (often e.g. sed, grep etc) unless there's a good reason to
+  embed it. Embedding user input in command lines can result in syntax errors
+  and other undesired behavior, or messy quoting requirements when the input
+  contains unusual characters.  Good reasons for embedding include
+  functionality (if the thing does not sanely work otherwise) or performance
+  (if it makes a big difference in speed), but all embedding cases should be
+  documented with rationale in comments in the code.
+
+  Do not use `_comp_compgen -- -W "$(...)"` or `_comp_compgen -- -W '$(...)'`
+  but always use `_comp_compgen_split -- "$(...)"`.  In the former case, when
+  the command output contains strings looking like shell expansions, the
+  expansions will be unexpectedly performed, which becomes a vulnerability.  In
+  the latter case, checks by shellcheck and shfmt will not be performed inside
+  `'...'`.  Also, `_comp_compgen_split` is `IFS`-safe.
 
 - When completing available options, offer only the most descriptive
   ones as completion results if there are multiple options that do the

--- a/bash_completion
+++ b/bash_completion
@@ -1024,6 +1024,9 @@ _comp_compgen_filedir()
         local _quoted=$ret
         _comp_unlocal ret
 
+        # work around bash-4.2 where compgen -f "''" produces nothing.
+        [[ $_quoted == "''" ]] && _quoted=""
+
         # Munge xspec to contain uppercase version too
         # https://lists.gnu.org/archive/html/bug-bash/2010-09/msg00036.html
         # news://news.gmane.io/4C940E1C.1010304@case.edu

--- a/bash_completion
+++ b/bash_completion
@@ -665,12 +665,14 @@ _comp_compgen()
 # caller _comp_compgen, the words are appended to the existing elements of the
 # array instead of replacing the existing elements.  This function ignores
 # ${cur-} or the prefix specified by `-v CUR`.
+# @return 0 if at least one completion is generated, or 1 otherwise.
 # @since 2.12
 _comp_compgen_set()
 {
     local _append=${_comp_compgen__append-}
     local _var=${_comp_compgen__var-COMPREPLY}
     eval -- "$_var${_append:++}=(\"\$@\")"
+    (($#))
 }
 
 # Simply split the text and generate completions.  This function should be used
@@ -1004,6 +1006,7 @@ _comp_quote_compgen()
 # @param $1  If `-d', complete only on directories.  Otherwise filter/pick only
 #            completions with `.$1' and the uppercase version of it as file
 #            extension.
+# @return 0 if at least one completion is generated, or 1 otherwise.
 #
 # @since 2.12
 _comp_compgen_filedir()

--- a/bash_completion
+++ b/bash_completion
@@ -2578,7 +2578,6 @@ _comp_command_offset()
     _comp_get_words cur
 
     if ((COMP_CWORD == 0)); then
-        local IFS=$'\n'
         compopt -o filenames
         _comp_compgen -- -d -c
     else

--- a/completions/bzip2
+++ b/completions/bzip2
@@ -26,7 +26,7 @@ _comp_cmd_bzip2()
         return
     fi
 
-    local IFS=$'\n' xspec="*.?(t)bz2"
+    local xspec="*.?(t)bz2"
 
     if [[ $prev == --* ]]; then
         [[ $prev == --@(decompress|list|test) ]] && xspec="!"$xspec

--- a/completions/cd
+++ b/completions/cd
@@ -13,7 +13,7 @@ _comp_cmd_cd()
         return
     fi
 
-    local IFS=$'\n' i j k
+    local i j k
 
     compopt -o filenames
 

--- a/completions/cd
+++ b/completions/cd
@@ -25,8 +25,8 @@ _comp_cmd_cd()
     fi
 
     local mark_dirs="" mark_symdirs=""
-    _comp_readline_variable_on mark-directories && mark_dirs=y
-    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=y
+    _comp_readline_variable_on mark-directories && mark_dirs=set
+    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=set
 
     # we have a CDPATH, so loop on its contents
     local paths dirs

--- a/completions/config_list
+++ b/completions/config_list
@@ -15,8 +15,8 @@ _comp_cmd_config_list()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--inputfile --outputfile --checkonly
-            --verbose --help' -- "$cur"))
+        _comp_compgen -- -W '--inputfile --outputfile --checkonly
+            --verbose --help'
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd

--- a/completions/cpio
+++ b/completions/cpio
@@ -31,8 +31,8 @@ _comp_cmd_cpio()
     [[ $was_split ]] && return
 
     if ((cword == 1)); then
-        COMPREPLY=($(compgen -W '-o --create -i --extract -p --pass-through
-            -? --help --license --usage --version' -- "$cur"))
+        _comp_compgen -- -W '-o --create -i --extract -p --pass-through -?
+            --help --license --usage --version'
     else
         case ${words[1]} in
             -o | --create)

--- a/completions/gzip
+++ b/completions/gzip
@@ -27,7 +27,7 @@ _comp_cmd_gzip()
         return
     fi
 
-    local IFS=$'\n' xspec="*.@(gz|t[ag]z)"
+    local xspec="*.@(gz|t[ag]z)"
     [[ ${1##*/} == pigz ]] && xspec="*.@([gz]z|t[ag]z)"
 
     if [[ $prev == --* ]]; then

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -19,7 +19,7 @@ _comp_cmd_ipmitool()
             local -a files
             _comp_expand_glob files '/dev/ipmi* /dev/ipmi/* /dev/ipmidev/*'
             ((${#files[@]})) &&
-                COMPREPLY=($(compgen -W '"${files[@]##*([^0-9])}"' -X '![0-9]*' -- "$cur"))
+                _comp_compgen -- -W '"${files[@]##*([^0-9])}"' -X '![0-9]*'
             return
             ;;
         -*I)

--- a/completions/java
+++ b/completions/java
@@ -81,11 +81,11 @@ _comp_cmd_java__classes()
             fi
 
         elif [[ -d $i ]]; then
-            COMPREPLY+=(
-                $(compgen -d -- "$i/$cur" | command sed -e "s|^$i/\(.*\)|\1.|")
-                $(compgen -f -X '!*.class' -- "$i/$cur" |
-                    command sed -e '/\$/d' -e "s|^$i/||")
-            )
+            local tmp
+            _comp_compgen -v tmp -c "$i/$cur" -- -d -S .
+            _comp_compgen -av tmp -c "$i/$cur" -- -f -X '!*.class'
+            ((${#tmp[@]})) &&
+                _comp_compgen -a -- -X '*\$*' -W '"${tmp[@]#$i/}"'
             [[ ${COMPREPLY-} == *.class ]] || compopt -o nospace
 
             # FIXME: if we have foo.class and foo/, the completion

--- a/completions/kldload
+++ b/completions/kldload
@@ -18,11 +18,11 @@ _comp_cmd_kldload()
 
     compopt -o filenames
     for i in "${moddirs[@]}"; do
-        modules=($(compgen -f "$i/$cur"))
-        modules=(${modules[@]#$i/})
-        COMPREPLY+=("${modules[@]}")
+        _comp_compgen -v modules -c "$i/$cur" -- -f &&
+            COMPREPLY+=("${modules[@]#$i/}")
     done
-    COMPREPLY=(${COMPREPLY[@]%.ko})
+    ((${#COMPREPLY[@]})) &&
+        COMPREPLY=("${COMPREPLY[@]%.ko}")
 
     # also add dirs in current dir
     _comp_compgen -a filedir -d

--- a/completions/koji
+++ b/completions/koji
@@ -198,8 +198,8 @@ _comp_cmd_koji()
             search)
                 case $nth in
                     1)
-                        COMPREPLY=($(compgen -W 'package build tag target
-                            user host rpm' -- "$cur"))
+                        _comp_compgen -- -W 'package build tag target user host
+                            rpm'
                         ;;
                 esac
                 ;;

--- a/completions/list_members
+++ b/completions/list_members
@@ -23,8 +23,8 @@ _comp_cmd_list_members()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        COMPREPLY=($(compgen -W '--output --regular --digest --nomail
-            --fullnames --preserve --help' -- "$cur"))
+        _comp_compgen -- -W '--output --regular --digest --nomail --fullnames
+            --preserve --help'
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd

--- a/completions/lzma
+++ b/completions/lzma
@@ -15,7 +15,7 @@ _comp_cmd_lzma()
         return
     fi
 
-    local IFS=$'\n' xspec="*.@(lzma|tlz)"
+    local xspec="*.@(lzma|tlz)"
 
     if [[ $prev == --* ]]; then
         [[ $prev == --@(decompress|list|test) ]] && xspec="!"$xspec

--- a/completions/qemu
+++ b/completions/qemu
@@ -45,8 +45,7 @@ _comp_cmd_qemu()
             return
             ;;
         -net)
-            COMPREPLY=($(compgen -W 'nic user tap socket vde none dump' \
-                -- "$cur"))
+            _comp_compgen -- -W 'nic user tap socket vde none dump'
             return
             ;;
         -serial | -parallel | -monitor)

--- a/completions/rpm
+++ b/completions/rpm
@@ -119,7 +119,7 @@ _comp_cmd_rpm()
                     *supplements) fmt="%{SUPPLEMENTNAME}" ;;
                 esac
                 _comp_compgen_split -- "$("$1" -qa --nodigest --nosignature \
-                    --queryformat=\"$fmt\\n\" 2>/dev/null |
+                    --queryformat="\"$fmt\\n\"" 2>/dev/null |
                     command grep -vF '(none)')"
             fi
             return

--- a/completions/rpm
+++ b/completions/rpm
@@ -30,8 +30,7 @@ _comp_deprecate_func 2.12 _rpm_installed_packages \
 
 _comp_cmd_rpm__groups()
 {
-    local IFS=$'\n'
-    _comp_compgen_split -- "$("${1:-rpm}" -qa --nodigest --nosignature \
+    _comp_compgen_split -l -- "$("${1:-rpm}" -qa --nodigest --nosignature \
         --queryformat='%{GROUP}\n' 2>/dev/null)"
 }
 
@@ -109,7 +108,7 @@ _comp_cmd_rpm()
                 _comp_compgen_filedir
             else
                 # complete on capabilities
-                local IFS=$'\n' fmt
+                local fmt
                 case $prev in
                     *enhances) fmt="%{ENHANCENAME}" ;;
                     *provides) fmt="%{PROVIDENAME}" ;;
@@ -118,8 +117,8 @@ _comp_cmd_rpm()
                     *suggests) fmt="%{SUGGESTNAME}" ;;
                     *supplements) fmt="%{SUPPLEMENTNAME}" ;;
                 esac
-                _comp_compgen_split -- "$("$1" -qa --nodigest --nosignature \
-                    --queryformat="\"$fmt\\n\"" 2>/dev/null |
+                _comp_compgen_split -l -- "$("$1" -qa --nodigest \
+                    --nosignature --queryformat="\"$fmt\\n\"" 2>/dev/null |
                     command grep -vF '(none)')"
             fi
             return

--- a/completions/ssh
+++ b/completions/ssh
@@ -182,8 +182,8 @@ _comp_cmd_ssh__suboption()
             _comp_compgen_filedir so
             ;;
         preferredauthentications)
-            COMPREPLY=($(compgen -W 'gssapi-with-mic host-based publickey
-                keyboard-interactive password' -- "$cur"))
+            _comp_compgen -- -W 'gssapi-with-mic host-based publickey
+                keyboard-interactive password'
             ;;
         protocol)
             local protocols=($(_comp_cmd_ssh__query "$1" protocol-version))
@@ -211,8 +211,7 @@ _comp_cmd_ssh__suboption()
             _comp_compgen -- -W 'DAEMON USER AUTH LOCAL{0..7}'
             ;;
         tunnel)
-            COMPREPLY=($(compgen -W 'yes no point-to-point ethernet' \
-                -- "$cur"))
+            _comp_compgen -- -W 'yes no point-to-point ethernet'
             ;;
         updatehostkeys | verifyhostkeydns)
             _comp_compgen -- -W 'yes no ask'

--- a/completions/ssh
+++ b/completions/ssh
@@ -273,13 +273,10 @@ _comp_cmd_ssh__configfile()
 # shellcheck disable=SC2120
 _comp_xfunc_ssh_identityfile()
 {
-    local cur=$cur
+    local cur=$cur tmp
     [[ ! $cur && -d ~/.ssh ]] && cur=~/.ssh/id
-    _comp_compgen -a filedir
-    if ((${#COMPREPLY[@]} > 0)); then
-        COMPREPLY=($(compgen -W '"${COMPREPLY[@]}"' \
-            -X "${1:+!}*.pub" -- "$cur"))
-    fi
+    _comp_compgen -v tmp -c "$cur" filedir &&
+        _comp_compgen -- -W '"${tmp[@]}"' -X "${1:+!}*.pub"
 }
 
 _comp_deprecate_func 2.12 _ssh_identityfile _comp_xfunc_ssh_identityfile

--- a/completions/ssh
+++ b/completions/ssh
@@ -274,6 +274,7 @@ _comp_cmd_ssh__configfile()
 # shellcheck disable=SC2120
 _comp_xfunc_ssh_identityfile()
 {
+    local cur=$cur
     [[ ! $cur && -d ~/.ssh ]] && cur=~/.ssh/id
     _comp_compgen -a filedir
     if ((${#COMPREPLY[@]} > 0)); then

--- a/completions/upgradepkg
+++ b/completions/upgradepkg
@@ -13,10 +13,9 @@ _comp_cmd_upgradepkg()
     if [[ $cur == ?*%* ]]; then
         prev="${cur%%?(\\)%*}"
         cur="${cur#*%}"
-        local nofiles="" IFS=$'\n'
+        local nofiles=""
         compopt -o filenames
-        COMPREPLY=($(compgen -P "$prev%" -f -X "!*.@(t[bgxl]z)" -- "$cur"))
-        [[ ${COMPREPLY-} ]] || nofiles=set
+        _comp_compgen -- -P "$prev%" -f -X "!*.@(t[bgxl]z)" || nofiles=set
         _comp_compgen -a -- -P "$prev%" -S '/' -d
         [[ $nofiles ]] && compopt -o nospace
         return

--- a/doc/api-and-naming.md
+++ b/doc/api-and-naming.md
@@ -145,11 +145,14 @@ specified by `-v var` in `OPTS`).
 ### Implementing a generator function
 
 To implement a generator function, one should generate completion candidates by
-calling `_comp_compgen` or other generators.  To avoid conflicts with the
-options specified to `_comp_compgen`, one should not directly modify or
-reference the target variable.  When post-filtering is needed, store them in
-local arrays, filter them, and finally append them by `_comp_compgen -- -W
-"${arr[@]}"`.
+calling `_comp_compgen` or other generators.
+
+To avoid conflicts with the options specified to `_comp_compgen`, one should
+not directly modify or reference the target variable.  When post-filtering is
+needed, store them in a local array, filter them, and finally append them by
+`_comp_compgen -- -W '"${arr[@]}"'`.  To split the output of commands and
+append the results to the target variable, use `_comp_compgen_split -- "$(cmd
+...)"` instead of using `_comp_split COMPREPLY "$(cmd ...)"`.
 
 A generator function should replace the existing content of the variable by
 default.  When the appending behavior is favored, the caller should specify it


### PR DESCRIPTION
This is the final round for the `_comp_compgen` rewrite.

- 76b572650f224e2e3b85918944af0bc8dfb49952, 7261319e6c320f7a33185e3819d8f668bdcee363, 7b2dc13e4fcb28bed335bcaebfab3b042abbc1b2, and 7920c9dbe46bd5ad0a92e78b744f00ffe8b14e76 are pre-changes.
- 81adc6ce741f69e936dfb0e1e891c372341814f2, 89e3eae9eeab564b426fd356e453d299415c38ac, 9a5ed03264c0a0f94f46eb12e347a81306ef6e19, and cdd2e3d4b39c79cd1d779f3708780a60d8394bd6 are the changes to `_comp_compgen`.
- 47d768368c5f40f36c606f0ae36faf3643da749d is doc changes
- d28e5ea5a7bada1ed13e69a3c0fda0d04c174dd5 is cleanup
