### PR TITLE
fix(lvm): update call to sub-command

### DIFF
--- a/completions/lvm
+++ b/completions/lvm
@@ -895,7 +895,7 @@ _comp_cmd_lvm()
                 vgdisplay | vgexport | vgextend | vgimport | vgmerge | vgmknodes | vgreduce | \
                 vgremove | vgrename | vgs | vgscan | vgsplit | lvchange | lvcreate | lvdisplay | \
                 lvextend | lvreduce | lvremove | lvrename | lvresize | lvscan)
-                "_${words[1]}"
+                "_comp_cmd_${words[1]}" "${words[@]:1}"
                 ;;
         esac
     fi

--- a/completions/lvm
+++ b/completions/lvm
@@ -895,7 +895,7 @@ _comp_cmd_lvm()
                 vgdisplay | vgexport | vgextend | vgimport | vgmerge | vgmknodes | vgreduce | \
                 vgremove | vgrename | vgs | vgscan | vgsplit | lvchange | lvcreate | lvdisplay | \
                 lvextend | lvreduce | lvremove | lvrename | lvresize | lvscan)
-                "_comp_cmd_${words[1]}" "${words[@]:1}"
+                _comp_command_offset 1
                 ;;
         esac
     fi

--- a/test/t/test_lvm.py
+++ b/test/t/test_lvm.py
@@ -5,3 +5,11 @@ class TestLvm:
     @pytest.mark.complete("lvm pv")
     def test_1(self, completion):
         assert completion
+
+    @pytest.mark.complete(
+        "lvm lvcreate --",
+        require_cmd=True,
+        xfail="! lvm lvcreate --help &>/dev/null",
+    )
+    def test_subcommand_options(self, completion):
+        assert completion

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -190,6 +190,7 @@ lvchange
 lvcreate
 lvdisplay
 lvextend
+lvm
 lvmdiskscan
 lvreduce
 lvremove


### PR DESCRIPTION
This fixes an error breaking completion with lvm when called with the `lvm <subcommand>` format. It builds the internal function call to the new function name format and passes in the command line arguments.

Before:
```
lvm lvcreate -bash: _lvcreate: command not found
```
After:
```
lvm lvcreate -
--activate                --ignoreactivationskip    --raidintegrity
--addtag                  --ignoremonitoring        --raidintegrityblocksize
--alloc                   --journal                 --raidintegritymode
--autobackup              --lockopt                 --readahead
```
```
lvcreate -
--activate                --ignoreactivationskip    --raidintegrity
--addtag                  --ignoremonitoring        --raidintegrityblocksize
--alloc                   --journal                 --raidintegritymode
--autobackup              --lockopt                 --readahead
```