### PR TITLE
feat(eog): add missing extension .heif

### DIFF
--- a/completions/eog
+++ b/completions/eog
@@ -19,7 +19,7 @@ _comp_cmd_eog()
         return
     fi
 
-    _comp_compgen_filedir '@(ani|avif|?(w)bmp|gif|heic|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|jxl|pcx|p[bgp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|webp|x[bp]m)'
+    _comp_compgen_filedir '@(ani|avif|?(w)bmp|gif|hei[cf]|ico|j2[ck]|jp[cefgx2]|jpeg|jpg2|jxl|pcx|p[bgp]m|pn[gm]|ras|svg?(z)|tga|tif?(f)|webp|x[bp]m)'
 } &&
     complete -F _comp_cmd_eog eog
 


### PR DESCRIPTION
The support for `.heic` has been added in #1010, but the gdk pixbuf loader, which supports `.heic`, [explicitly supports also `.heif` and `.avif`](https://github.com/strukturag/libheif/blob/4a2f42f01e475258e67371db99108636d32f561c/gdk-pixbuf/pixbufloader-heif.c#L224-L229). The extension `.avif` is already included in the list, but `.heif` is currently missing.
