### PR TITLE
test(tree): xfail options test if `--help` contains no options

### DIFF
--- a/test/t/test_tree.py
+++ b/test/t/test_tree.py
@@ -10,7 +10,11 @@ class TestTree:
     def test_fromfile(self, completion):
         assert completion == ["bar", "bar bar.d/", "foo", "foo.d/"]
 
-    @pytest.mark.complete("tree -", require_cmd=True)
+    @pytest.mark.complete(
+        "tree -",
+        require_cmd=True,
+        xfail="! tree --help 2>&1 | command grep -qF -- ' -'",
+    )
     def test_options(self, completion):
         assert completion
 


### PR DESCRIPTION
Such as with busybox 1.36.1's `tree` applet.

This is causing test failures currently, such as in https://github.com/scop/bash-completion/actions/runs/5229055368/jobs/9441810374