### PR TITLE
feat(eog): associate with `*.heic` and `*.jxl`

### DIFF
--- a/completions/eog
+++ b/completions/eog
@@ -19,7 +19,7 @@ _comp_cmd_eog()
         return
     fi
 
-    _comp_compgen_filedir '@(ani|avif|?(w)bmp|gif|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|pcx|p[bgp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|webp|x[bp]m)'
+    _comp_compgen_filedir '@(ani|avif|?(w)bmp|gif|heic|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|jxl|pcx|p[bgp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|webp|x[bp]m)'
 } &&
     complete -F _comp_cmd_eog eog
 


### PR DESCRIPTION
eog supports these via add-on gdk-pixbuf loaders.