### PR TITLE
Added RequiredRSASize option for ssh client.

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -73,11 +73,11 @@ _comp_xfunc_ssh_options()
         PasswordAuthentication PermitLocalCommand PKCS11Provider Port
         PreferredAuthentications ProxyCommand ProxyJump ProxyUseFdpass
         PubkeyAcceptedAlgorithms PubkeyAuthentication RekeyLimit RemoteCommand
-        RemoteForward RequestTTY RevokedHostKeys SecurityKeyProvider SendEnv
-        ServerAliveCountMax ServerAliveInterval SetEnv StreamLocalBindMask
-        StreamLocalBindUnlink StrictHostKeyChecking SyslogFacility TCPKeepAlive
-        Tunnel TunnelDevice UpdateHostKeys User UserKnownHostsFile
-        VerifyHostKeyDNS VisualHostKey XAuthLocation
+        RemoteForward RequestTTY RequiredRSASize RevokedHostKeys
+        SecurityKeyProvider SendEnv ServerAliveCountMax ServerAliveInterval
+        SetEnv StreamLocalBindMask StreamLocalBindUnlink StrictHostKeyChecking
+        SyslogFacility TCPKeepAlive Tunnel TunnelDevice UpdateHostKeys User
+        UserKnownHostsFile VerifyHostKeyDNS VisualHostKey XAuthLocation
     )
     # Selected old ones
     opts+=(
@@ -209,6 +209,9 @@ _comp_cmd_ssh__suboption()
             ;;
         requesttty)
             _comp_compgen -- -W 'no yes force auto'
+            ;;
+        requiredrsasize)
+            _comp_compgen -- -W '1024 2048 3072 4096 7680 15360'
             ;;
         stricthostkeychecking)
             _comp_compgen -- -W 'accept-new ask no off'


### PR DESCRIPTION
This is actually a bug, because the "RequiredRSASize" exists in recent OpenSSH source.

The reason I make this change are as follows:
1. The RequiredRSASize option was added in openssh/openssh-portable@54b333d .
2. RHEL 9.1 changed minimum RSA key size to 2048 by default, broke connections to old SSH servers. Reference: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.1_release_notes/new-features#BZ-2066882
3. Fedora Linux sync'd the change from RHEL 9.1. Reference: https://packages.fedoraproject.org/pkgs/openssh/openssh-server/fedora-37.html
4. I was connecting to a legacy device over SSH and tried very hard to remember this option.

I have ran the supplied test for ssh, got the following output:
```
====== 12 passed, 1 xfailed in 35.62s ======
```