### PR TITLE
feat(_comp_variable_assignments): complete only well-known `LC_*`-variables

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1285,7 +1285,10 @@ _comp_variable_assignments()
         TERM)
             _comp_compgen_terms
             ;;
-        LANG | LC_*)
+        LANG | LC_ALL | LC_COLLATE | LC_CTYPE | LC_MESSAGES | LC_MONETARY | \
+        LC_NUMERIC | LC_TIME | \
+        LC_ADDRESS | LC_IDENTIFICATION | LC_MEASUREMENT | LC_NAME | \
+        LC_PAPER | LC_TELEPHONE)
             _comp_compgen_split -- "$(locale -a 2>/dev/null)"
             ;;
         LANGUAGE)


### PR DESCRIPTION

POSIX.1-2017 standardises:
LANG, LC_ALL, LC_COLLATE, LC_CTYPE, LC_MESSAGES, LC_MONETARY, LC_NUMERIC and LC_TIME

The GNU C Library version 2.38 standardises:
LC_ADDRESS, LC_IDENTIFICATION, LC_MEASUREMENT, LC_NAME, LC_PAPER and LC_TELEPHONE