### PR TITLE
fix(make): handle multiple short options in skipping arguments

### DIFF
--- a/completions/make
+++ b/completions/make
@@ -187,7 +187,7 @@ _comp_cmd_make()
         # before we check for makefiles, see if a path was specified
         # with -C/--directory
         for ((i = 1; i < ${#words[@]}; i++)); do
-            if [[ ${words[i]} == -@(C|-directory) ]]; then
+            if [[ ${words[i]} == @(-${noargopts}C|--directory) ]]; then
                 # Expand tilde expansion
                 local ret
                 _comp_dequote "${words[i + 1]-}" &&
@@ -200,7 +200,7 @@ _comp_cmd_make()
         # before we scan for targets, see if a Makefile name was
         # specified with -f/--file/--makefile
         for ((i = 1; i < ${#words[@]}; i++)); do
-            if [[ ${words[i]} == -@(f|-?(make)file) ]]; then
+            if [[ ${words[i]} == @(-${noargopts}f|--?(make)file) ]]; then
                 # Expand tilde expansion
                 local ret
                 _comp_dequote "${words[i + 1]-}" &&

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -44,6 +44,11 @@ class TestMake:
         assert completion == "all clean extra_makefile install sample".split()
         os.remove(f"{bash.cwd}/make/extra_makefile")
 
+    @pytest.mark.complete("make -nC make ", require_cmd=True)
+    def test_8n(self, bash, completion):
+        assert completion == "all clean extra_makefile install sample".split()
+        os.remove(f"{bash.cwd}/make/extra_makefile")
+
     @pytest.mark.complete("make -", require_cmd=True)
     def test_9(self, completion):
         assert completion


### PR DESCRIPTION
Fixes https://github.com/scop/bash-completion/issues/898