### PR TITLE
style: remove function end comments

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -826,7 +826,7 @@ _comp__reassemble_words()
             printf -v "$2[i]" %s "${COMP_WORDS[i]}"
         done
     fi
-} # _comp__reassemble_words()
+}
 
 # @param $1 exclude  Characters out of $COMP_WORDBREAKS which should NOT be
 #     considered word breaks. This is useful for things like scp where
@@ -1013,7 +1013,7 @@ _comp_ltrim_colon_completions()
 {
     ((${#COMPREPLY[@]})) || return 0
     _comp_compgen -c "$1" ltrim_colon "${COMPREPLY[@]}"
-} # _comp_ltrim_colon_completions()
+}
 
 # This function quotes the argument in a way so that readline dequoting
 # results in the original argument.  This is necessary for at least
@@ -1050,7 +1050,7 @@ _comp_quote_compgen()
             printf -v ret "$value" # Decode escape sequences of \....
         fi
     fi
-} # _comp_quote_compgen()
+}
 
 # This function performs file and directory completion. It's better than
 # simply using 'compgen -f', because it honours spaces in filenames.
@@ -1112,7 +1112,7 @@ _comp_compgen_filedir()
     # ${v+"${a[@]}"} when IFS does not contain whitespace.
     local IFS=$' \t\n'
     _comp_compgen -U toks set ${toks[@]+"${toks[@]}"}
-} # _comp_compgen_filedir()
+}
 
 # This function splits $cur=--foo=bar into $prev=--foo, $cur=bar, making it
 # easier to support both "--foo bar" and "--foo=bar" style completions.
@@ -2380,7 +2380,7 @@ _known_hosts()
     [[ ${1-} == -c || ${2-} == -c ]] && options+=(-c)
     local IFS=$' \t\n' # Workaround for connected ${v+"$@"} in bash < 4.4
     _comp_compgen_known_hosts ${options[@]+"${options[@]}"} -- "$cur"
-} # _known_hosts()
+}
 
 # Helper function to locate ssh included files in configs
 # This function looks for the "Include" keyword in ssh config files and
@@ -2434,7 +2434,7 @@ _comp__included_ssh_config_files()
             fi
         done
     done
-} # _comp__included_ssh_config_files()
+}
 
 # Helper function for completing _known_hosts.
 # This function performs host completion based on ssh's config and known_hosts
@@ -2658,7 +2658,7 @@ _comp_compgen_known_hosts__impl()
     ((${#known_hosts[@]})) || return 1
 
     _comp_compgen -v known_hosts -c "$prefix$cur" ltrim_colon "${known_hosts[@]}"
-} # _comp_compgen_known_hosts__impl()
+}
 complete -F _known_hosts traceroute traceroute6 \
     fping fping6 telnet rsh rlogin ftp dig drill mtr ssh-installkeys showmount
 

--- a/bash_completion.d/000_bash_completion_compat.bash
+++ b/bash_completion.d/000_bash_completion_compat.bash
@@ -64,7 +64,7 @@ quote_readline()
     local ret
     _comp_quote_compgen "$1"
     printf %s "$ret"
-} # quote_readline()
+}
 
 # This function is the same as `_comp_quote_compgen`, but receives the second
 # argument specifying the variable name to store the result.
@@ -173,7 +173,7 @@ _get_cword()
             printf "%s" "${cur:0:index}"
         fi
     fi
-} # _get_cword()
+}
 
 # Get word previous to the current word.
 # This is a good alternative to `prev=${COMP_WORDS[COMP_CWORD-1]}' because bash4
@@ -382,7 +382,7 @@ __expand_tilde_by_ref()
     _comp_expand_tilde "${!1-}"
     # shellcheck disable=SC2059
     [[ $1 == ret ]] || printf -v "$1" "$ret"
-} # __expand_tilde_by_ref()
+}
 
 # @deprecated 2.12 Use `_comp_compgen -a cd_devices`
 _cd_devices()


### PR DESCRIPTION
These are being used inconsistently here and there, and I don't think there's a need for them in the first place.