### PR TITLE
fix(eog): add completion for AVIF and WEBP files

### DIFF
--- a/completions/eog
+++ b/completions/eog
@@ -19,7 +19,7 @@ _comp_cmd_eog()
         return
     fi
 
-    _comp_compgen_filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[gp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m)'
+    _comp_compgen_filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[gp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m|avif|webp)'
 } &&
     complete -F _comp_cmd_eog eog
 


### PR DESCRIPTION
I'm not sure what to write here - it is what it says on the tin, I've just added two more file extensions.