### PR TITLE
Add ppm extension for eog

### DIFF
--- a/completions/eog
+++ b/completions/eog
@@ -19,7 +19,7 @@ _comp_cmd_eog()
         return
     fi
 
-    _comp_compgen_filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[gp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m)'
+    _comp_compgen_filedir '@(ani|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[bgp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|x[bp]m)'
 } &&
     complete -F _comp_cmd_eog eog
 


### PR DESCRIPTION
Currently eog completion for netpbm format (https://en.wikipedia.org/wiki/Netpbm) only has pgm and ppm, but there is also ppm and is supported by eog.