### PR TITLE
feat(xrandr): comma separated `--setmonitor` third argument

### DIFF
--- a/completions/xrandr
+++ b/completions/xrandr
@@ -149,9 +149,9 @@ _comp_cmd_xrandr()
     if ((cword >= 3)); then
         case "${words[cword - 3]}" in
             --setmonitor)
-                _comp_cmd_xrandr__compgen_outputs "$1"
-                _comp_compgen -a -- -W "none"
-                # TODO: the third argument is actually a comma-separated list
+                _comp_compgen -c "${cur##*,}" -i xrandr outputs "$1"
+                _comp_compgen -ac "${cur##*,}" -- -W "none"
+                _comp_delimited , -W '"${COMPREPLY[@]}"'
                 return
                 ;;
         esac


### PR DESCRIPTION
Requires/stacks on top of #1025, drafting until that one is merged.