### PR TITLE
fix(chgrp): typo in chgrp completion

### DIFF
--- a/completions/chgrp
+++ b/completions/chgrp
@@ -30,7 +30,7 @@ _comp_cmd_chgrp()
     if [[ $cword -eq 1 && $cur != -* || $prev == -* ]]; then
         _comp_compgen_allowed_groups
     else
-        _comp_compgend filedir
+        _comp_compgen_filedir
     fi
 
 } &&


### PR DESCRIPTION
Replaces '_comp_compgend filedir' with '_comp_compgen_filedir' in the chgrp completion.

fixes `chgrp git -bash: _comp_compgend: command not found`