### PR TITLE
refactor: prefix `command` to the `awk` command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: shfmt
         types: [text]
-        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|update-test-cmd-list)|.+\.sh(\.in)?)$
+        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -22,7 +22,7 @@ repos:
       - id: shellcheck
         args: [-f, gcc]
         types: [text]
-        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|update-test-cmd-list)|.+\.sh(\.in)?)$
+        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
         require_serial: false  # We disable SC1090 anyway, so parallel is ok
 

--- a/bash_completion
+++ b/bash_completion
@@ -1702,7 +1702,7 @@ _comp_compgen_available_interfaces()
         else
             ifconfig -a || ip -c=never link show || ip link show
         fi
-    } 2>/dev/null | awk \
+    } 2>/dev/null | _comp_awk \
         '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }')" &&
         _comp_compgen -U generated set "${generated[@]}"
 }
@@ -1943,7 +1943,7 @@ _comp_compgen_services()
         systemctl list-units --full --all ||
             systemctl list-unit-files
     } 2>/dev/null |
-        awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }')
+        _comp_awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }')
     _comp_split -la services "$_generated"
 
     if [[ -x /sbin/upstart-udev-bridge ]]; then
@@ -2016,7 +2016,7 @@ _comp_compgen_kernel_modules()
 _comp_compgen_inserted_kernel_modules()
 {
     _comp_compgen -c "${1:-$cur}" split -- "$(PATH="$PATH:/sbin" lsmod |
-        awk '{if (NR != 1) print $1}')"
+        _comp_awk '{if (NR != 1) print $1}')"
 }
 
 # This function completes on user or user:group format; as for chown and cpio.
@@ -2097,7 +2097,7 @@ _comp_compgen_allowed_groups()
 _comp_compgen_selinux_users()
 {
     _comp_compgen_split -- "$(semanage user -nl 2>/dev/null |
-        awk '{ print $1 }')"
+        _comp_awk '{ print $1 }')"
 }
 
 # This function completes on valid shells
@@ -2124,14 +2124,14 @@ _comp_compgen_fstypes()
     if [[ -e /proc/filesystems ]]; then
         # Linux
         _fss="$(cut -d$'\t' -f2 /proc/filesystems)
-             $(awk '! /\*/ { print $NF }' /etc/filesystems 2>/dev/null)"
+             $(_comp_awk '! /\*/ { print $NF }' /etc/filesystems 2>/dev/null)"
     else
         # Generic
-        _fss="$(awk '/^[ \t]*[^#]/ { print $3 }' /etc/fstab 2>/dev/null)
-             $(awk '/^[ \t]*[^#]/ { print $3 }' /etc/mnttab 2>/dev/null)
-             $(awk '/^[ \t]*[^#]/ { print $4 }' /etc/vfstab 2>/dev/null)
-             $(awk '{ print $1 }' /etc/dfs/fstypes 2>/dev/null)
-             $(lsvfs 2>/dev/null | awk '$1 !~ /^(Filesystem|[^a-zA-Z])/ { print $1 }')
+        _fss="$(_comp_awk '/^[ \t]*[^#]/ { print $3 }' /etc/fstab 2>/dev/null)
+             $(_comp_awk '/^[ \t]*[^#]/ { print $3 }' /etc/mnttab 2>/dev/null)
+             $(_comp_awk '/^[ \t]*[^#]/ { print $4 }' /etc/vfstab 2>/dev/null)
+             $(_comp_awk '{ print $1 }' /etc/dfs/fstypes 2>/dev/null)
+             $(lsvfs 2>/dev/null | _comp_awk '$1 !~ /^(Filesystem|[^a-zA-Z])/ { print $1 }')
              $([[ -d /etc/fs ]] && command ls /etc/fs)"
     fi
 
@@ -2289,7 +2289,7 @@ _comp_count_args()
 # @since 2.12
 _comp_compgen_pci_ids()
 {
-    _comp_compgen_split -- "$(PATH="$PATH:/sbin" lspci -n | awk '{print $3}')"
+    _comp_compgen_split -- "$(PATH="$PATH:/sbin" lspci -n | _comp_awk '{print $3}')"
 }
 
 # This function completes on USB IDs
@@ -2297,7 +2297,7 @@ _comp_compgen_pci_ids()
 # @since 2.12
 _comp_compgen_usb_ids()
 {
-    _comp_compgen_split -- "$(PATH="$PATH:/sbin" lsusb | awk '{print $6}')"
+    _comp_compgen_split -- "$(PATH="$PATH:/sbin" lsusb | _comp_awk '{print $6}')"
 }
 
 # CD device names
@@ -2325,11 +2325,11 @@ _comp_compgen_terms()
         command sed -ne 's/^\([^[:space:]#|]\{2,\}\)|.*/\1/p' /etc/termcap
         {
             toe -a || toe
-        } | awk '{ print $1 }'
+        } | _comp_awk '{ print $1 }'
         _comp_expand_glob dirs '/{etc,lib,usr/lib,usr/share}/terminfo/?'
         ((${#dirs[@]})) &&
             find "${dirs[@]}" -type f -maxdepth 1 |
-            awk -F/ '{ print $NF }'
+            _comp_awk -F/ '{ print $NF }'
     } 2>/dev/null)"
 }
 
@@ -2533,7 +2533,7 @@ _comp_compgen_known_hosts__impl()
         # TODO(?): try to make known hosts files with more than one consecutive
         #          spaces in their name work (watch out for ~ expansion
         #          breakage! Alioth#311595)
-        if _comp_split -l tmpkh "$(awk 'sub("^[ \t]*([Gg][Ll][Oo][Bb][Aa][Ll]|[Uu][Ss][Ee][Rr])[Kk][Nn][Oo][Ww][Nn][Hh][Oo][Ss][Tt][Ss][Ff][Ii][Ll][Ee][ \t=]+", "") { print $0 }' "${config[@]}" | sort -u)"; then
+        if _comp_split -l tmpkh "$(_comp_awk 'sub("^[ \t]*([Gg][Ll][Oo][Bb][Aa][Ll]|[Uu][Ss][Ee][Rr])[Kk][Nn][Oo][Ww][Nn][Hh][Oo][Ss][Tt][Ss][Ff][Ii][Ll][Ee][ \t=]+", "") { print $0 }' "${config[@]}" | sort -u)"; then
             local tmpkh2 j ret
             for i in "${tmpkh[@]}"; do
                 # First deal with quoted entries...
@@ -2628,7 +2628,7 @@ _comp_compgen_known_hosts__impl()
         type avahi-browse &>/dev/null; then
         # Some old versions of avahi-browse reportedly didn't have -k
         # (even if mentioned in the manpage); those we do not support any more.
-        local generated=$(avahi-browse -cprak 2>/dev/null | awk -F';' \
+        local generated=$(avahi-browse -cprak 2>/dev/null | _comp_awk -F';' \
             '/^=/ && $5 ~ /^_(ssh|workstation)\._tcp$/ { print $7 }' |
             sort -u)
         _comp_compgen -av known_hosts -- -P "$prefix" -S "$suffix" -W '$generated'
@@ -2636,7 +2636,7 @@ _comp_compgen_known_hosts__impl()
 
     # Add hosts reported by ruptime.
     if type ruptime &>/dev/null; then
-        local generated=$(ruptime 2>/dev/null | awk '!/^ruptime:/ { print $1 }')
+        local generated=$(ruptime 2>/dev/null | _comp_awk '!/^ruptime:/ { print $1 }')
         _comp_compgen -av known_hosts -- -W '$generated'
     fi
 

--- a/bash_completion
+++ b/bash_completion
@@ -2329,7 +2329,7 @@ _comp_compgen_terms()
         _comp_expand_glob dirs '/{etc,lib,usr/lib,usr/share}/terminfo/?'
         ((${#dirs[@]})) &&
             find "${dirs[@]}" -type f -maxdepth 1 |
-            _comp_awk -F/ '{ print $NF }'
+            _comp_awk -F / '{ print $NF }'
     } 2>/dev/null)"
 }
 
@@ -2628,7 +2628,7 @@ _comp_compgen_known_hosts__impl()
         type avahi-browse &>/dev/null; then
         # Some old versions of avahi-browse reportedly didn't have -k
         # (even if mentioned in the manpage); those we do not support any more.
-        local generated=$(avahi-browse -cprak 2>/dev/null | _comp_awk -F';' \
+        local generated=$(avahi-browse -cprak 2>/dev/null | _comp_awk -F ';' \
             '/^=/ && $5 ~ /^_(ssh|workstation)\._tcp$/ { print $7 }' |
             sort -u)
         _comp_compgen -av known_hosts -- -P "$prefix" -S "$suffix" -W '$generated'

--- a/completions/_adb
+++ b/completions/_adb
@@ -39,7 +39,7 @@ _comp_cmd_adb()
             _comp_compgen -av tmp help -- help
         fi
         if [[ ! $cur || $cur != -* ]]; then
-            tmp+=($("$1" help 2>&1 | awk '$1 == "adb" { print $2 }'))
+            tmp+=($("$1" help 2>&1 | _comp_awk '$1 == "adb" { print $2 }'))
             tmp+=(devices connect disconnect sideload)
         fi
         ((${#tmp[@]})) &&

--- a/completions/_mock
+++ b/completions/_mock
@@ -45,7 +45,7 @@ _comp_cmd_mock()
             # This would actually depend on what the target root
             # can be used to build for...
             _comp_compgen_split -- "$(command rpm --showrc | command sed -ne \
-                's/^\s*compatible\s\s*archs\s*:\s*\(.*\)/\1/i p')"
+                's/^[[:space:]]*compatible[[:space:]]\{1,\}archs[[:space:]]*:[[:space:]]*\(.*\)/\1/i p')"
             return
             ;;
         --enable-plugin | --disable-plugin)

--- a/completions/_mock
+++ b/completions/_mock
@@ -40,12 +40,15 @@ _comp_cmd_mock()
             return
             ;;
         --target)
+            # Case-insensitive BRE to match "compatible archs"
+            local regex_header='[cC][oO][mM][pP][aA][tT][iI][bB][lL][eE][[:space:]]\{1,\}[aA][rR][cC][hH][sS]'
+
             # Yep, compatible archs, not compatible build archs
             # (e.g. ix86 chroot builds in x86_64 mock host)
             # This would actually depend on what the target root
             # can be used to build for...
             _comp_compgen_split -- "$(command rpm --showrc | command sed -ne \
-                's/^[[:space:]]*compatible[[:space:]]\{1,\}archs[[:space:]]*:[[:space:]]*\(.*\)/\1/i p')"
+                "s/^[[:space:]]*${regex_header}[[:space:]]*:[[:space:]]*\(.*\)/\1/p")"
             return
             ;;
         --enable-plugin | --disable-plugin)

--- a/completions/_modules
+++ b/completions/_modules
@@ -54,7 +54,7 @@ _comp_cmd_module()
 
         local options
         options="$(module help 2>&1 | command grep -E '^[[:space:]]*\+' |
-            awk '{print $2}' | command sed -e 's/|/ /g' | sort)"
+            _comp_awk '{print $2}' | command sed -e 's/|/ /g' | sort)"
 
         _comp_compgen -- -W "$options"
 

--- a/completions/_mount
+++ b/completions/_mount
@@ -34,7 +34,7 @@ _comp_cmd_mount()
         for sm in "$(type -P showmount)" {,/usr}/{,s}bin/showmount; do
             [[ -x $sm ]] || continue
             _comp_compgen -c "${cur#*:}" split -- "$(
-                "$sm" -e ${cur%%:*} | awk 'NR>1 {print $1}'
+                "$sm" -e ${cur%%:*} | _comp_awk 'NR>1 {print $1}'
             )"
             return
         done
@@ -53,17 +53,17 @@ _comp_cmd_mount()
     elif [[ -r /etc/vfstab ]]; then
         # Solaris
         _comp_compgen_split -- "$(
-            awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}' /etc/vfstab
+            _comp_awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}' /etc/vfstab
         )"
     elif [[ ! -e /etc/fstab ]]; then
         # probably Cygwin
         _comp_compgen_split -- "$(
-            "$1" | awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}'
+            "$1" | _comp_awk '! /^[ \t]*#/ {if ($3 ~ /\//) print $3}'
         )"
     else
         # probably BSD
         _comp_compgen_split -- "$(
-            awk '! /^[ \t]*#/ {if ($2 ~ /\//) print $2}' /etc/fstab
+            _comp_awk '! /^[ \t]*#/ {if ($2 ~ /\//) print $2}' /etc/fstab
         )"
     fi
 } &&

--- a/completions/_mount.linux
+++ b/completions/_mount.linux
@@ -226,7 +226,7 @@ _comp_cmd_mount()
         for sm in "$(type -P showmount)" {,/usr}/{,s}bin/showmount; do
             [[ -x $sm ]] || continue
             _comp_compgen -c "${cur#*:}" split -- "$(
-                "$sm" -e ${cur%%:*} | awk 'NR>1 {print $1}'
+                "$sm" -e ${cur%%:*} | _comp_awk 'NR>1 {print $1}'
             )"
             return
         done

--- a/completions/_rfkill
+++ b/completions/_rfkill
@@ -17,9 +17,9 @@ _comp_cmd_rfkill()
                 ;;
             2)
                 if [[ $prev == block || $prev == unblock ]]; then
-                    _comp_compgen_split -- "$("$1" list |
-                        _comp_awk -F: '/^[0-9]/ {print $1}') all wifi bluetooth uwb
-                        wimax wwan gps"
+                    _comp_compgen_split -- "
+                        $("$1" list | _comp_awk -F : '/^[0-9]/ {print $1}')
+                        all wifi bluetooth uwb wimax wwan gps"
                 fi
                 ;;
         esac

--- a/completions/_rfkill
+++ b/completions/_rfkill
@@ -18,7 +18,7 @@ _comp_cmd_rfkill()
             2)
                 if [[ $prev == block || $prev == unblock ]]; then
                     _comp_compgen_split -- "$("$1" list |
-                        awk -F: '/^[0-9]/ {print $1}') all wifi bluetooth uwb
+                        _comp_awk -F: '/^[0-9]/ {print $1}') all wifi bluetooth uwb
                         wimax wwan gps"
                 fi
                 ;;

--- a/completions/_udevadm
+++ b/completions/_udevadm
@@ -59,7 +59,7 @@ _comp_cmd_udevadm()
                 ;;
             *)
                 _comp_compgen_split -- "$("$1" --help 2>/dev/null |
-                    awk '/^[ \t]/ { print $1 }')"
+                    _comp_awk '/^[ \t]/ { print $1 }')"
                 ;;
         esac
         return

--- a/completions/_xm
+++ b/completions/_xm
@@ -7,7 +7,7 @@
 _comp_cmd_xm__domain_names()
 {
     _comp_compgen_split -- "$(xm list 2>/dev/null |
-        awk '!/Name|Domain-0/ { print $1 }')"
+        _comp_awk '!/Name|Domain-0/ { print $1 }')"
 }
 
 _comp_cmd_xm()
@@ -147,7 +147,7 @@ _comp_cmd_xm()
                             ;;
                         3)
                             _comp_compgen_split -- "$(xm block-list "$prev" \
-                                2>/dev/null | awk '!/Vdev/ { print $1 }')"
+                                2>/dev/null | _comp_awk '!/Vdev/ { print $1 }')"
                             ;;
                     esac
                     ;;
@@ -171,7 +171,7 @@ _comp_cmd_xm()
                             ;;
                         3)
                             _comp_compgen_split -- "$(xm network-list "$prev" \
-                                2>/dev/null | awk '!/Idx/ { print $1 }')"
+                                2>/dev/null | _comp_awk '!/Idx/ { print $1 }')"
                             ;;
                     esac
                     ;;

--- a/completions/_yum
+++ b/completions/_yum
@@ -25,7 +25,7 @@ _comp_cmd_yum__compgen_repolist()
     # Drop first ("repo id      repo name") and last ("repolist: ...") rows
     _comp_compgen_split -- "$(
         yum --noplugins -C repolist "$1" 2>/dev/null |
-            command sed -ne '/^repo\s\s*id/d' -e '/^repolist:/d' \
+            command sed -ne '/^repo[[:space:]]\{1,\}id/d' -e '/^repolist:/d' \
                 -e 's/[[:space:]].*//p'
     )"
 }

--- a/completions/apache2ctl
+++ b/completions/apache2ctl
@@ -6,7 +6,7 @@ _comp_cmd_apache2ctl()
     _comp_initialize -- "$@" || return
 
     local APWORDS
-    APWORDS=$("$1" 2>&1 >/dev/null | awk 'NR<2 { print $3; exit }' |
+    APWORDS=$("$1" 2>&1 >/dev/null | _comp_awk 'NR<2 { print $3; exit }' |
         tr "|" " ")
 
     _comp_compgen -- -W "$APWORDS"

--- a/completions/apt-cache
+++ b/completions/apt-cache
@@ -26,7 +26,7 @@ _comp_xfunc_apt_cache_compgen_sources()
 _comp_cmd_apt_cache__compgen_sources()
 {
     _comp_compgen_split -- "$("$1" dumpavail |
-        awk '$1 == "Source:" { print $2 }' | sort -u)"
+        _comp_awk '$1 == "Source:" { print $2 }' | sort -u)"
 }
 
 # List APT binary packages

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -36,7 +36,7 @@ _comp_cmd_apt_get()
                 pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
                 _comp_compgen -x apt-cache packages
                 _comp_compgen -a split -- "$(apt-cache dumpavail |
-                    awk '$1 == "Source:" { print $2 }' | sort -u)"
+                    _comp_awk '$1 == "Source:" { print $2 }' | sort -u)"
                 ;;
             install | reinstall)
                 if _comp_looks_like_path "$cur"; then

--- a/completions/aspell
+++ b/completions/aspell
@@ -36,7 +36,7 @@ _comp_cmd_aspell()
             ;;
         --mode)
             _comp_compgen_split -- "$("$1" modes 2>/dev/null |
-                awk '{ print $1 }')"
+                _comp_awk '{ print $1 }')"
             return
             ;;
         --sug-mode)
@@ -53,7 +53,7 @@ _comp_cmd_aspell()
             ;;
         --add-filter | --rem-filter)
             _comp_compgen_split -- "$("$1" filters 2>/dev/null |
-                awk '{ print $1 }')"
+                _comp_awk '{ print $1 }')"
             return
             ;;
     esac

--- a/completions/bk
+++ b/completions/bk
@@ -7,7 +7,7 @@ _comp_cmd_bk()
     _comp_initialize -- "$@" || return
 
     local BKCMDS="$(bk help topics 2>/dev/null |
-        awk '/^  bk/ { print $2 }' | xargs printf '%s ')"
+        _comp_awk '/^  bk/ { print $2 }' | xargs printf '%s ')"
 
     _comp_compgen -- -W "$BKCMDS"
     _comp_compgen -a filedir

--- a/completions/brctl
+++ b/completions/brctl
@@ -19,7 +19,7 @@ _comp_cmd_brctl()
 
                 *)
                     _comp_compgen_split -- "$("$1" show |
-                        awk 'NR>1 {print $1}')"
+                        _comp_awk 'NR>1 {print $1}')"
                     ;;
             esac
             ;;

--- a/completions/ccache
+++ b/completions/ccache
@@ -23,7 +23,7 @@ _comp_cmd_ccache()
         --set-config | -${noargopts}o)
             if [[ $cur != *=* ]]; then
                 _comp_compgen_split -S = -- "$("$1" -p 2>/dev/null |
-                    awk '$3 = "=" { print $2 }')"
+                    _comp_awk '$3 = "=" { print $2 }')"
                 [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
             fi
             return

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -4,7 +4,7 @@ _comp_cmd_chronyc__command_args()
 {
     local -a args
     _comp_split args "$("$1" help 2>/dev/null |
-        awk '/^'"$prev"'\s[^ []/ { gsub("\\|", " ", $2); print $2 }')"
+        _comp_awk '/^'"$prev"'\s[^ []/ { gsub("\\|", " ", $2); print $2 }')"
     case $args in
         \<address\>) _comp_compgen_known_hosts -- "$cur" ;;
         \<*) ;;
@@ -43,7 +43,7 @@ _comp_cmd_chronyc()
     case $args in
         0)
             _comp_compgen_split -- "$("$1" help 2>/dev/null |
-                awk '!/(^ |: *$)/ { sub("\\|", " ", $1); print $1 }')"
+                _comp_awk '!/(^ |: *$)/ { sub("\\|", " ", $1); print $1 }')"
             ;;
         1)
             _comp_cmd_chronyc__command_args "$1"

--- a/completions/chronyc
+++ b/completions/chronyc
@@ -4,7 +4,7 @@ _comp_cmd_chronyc__command_args()
 {
     local -a args
     _comp_split args "$("$1" help 2>/dev/null |
-        _comp_awk '/^'"$prev"'\s[^ []/ { gsub("\\|", " ", $2); print $2 }')"
+        _comp_awk '/^'"$prev"'[ \t][^ []/ { gsub("\\|", " ", $2); print $2 }')"
     case $args in
         \<address\>) _comp_compgen_known_hosts -- "$cur" ;;
         \<*) ;;

--- a/completions/configure
+++ b/completions/configure
@@ -29,7 +29,7 @@ _comp_cmd_configure()
     # the form --option=SETTING will include 'SETTING' as a contextual hint
     if [[ ${BASH_COMPLETION_CMD_CONFIGURE_HINTS-${COMP_CONFIGURE_HINTS-}} ]]; then
         _comp_compgen_split -- "$("$1" --help 2>&1 |
-            awk '/^  --[A-Za-z]/ { print $1; \
+            _comp_awk '/^  --[A-Za-z]/ { print $1; \
             if ($2 ~ /--[A-Za-z]/) print $2 }' | command sed -e 's/[[,].*//g')"
         [[ ${COMPREPLY-} == *=* ]] && compopt -o nospace
     else

--- a/completions/cpan2dist
+++ b/completions/cpan2dist
@@ -28,7 +28,7 @@ _comp_cmd_cpan2dist()
                 packagelist="$dir/02packages.details.txt.gz"
         done
         [[ $packagelist ]] && COMPREPLY=($(zgrep "^${cur//-/::}" \
-            "$packagelist" 2>/dev/null | awk '{print $1}' |
+            "$packagelist" 2>/dev/null | _comp_awk '{print $1}' |
             command sed -e 's/::/-/g'))
     fi
 } &&

--- a/completions/curl
+++ b/completions/curl
@@ -105,7 +105,7 @@ _comp_cmd_curl()
         --help | -${noargopts}h)
             local x categories=(
                 $("$1" --help non-existent-category 2>&1 |
-                    awk '/^[[:space:]]/ {print $1}')
+                    _comp_awk '/^[[:space:]]/ {print $1}')
             )
             if ((${#categories[@]})); then
                 for x in "${categories[@]}"; do

--- a/completions/curl
+++ b/completions/curl
@@ -105,7 +105,7 @@ _comp_cmd_curl()
         --help | -${noargopts}h)
             local x categories=(
                 $("$1" --help non-existent-category 2>&1 |
-                    _comp_awk '/^[[:space:]]/ {print $1}')
+                    _comp_awk '/^[ \t]/ {print $1}')
             )
             if ((${#categories[@]})); then
                 for x in "${categories[@]}"; do

--- a/completions/cvs
+++ b/completions/cvs
@@ -23,7 +23,7 @@ _comp_cmd_cvs__modules()
 _comp_cmd_cvs__compgen_commands()
 {
     _comp_compgen_split -- "$(
-        "$1" --help-commands 2>&1 | awk '/^(     *|\t)/ { print $1 }'
+        "$1" --help-commands 2>&1 | _comp_awk '/^(     *|\t)/ { print $1 }'
     )"
 }
 
@@ -42,7 +42,7 @@ _comp_xfunc_cvs_compgen_roots()
 {
     local -a cvsroots=()
     [[ -v CVSROOT ]] && cvsroots=("$CVSROOT")
-    [[ -r ~/.cvspass ]] && cvsroots+=($(awk '{ print $2 }' ~/.cvspass))
+    [[ -r ~/.cvspass ]] && cvsroots+=($(_comp_awk '{ print $2 }' ~/.cvspass))
     [[ -r CVS/Root ]] && mapfile -tO "${#cvsroots[@]}" cvsroots <CVS/Root
     ((${#cvsroots[@]})) &&
         _comp_compgen -U cvsroots -- -W '"${cvsroots[@]}"'
@@ -237,7 +237,7 @@ _comp_cmd_cvs()
             if [[ $cur != -* ]]; then
                 [[ ! $has_cvsroot ]] && cvsroot=${CVSROOT-}
                 COMPREPLY=($(cvs -d "$cvsroot" co -c 2>/dev/null |
-                    awk '{print $1}'))
+                    _comp_awk '{print $1}'))
                 ((${#COMPREPLY[@]})) &&
                     _comp_compgen -- -W '"${COMPREPLY[@]}"'
             else
@@ -321,7 +321,7 @@ _comp_cmd_cvs()
 
             if [[ $cur != -* ]]; then
                 [[ ! $has_cvsroot ]] && cvsroot=${CVSROOT-}
-                COMPREPLY=($(cvs -d "$cvsroot" co -c | awk '{print $1}'))
+                COMPREPLY=($(cvs -d "$cvsroot" co -c | _comp_awk '{print $1}'))
                 ((${#COMPREPLY[@]})) &&
                     _comp_compgen -- -W '"${COMPREPLY[@]}"'
             else

--- a/completions/cvsps
+++ b/completions/cvsps
@@ -11,22 +11,22 @@ _comp_cmd_cvsps()
             ;;
         -s)
             _comp_compgen_split -- "$("$1" 2>/dev/null |
-                awk '/^PatchSet:?[ \t]/ { print $2 }')"
+                _comp_awk '/^PatchSet:?[ \t]/ { print $2 }')"
             return
             ;;
         -a)
             _comp_compgen_split -- "$("$1" 2>/dev/null |
-                awk '/^Author:[ \t]/ { print $2 }')"
+                _comp_awk '/^Author:[ \t]/ { print $2 }')"
             return
             ;;
         -b)
             _comp_compgen_split -- "$("$1" 2>/dev/null |
-                awk '/^Branch:[ \t]/ { print $2 }')"
+                _comp_awk '/^Branch:[ \t]/ { print $2 }')"
             return
             ;;
         -r)
             _comp_compgen_split -- "$("$1" 2>/dev/null |
-                awk '/^Tag:[ \t]+[^(]/ { print $2 }')"
+                _comp_awk '/^Tag:[ \t]+[^(]/ { print $2 }')"
             return
             ;;
         -p)

--- a/completions/dpkg
+++ b/completions/dpkg
@@ -35,7 +35,7 @@ _comp_xfunc_dpkg_compgen_held_packages()
 {
     _comp_compgen_split -- "$(
         dpkg --get-selections ${cur:+"$cur}"} |
-            awk '{for(i=2;i<=NF;i++){ if($i=="hold"){ print $1;break }}}'
+            _comp_awk '{for(i=2;i<=NF;i++){ if($i=="hold"){ print $1;break }}}'
     )"
 }
 

--- a/completions/fio
+++ b/completions/fio
@@ -36,7 +36,7 @@ _comp_cmd_fio()
             return
             ;;
         --cmdhelp)
-            ret=($("$1" --cmdhelp=all 2>/dev/null | awk '{print $1}') all)
+            ret=($("$1" --cmdhelp=all 2>/dev/null | _comp_awk '{print $1}') all)
             _comp_compgen -- -W '"${ret[@]}"'
             return
             ;;
@@ -141,7 +141,7 @@ _comp_cmd_fio()
     if [[ $cur == -* ]]; then
         _comp_compgen_help
         _comp_compgen -a split -- "$("$1" --cmdhelp=all 2>/dev/null |
-            awk '{printf "--%s=\n", $1}')"
+            _comp_awk '{printf "--%s=\n", $1}')"
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
         return
     fi

--- a/completions/firefox
+++ b/completions/firefox
@@ -15,7 +15,7 @@ _comp_cmd_firefox()
             ;;
         -P)
             _comp_compgen_split -- "$(
-                _comp_awk -F= '$1 == "Name" { print $2 }' \
+                _comp_awk -F = '$1 == "Name" { print $2 }' \
                     ~/.mozilla/firefox/profiles.ini 2>/dev/null
             )"
             return

--- a/completions/firefox
+++ b/completions/firefox
@@ -15,7 +15,7 @@ _comp_cmd_firefox()
             ;;
         -P)
             _comp_compgen_split -- "$(
-                awk -F= '$1 == "Name" { print $2 }' \
+                _comp_awk -F= '$1 == "Name" { print $2 }' \
                     ~/.mozilla/firefox/profiles.ini 2>/dev/null
             )"
             return

--- a/completions/fusermount
+++ b/completions/fusermount
@@ -10,7 +10,7 @@ _comp_cmd_fusermount()
             return
             ;;
         -*u)
-            _comp_compgen_split -- "$(awk \
+            _comp_compgen_split -- "$(_comp_awk \
                 '{ if ($3 ~ /^fuse(\.|$)/) print $2 }' /etc/mtab 2>/dev/null)"
             return
             ;;

--- a/completions/gdb
+++ b/completions/gdb
@@ -37,7 +37,7 @@ _comp_cmd_gdb()
         fi
     elif ((cword == 2)); then
         _comp_compgen_split -- "$(command ps axo comm,pid |
-            awk '{if ($1 ~ /^'"${prev##*/}"'/) print $2}')"
+            _comp_awk '{if ($1 ~ /^'"${prev##*/}"'/) print $2}')"
         compopt -o filenames
         _comp_compgen -a -- -f -X '!?(*/)core?(.?*)' -o plusdirs
     fi

--- a/completions/getconf
+++ b/completions/getconf
@@ -12,7 +12,7 @@ _comp_cmd_getconf()
             ;;
         -v)
             _comp_compgen -c "${cur:-POSIX_V}" split -- "$(
-                "$1" -a 2>/dev/null | awk '{ print $1 }'
+                "$1" -a 2>/dev/null | _comp_awk '{ print $1 }'
             )"
             return
             ;;
@@ -24,7 +24,7 @@ _comp_cmd_getconf()
         _comp_compgen -- -W '-a -v'
     else
         _comp_compgen_split -- "$(
-            "$1" -a 2>/dev/null | awk '{ print $1 }'
+            "$1" -a 2>/dev/null | _comp_awk '{ print $1 }'
         )"
     fi
 } &&

--- a/completions/getent
+++ b/completions/getent
@@ -45,7 +45,7 @@ _comp_cmd_getent()
             return
             ;;
         protocols | networks | ahosts | ahostsv4 | ahostsv6 | rpc)
-            _comp_compgen_split -- "$("$1" "$db" | awk '{ print $1 }')"
+            _comp_compgen_split -- "$("$1" "$db" | _comp_awk '{ print $1 }')"
             return
             ;;
         aliases | shadow | gshadow)

--- a/completions/gm
+++ b/completions/gm
@@ -3,7 +3,7 @@
 _comp_cmd_gm__commands()
 {
     _comp_compgen -a split -- "$("$1" help |
-        awk '/^ +[^ ]+ +- / { print $1 }')"
+        _comp_awk '/^ +[^ ]+ +- / { print $1 }')"
 }
 
 _comp_cmd_gm()

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -24,13 +24,13 @@ _comp_cmd_gphoto2()
             ;;
         --port)
             _comp_compgen_split -- "$("$1" --list-ports 2>/dev/null |
-                awk 'NR>3 { print $1 }')"
+                _comp_awk 'NR>3 { print $1 }')"
             _comp_ltrim_colon_completions "$cur"
             return
             ;;
         --camera)
             _comp_compgen_split -l -- "$("$1" --list-cameras 2>/dev/null |
-                awk -F'"' 'NR>2 { print $2 }')"
+                _comp_awk -F'"' 'NR>2 { print $2 }')"
             return
             ;;
         --get-config | --set-config | --set-config-index | --set-config-value)

--- a/completions/gphoto2
+++ b/completions/gphoto2
@@ -30,7 +30,7 @@ _comp_cmd_gphoto2()
             ;;
         --camera)
             _comp_compgen_split -l -- "$("$1" --list-cameras 2>/dev/null |
-                _comp_awk -F'"' 'NR>2 { print $2 }')"
+                _comp_awk -F '"' 'NR>2 { print $2 }')"
             return
             ;;
         --get-config | --set-config | --set-config-index | --set-config-value)

--- a/completions/hcitool
+++ b/completions/hcitool
@@ -3,13 +3,13 @@
 _comp_cmd_hcitool__bluetooth_addresses()
 {
     if [[ ${COMP_BLUETOOTH_SCAN-} ]]; then
-        _comp_compgen -a split -- "$(hcitool scan | awk '/^\t/{print $1}')"
+        _comp_compgen -a split -- "$(hcitool scan | _comp_awk '/^\t/{print $1}')"
     fi
 }
 
 _comp_cmd_hcitool__bluetooth_devices()
 {
-    _comp_compgen -a split -- "$(hcitool dev | awk '/^\t/{print $1}')"
+    _comp_compgen -a split -- "$(hcitool dev | _comp_awk '/^\t/{print $1}')"
 }
 
 _comp_cmd_hcitool__bluetooth_services()

--- a/completions/ifstat
+++ b/completions/ifstat
@@ -50,7 +50,7 @@ _comp_cmd_ifstat()
         --extended | -${noargopts}x)
             # iproute2: parse xstat types
             _comp_compgen_split -- "$("$1" -x nonexistent-xstat 2>&1 |
-                awk 'found { print $1 } /supported xstats:/ { found=1 }')"
+                _comp_awk 'found { print $1 } /supported xstats:/ { found=1 }')"
             return
             ;;
     esac

--- a/completions/influx
+++ b/completions/influx
@@ -14,7 +14,7 @@ _comp_cmd_influx()
             return
             ;;
         -format | -precision | -consistency)
-            local args=$("$1" --help 2>&1 | awk "\$1 == \"$prev\" { print \$2 }")
+            local args=$("$1" --help 2>&1 | _comp_awk "\$1 == \"$prev\" { print \$2 }")
             _comp_compgen -F $' \t\n'"\"'|" -- -W "$args"
             return
             ;;

--- a/completions/ip
+++ b/completions/ip
@@ -2,7 +2,7 @@
 
 _comp_cmd_ip__iproute2_etc()
 {
-    _comp_compgen -a split -- "$(awk '!/#/ { print $2 }' "/etc/iproute2/$1" \
+    _comp_compgen -a split -- "$(_comp_awk '!/#/ { print $2 }' "/etc/iproute2/$1" \
         2>/dev/null)"
 }
 
@@ -11,7 +11,7 @@ _comp_cmd_ip__netns()
     _comp_compgen_split -- "$(
         {
             ${1-ip} -c=never netns list 2>/dev/null || ${1-ip} netns list
-        } | awk '{print $1}'
+        } | _comp_awk '{print $1}'
     )"
 }
 

--- a/completions/iperf
+++ b/completions/iperf
@@ -68,20 +68,21 @@ _comp_cmd_iperf()
     [[ $was_split ]] && return
 
     # Filter mode specific options
-    local i filter=cat
+    local -a filter=(cat)
+    local i
     for i in "${words[@]}"; do
         case $i in
             -s | --server)
-                filter='command sed -e /^Client.specific/,/^\(Server.specific.*\)\?$/d'
+                filter=(command sed -e '/^Client.specific/,/^\(Server.specific.*\)\?$/d')
                 ;;
             -c | --client)
-                filter='command sed -e /^Server.specific/,/^\(Client.specific.*\)\?$/d'
+                filter=(command sed -e '/^Server.specific/,/^\(Client.specific.*\)\?$/d')
                 ;;
         esac
     done
-    [[ $filter != cat ]] && filter+=' -e /--client/d -e /--server/d'
+    [[ $filter != cat ]] && filter+=(-e '/--client/d' -e '/--server/d')
 
-    _comp_compgen_help - <<<"$("$1" --help 2>&1 | $filter)"
+    _comp_compgen_help - <<<"$("$1" --help 2>&1 | "${filter[@]}")"
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_iperf iperf iperf3

--- a/completions/iperf
+++ b/completions/iperf
@@ -73,10 +73,10 @@ _comp_cmd_iperf()
     for i in "${words[@]}"; do
         case $i in
             -s | --server)
-                filter=(command sed -e '/^Client.specific/,/^\(Server.specific.*\)\?$/d')
+                filter=(command sed -e '/^Client.specific/,/^\(Server.specific.*\)\{0,1\}$/d')
                 ;;
             -c | --client)
-                filter=(command sed -e '/^Server.specific/,/^\(Client.specific.*\)\?$/d')
+                filter=(command sed -e '/^Server.specific/,/^\(Client.specific.*\)\{0,1\}$/d')
                 ;;
         esac
     done

--- a/completions/ipmitool
+++ b/completions/ipmitool
@@ -50,7 +50,7 @@ _comp_cmd_ipmitool()
             ;;
         -*o)
             _comp_compgen_split -- "$("$1" -o list 2>&1 |
-                awk '/^[ \t]+/ { print $1 }') list"
+                _comp_awk '/^[ \t]+/ { print $1 }') list"
             return
             ;;
     esac

--- a/completions/iwconfig
+++ b/completions/iwconfig
@@ -25,13 +25,13 @@ _comp_cmd_iwconfig()
             ;;
         channel)
             _comp_compgen_split -- "$(iwlist "${words[1]}" channel |
-                awk '/^[ \t]*Channel/ {print $2}')"
+                _comp_awk '/^[ \t]*Channel/ {print $2}')"
             return
             ;;
 
         freq)
             _comp_compgen_split -- "$(iwlist "${words[1]}" channel |
-                awk '/^[ \t]*Channel/ {print $4"G"}')"
+                _comp_awk '/^[ \t]*Channel/ {print $4"G"}')"
             return
             ;;
         ap)
@@ -45,7 +45,7 @@ _comp_cmd_iwconfig()
         rate)
             _comp_compgen -- -W 'auto fixed'
             _comp_compgen -a split -- "$(iwlist "${words[1]}" rate |
-                awk '/^[ \t]*[0-9]/ {print $1"M"}')"
+                _comp_awk '/^[ \t]*[0-9]/ {print $1"M"}')"
             return
             ;;
         rts | frag)

--- a/completions/java
+++ b/completions/java
@@ -73,7 +73,7 @@ _comp_cmd_java__classes()
             elif type unzip &>/dev/null; then
                 # Last column, between entries consisting entirely of dashes
                 COMPREPLY+=($(unzip -lq "$i" "$cur*" 2>/dev/null |
-                    awk '$NF ~ /^-+$/ { flag=!flag; next };
+                    _comp_awk '$NF ~ /^-+$/ { flag=!flag; next };
                          flag && $NF ~ /^[^$]*\.class/ { print $NF }'))
             elif type jar &>/dev/null; then
                 COMPREPLY+=($(jar tf "$i" "$cur" |

--- a/completions/koji
+++ b/completions/koji
@@ -28,7 +28,7 @@ _comp_cmd_koji__tag()
 _comp_cmd_koji__target()
 {
     _comp_compgen -a split -- "$("$1" -q list-targets 2>/dev/null |
-        awk '{ print $1 }')"
+        _comp_awk '{ print $1 }')"
 }
 
 _comp_cmd_koji()
@@ -238,7 +238,7 @@ _comp_cmd_koji()
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     elif [[ ! $has_command ]]; then
         _comp_compgen_split -- "$("$1" --help-commands 2>/dev/null |
-            awk '/^(  +|\t)/ { print $1 }')"
+            _comp_awk '/^(  +|\t)/ { print $1 }')"
     fi
 } &&
     complete -F _comp_cmd_koji koji arm-koji ppc-koji s390-koji sparc-koji

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -3,13 +3,13 @@
 _comp_cmd_ktutil__heimdal_principals()
 {
     _comp_compgen_split -- "$(kadmin -l dump 2>/dev/null |
-        awk '{print $1}')"
+        _comp_awk '{print $1}')"
 }
 
 _comp_cmd_ktutil__heimdal_realms()
 {
     _comp_compgen_split -- "$(kadmin -l dump 2>/dev/null |
-        awk '{print $1}' | awk -F@ '{print $2}')"
+        _comp_awk '{print $1}' | _comp_awk -F@ '{print $2}')"
 }
 
 _comp_cmd_ktutil__heimdal_encodings()

--- a/completions/ktutil
+++ b/completions/ktutil
@@ -9,7 +9,7 @@ _comp_cmd_ktutil__heimdal_principals()
 _comp_cmd_ktutil__heimdal_realms()
 {
     _comp_compgen_split -- "$(kadmin -l dump 2>/dev/null |
-        _comp_awk '{print $1}' | _comp_awk -F@ '{print $2}')"
+        _comp_awk '{print $1}' | _comp_awk -F @ '{print $2}')"
 }
 
 _comp_cmd_ktutil__heimdal_encodings()

--- a/completions/lilo
+++ b/completions/lilo
@@ -2,7 +2,7 @@
 
 _comp_cmd_lilo__labels()
 {
-    _comp_compgen_split -- "$(awk -F= '$1 ~ /^[ \t]*label$/ {print $2}' \
+    _comp_compgen_split -- "$(_comp_awk -F= '$1 ~ /^[ \t]*label$/ {print $2}' \
         "${1:-/etc/lilo.conf}" 2>/dev/null | command sed -e 's/\"//g')"
 }
 

--- a/completions/lilo
+++ b/completions/lilo
@@ -2,7 +2,7 @@
 
 _comp_cmd_lilo__labels()
 {
-    _comp_compgen_split -- "$(_comp_awk -F= '$1 ~ /^[ \t]*label$/ {print $2}' \
+    _comp_compgen_split -- "$(_comp_awk -F = '$1 ~ /^[ \t]*label$/ {print $2}' \
         "${1:-/etc/lilo.conf}" 2>/dev/null | command sed -e 's/\"//g')"
 }
 

--- a/completions/lintian
+++ b/completions/lintian
@@ -6,7 +6,7 @@ _comp_cmd_lintian__tags()
     _comp_expand_glob check_files '/usr/share/lintian/checks/*.desc'
     ((${#check_files[@]})) || return 0
 
-    tags=$(awk '/^Tag/ { print $2 }' "${check_files[@]}")
+    tags=$(_comp_awk '/^Tag/ { print $2 }' "${check_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }
         for item in $search; do
@@ -26,14 +26,14 @@ _comp_cmd_lintian__checks()
     _comp_expand_glob check_files '/usr/share/lintian/checks/*.desc'
     ((${#check_files[@]})) || return 0
 
-    checks=$(awk '/^(Check-Script|Abbrev)/ { print $2 }' \
+    checks=$(_comp_awk '/^(Check-Script|Abbrev)/ { print $2 }' \
         "${check_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }
         for item in $search; do
             match=$(command grep -nE "^(Check-Script|Abbrev): $item$" \
                 "${check_files[@]}" | cut -d: -f1)
-            todisable=$(awk '/^(Check-Script|Abbrev)/ { print $2 }' "$match")
+            todisable=$(_comp_awk '/^(Check-Script|Abbrev)/ { print $2 }' "$match")
             for name in $todisable; do
                 checks=$(command sed -e "s/\<$name\>//g" <<<"$checks")
             done
@@ -52,7 +52,7 @@ _comp_cmd_lintian__infos()
     _comp_expand_glob collection_files '/usr/share/lintian/collection/*.desc'
     ((${#collection_files[@]})) || return 0
 
-    infos=$(awk '/^Collector/ { print $2 }' \
+    infos=$(_comp_awk '/^Collector/ { print $2 }' \
         "${collection_files[@]}")
     if [[ $cur == *, ]]; then
         search=${cur//,/ }

--- a/completions/locale-gen
+++ b/completions/locale-gen
@@ -24,7 +24,7 @@ _comp_cmd_locale_gen()
     fi
 
     _comp_compgen_split -- "$(
-        awk '{ print $1 }' /usr/share/i18n/SUPPORTED 2>/dev/null
+        _comp_awk '{ print $1 }' /usr/share/i18n/SUPPORTED 2>/dev/null
     )"
 } &&
     complete -F _comp_cmd_locale_gen locale-gen

--- a/completions/mcrypt
+++ b/completions/mcrypt
@@ -21,7 +21,7 @@ _comp_cmd_mcrypt()
             ;;
         -a | --algorithm)
             _comp_compgen_split -- "$("$1" --list 2>/dev/null |
-                awk '{print $1}')"
+                _comp_awk '{print $1}')"
             return
             ;;
         -h | --hash)

--- a/completions/medusa
+++ b/completions/medusa
@@ -15,7 +15,7 @@ _comp_cmd_medusa()
             return
             ;;
         -*M)
-            _comp_compgen_split -- "$("$1" -d | awk '/^ +\+/ {print $2}' |
+            _comp_compgen_split -- "$("$1" -d | _comp_awk '/^ +\+/ {print $2}' |
                 command sed -e 's/\.mod$//')"
             return
             ;;

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -98,7 +98,7 @@ _comp_cmd_modprobe()
                 else
                     _comp_compgen_split -S = -- "$(PATH="$PATH:/sbin" \
                         modinfo -p "$module" 2>/dev/null |
-                        _comp_awk -F: '!/^[ \t]/ { print $1 }')"
+                        _comp_awk -F : '!/^[ \t]/ { print $1 }')"
                     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
                 fi
             else

--- a/completions/modprobe
+++ b/completions/modprobe
@@ -98,7 +98,7 @@ _comp_cmd_modprobe()
                 else
                     _comp_compgen_split -S = -- "$(PATH="$PATH:/sbin" \
                         modinfo -p "$module" 2>/dev/null |
-                        awk -F: '!/^[ \t]/ { print $1 }')"
+                        _comp_awk -F: '!/^[ \t]/ { print $1 }')"
                     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
                 fi
             else

--- a/completions/mplayer
+++ b/completions/mplayer
@@ -4,7 +4,7 @@ _comp_cmd_mplayer__options()
 {
     cur=${cur%\\}
     _comp_compgen_split -- "$("$1" -noconfig all "$2" help 2>/dev/null |
-        command sed -e '/^Available/,/^$/!d' -e '/^Available/d' | awk '{print $1}' |
+        command sed -e '/^Available/,/^$/!d' -e '/^Available/d' | _comp_awk '{print $1}' |
         command sed -e 's/:$//' -e 's/^'"${2#-}"'$//' -e 's/<.*//')"
 }
 

--- a/completions/msynctool
+++ b/completions/msynctool
@@ -8,7 +8,7 @@ _comp_cmd_msynctool()
     case $words in
         --configure)
             _comp_compgen_split -- "$("$1" --showgroup "$prev" |
-                awk '/^Member/ {print $2}' | command sed -e 's/:$//')"
+                _comp_awk '/^Member/ {print $2}' | command sed -e 's/:$//')"
             return
             ;;
         --addmember)

--- a/completions/mtx
+++ b/completions/mtx
@@ -12,11 +12,11 @@ _comp_cmd_mtx()
         inventory status load unload eepos first last next"
 
     tapes=$(mtx status 2>/dev/null |
-        awk '/Storage Element [0-9]+:Full/ { printf "%s ", $3 }')
+        _comp_awk '/Storage Element [0-9]+:Full/ { printf "%s ", $3 }')
     tapes=${tapes//:Full/}
 
     drives=$(mtx status 2>/dev/null |
-        awk '/Data Transfer Element [0-9]+:(Full|Empty)/ { printf "%s ", $4 }')
+        _comp_awk '/Data Transfer Element [0-9]+:(Full|Empty)/ { printf "%s ", $4 }')
     drives=${drives//:Full/}
     drives=${drives//:Empty/}
 

--- a/completions/openssl
+++ b/completions/openssl
@@ -22,14 +22,14 @@ _comp_cmd_openssl__compgen_sections()
 
     [[ ! -f $config ]] && return
 
-    _comp_compgen -U config split -- "$(awk '/\[.*\]/ {print $2}' "$config")"
+    _comp_compgen -U config split -- "$(_comp_awk '/\[.*\]/ {print $2}' "$config")"
 }
 
 _comp_cmd_openssl__compgen_digests()
 {
     _comp_compgen_split -- "$(
         "$1" dgst -h 2>&1 |
-            awk '/^-.*[ \t]to use the .* message digest algorithm/ { print $1 }'
+            _comp_awk '/^-.*[ \t]to use the .* message digest algorithm/ { print $1 }'
         local -a digests=($("$1" help 2>&1 |
             command sed -ne '/^Message Digest commands/,/^[[:space:]]*$/p' |
             command sed -e 1d))

--- a/completions/p4
+++ b/completions/p4
@@ -9,7 +9,7 @@ _comp_cmd_p4()
     local p4commands p4filetypes
 
     # rename isn't really a command
-    p4commands="$(p4 help commands 2>/dev/null | awk 'NF>3 {print $1}')"
+    p4commands="$(p4 help commands 2>/dev/null | _comp_awk 'NF>3 {print $1}')"
     p4filetypes="ctext cxtext ktext kxtext ltext tempobj ubinary \
         uresource uxbinary xbinary xltext xtempobj xtext \
         text binary resource"

--- a/completions/perl
+++ b/completions/perl
@@ -132,7 +132,7 @@ _comp_cmd_perldoc()
             if [[ $cur == p* ]]; then
                 _comp_compgen -a split -- "$(PERLDOC_PAGER=cat "$1" -u perl |
                     command sed -ne '/perl.*Perl overview/,/perlwin32/p' |
-                    awk 'NF >= 2 && $1 ~ /^perl/ { print $1 }')"
+                    _comp_awk 'NF >= 2 && $1 ~ /^perl/ { print $1 }')"
             fi
         fi
         _comp_compgen -a filedir 'p@([lm]|od)'

--- a/completions/pine
+++ b/completions/pine
@@ -24,7 +24,7 @@ _comp_cmd_pine()
     if [[ $cur == -* ]]; then
         _comp_compgen_help -- -h
     else
-        _comp_compgen_split -- "$(awk '{print $1}' ~/.addressbook 2>/dev/null)"
+        _comp_compgen_split -- "$(_comp_awk '{print $1}' ~/.addressbook 2>/dev/null)"
     fi
 } &&
     complete -F _comp_cmd_pine pine alpine

--- a/completions/pkg-config
+++ b/completions/pkg-config
@@ -36,7 +36,7 @@ _comp_cmd_pkg_config()
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen_split -- "$("$1" --list-all 2>/dev/null |
-            awk '{print $1}')"
+            _comp_awk '{print $1}')"
         _comp_compgen -a filedir pc
     fi
 } &&

--- a/completions/pkg-get
+++ b/completions/pkg-get
@@ -16,7 +16,7 @@ _comp_cmd_pkg_get__catalog_file()
     conffile="${conffile:-/opt/csw/etc/pkg-get.conf}"
 
     if [[ ! $url ]]; then
-        url=$(awk -F= ' $1=="url" { print $2 }' "$conffile")
+        url=$(_comp_awk -F= ' $1=="url" { print $2 }' "$conffile")
     fi
 
     ret="${url##*//}"
@@ -49,7 +49,7 @@ _comp_cmd_pkg_get__catalog_file()
                 local ret
                 _comp_cmd_pkg_get__catalog_file "$url"
                 if [[ -f $ret ]]; then
-                    local packages_list=$(awk '$0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "$ret")
+                    local packages_list=$(_comp_awk '$0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "$ret")
                     _comp_compgen -- -W "${packages_list}"
                 fi
             fi

--- a/completions/pkg-get
+++ b/completions/pkg-get
@@ -16,7 +16,7 @@ _comp_cmd_pkg_get__catalog_file()
     conffile="${conffile:-/opt/csw/etc/pkg-get.conf}"
 
     if [[ ! $url ]]; then
-        url=$(_comp_awk -F= ' $1=="url" { print $2 }' "$conffile")
+        url=$(_comp_awk -F = ' $1=="url" { print $2 }' "$conffile")
     fi
 
     ret="${url##*//}"

--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -73,7 +73,7 @@ _comp_cmd_pkgutil()
     if [[ $command && $cur != -* ]]; then
 
         local mirrors mirror_url
-        mirrors=$(_comp_awk -F= ' $1 ~ /^ *mirror *$/ { print $2 }' "${configuration_files[@]}")
+        mirrors=$(_comp_awk -F = ' $1 ~ /^ *mirror *$/ { print $2 }' "${configuration_files[@]}")
         mirrors=${mirrors:-http://mirror.opencsw.org/opencsw/testing}
         for mirror_url in $mirrors; do
             _comp_cmd_pkgutil__url2catalog "$mirror_url"

--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -73,7 +73,7 @@ _comp_cmd_pkgutil()
     if [[ $command && $cur != -* ]]; then
 
         local mirrors mirror_url
-        mirrors=$(awk -F= ' $1 ~ /^ *mirror *$/ { print $2 }' "${configuration_files[@]}")
+        mirrors=$(_comp_awk -F= ' $1 ~ /^ *mirror *$/ { print $2 }' "${configuration_files[@]}")
         mirrors=${mirrors:-http://mirror.opencsw.org/opencsw/testing}
         for mirror_url in $mirrors; do
             _comp_cmd_pkgutil__url2catalog "$mirror_url"
@@ -81,12 +81,12 @@ _comp_cmd_pkgutil()
         done
 
         if [[ $command == -@([dius]|-download|-install|-upgrade|-stream) ]]; then
-            local packages_list=$(awk ' $0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "${catalog_files[@]}")
+            local packages_list=$(_comp_awk ' $0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "${catalog_files[@]}")
             _comp_compgen -- -W "${packages_list}"
 
         elif [[ $command == @(-r|--remove) ]]; then
             local packages_list=$(
-                pkginfo | awk ' $2 ~ /^CSW/ { printf ("%s|",$2) }'
+                pkginfo | _comp_awk ' $2 ~ /^CSW/ { printf ("%s|",$2) }'
             )
             packages_list=${packages_list%|}
             packages_list=$(nawk " \$3 ~ /^$packages_list\$/ { print \$1 }" "${catalog_files[@]}")

--- a/completions/ps
+++ b/completions/ps
@@ -50,7 +50,7 @@ _comp_cmd_ps()
         --format | ?(-)[Oo] | [^-]*[Oo])
             # TODO: This doesn't work well when there are multiple options for
             # the non-first item (similarly to useradd --groups and others).
-            local labels=$("$1" L | awk '{ print $1 }')
+            local labels=$("$1" L | _comp_awk '{ print $1 }')
             _comp_delimited , -W '$labels'
             return
             ;;

--- a/completions/ps
+++ b/completions/ps
@@ -62,7 +62,7 @@ _comp_cmd_ps()
             "$1" --help
             "$1" --help all
         } 2>/dev/null |
-            sed -e "s/, [A-Za-z],/,/")" ||
+            command sed -e "s/, [A-Za-z],/,/")" ||
             _comp_compgen_usage
     fi
 } &&

--- a/completions/psql
+++ b/completions/psql
@@ -5,7 +5,7 @@ _comp_cmd_psql__databases()
     # -w was introduced in 8.4, https://launchpad.net/bugs/164772
     # "Access privileges" in output may contain linefeeds, hence the NF > 1
     _comp_compgen_split -- "$(psql -XAtqwlF $'\t' 2>/dev/null |
-        awk 'NF > 1 { print $1 }')"
+        _comp_awk 'NF > 1 { print $1 }')"
 }
 
 _comp_cmd_psql__users()

--- a/completions/puppet
+++ b/completions/puppet
@@ -24,7 +24,7 @@ _comp_cmd_puppet__certs()
     if [[ $1 == --all ]]; then
         cert_list=$(
             $puppetca --list --all |
-                command sed -e 's/^[+-]\{0,1\}\s*\(\S\+\)\s\+.*$/\1/'
+                command sed -e 's/^[+-]\{0,1\}\s*\(\S\{1,\}\)\s\{1,\}.*$/\1/'
         )
     else
         cert_list=$("$puppetca" --list)

--- a/completions/puppet
+++ b/completions/puppet
@@ -24,7 +24,7 @@ _comp_cmd_puppet__certs()
     if [[ $1 == --all ]]; then
         cert_list=$(
             $puppetca --list --all |
-                command sed -e 's/^[+-]\{0,1\}\s*\(\S\{1,\}\)\s\{1,\}.*$/\1/'
+                command sed -e 's/^[+-]\{0,1\}[[:space:]]*\([^[:space:]]\{1,\}\)[[:space:]]\{1,\}.*$/\1/'
         )
     else
         cert_list=$("$puppetca" --list)
@@ -35,7 +35,7 @@ _comp_cmd_puppet__certs()
 _comp_cmd_puppet__types()
 {
     puppet_types=$(
-        puppet describe --list | command sed -e 's/^\(\S\{1,\}\).*$/\1/'
+        puppet describe --list | command sed -e 's/^\([^[:space:]]\{1,\}\).*$/\1/'
     )
     _comp_compgen -a -- -W "$puppet_types"
 }
@@ -47,7 +47,7 @@ _comp_cmd_puppet__references()
         puppetdoc=puppetdoc
 
     puppet_doc_list=$(
-        $puppetdoc --list | command sed -e 's/^\(\S\{1,\}\).*$/\1/'
+        $puppetdoc --list | command sed -e 's/^\([^[:space:]]\{1,\}\).*$/\1/'
     )
     _comp_compgen -a -- -W "$puppet_doc_list"
 }

--- a/completions/python
+++ b/completions/python
@@ -98,7 +98,7 @@ _comp_cmd_python()
             ;;
         -${noargopts}X)
             _comp_compgen_split -- "$("$1" -h 2>&1 |
-                awk '$1 == "-X" && $2 ~ /:$/ {
+                _comp_awk '$1 == "-X" && $2 ~ /:$/ {
                     sub(":$","",$2); sub("=.*","=",$2); print $2
                 }')"
             [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
@@ -115,7 +115,7 @@ _comp_cmd_python()
         _comp_compgen_filedir '@(py?([cowz])|zip)'
     else
         _comp_compgen_help - <<<"$("$1" -h |
-            awk '{ sub("\\(-bb:","\n-bb "); print }')"
+            _comp_awk '{ sub("\\(-bb:","\n-bb "); print }')"
     fi
 } &&
     complete -F _comp_cmd_python \

--- a/completions/qemu
+++ b/completions/qemu
@@ -27,13 +27,15 @@ _comp_cmd_qemu()
             return
             ;;
         -soundhw)
-            _comp_compgen_split -- "$("$1" -soundhw help |
-                _comp_awk '/^[[:lower:]]/ {print $1}') all"
+            _comp_compgen_split -- "$("$1" -soundhw help | _comp_awk '
+                function islower(s) { return length(s) > 0 && s == tolower(s); }
+                islower(substr($0, 1, 1)) {print $1}') all"
             return
             ;;
         -machine | -M)
-            _comp_compgen_split -- "$("$1" "$prev" help | _comp_awk \
-                '/^[[:lower:]]/ {print $1}')"
+            _comp_compgen_split -- "$("$1" "$prev" help | _comp_awk '
+                function islower(s) { return length(s) > 0 && s == tolower(s); }
+                islower(substr($0, 1, 1)) {print $1}')"
             return
             ;;
         -cpu)

--- a/completions/qemu
+++ b/completions/qemu
@@ -28,16 +28,16 @@ _comp_cmd_qemu()
             ;;
         -soundhw)
             _comp_compgen_split -- "$("$1" -soundhw help |
-                awk '/^[[:lower:]]/ {print $1}') all"
+                _comp_awk '/^[[:lower:]]/ {print $1}') all"
             return
             ;;
         -machine | -M)
-            _comp_compgen_split -- "$("$1" "$prev" help | awk \
+            _comp_compgen_split -- "$("$1" "$prev" help | _comp_awk \
                 '/^[[:lower:]]/ {print $1}')"
             return
             ;;
         -cpu)
-            _comp_compgen_split -- "$("$1" -cpu help | awk '{print $2}')"
+            _comp_compgen_split -- "$("$1" -cpu help | _comp_awk '{print $2}')"
             return
             ;;
         -usbdevice)
@@ -80,7 +80,7 @@ _comp_cmd_qemu()
             ;;
         -watchdog)
             _comp_compgen_split -- "$("$1" -watchdog help 2>&1 |
-                awk '{print $1}')"
+                _comp_awk '{print $1}')"
             return
             ;;
         -watchdog-action)

--- a/completions/quota
+++ b/completions/quota
@@ -31,7 +31,7 @@ _comp_cmd_quota__filesystems()
 {
     #  Only list filesystems starting with "/", otherwise we also get
     #+ "binfmt_misc", "proc", "tmpfs", ...
-    _comp_compgen_split -- "$(awk '/^\// {print $1}' /etc/mtab)"
+    _comp_compgen_split -- "$(_comp_awk '/^\// {print $1}' /etc/mtab)"
 }
 
 _comp_cmd_quota()

--- a/completions/reportbug
+++ b/completions/reportbug
@@ -33,7 +33,7 @@ _comp_cmd_reportbug()
             ;;
         --tag | --ui | --interface | --type | --bts | --severity | --mode | -${noargopts}[TutBS])
             _comp_compgen_split -- "$("$1" "$prev" help 2>&1 |
-                sed -ne '/^[[:space:]]/p')"
+                command sed -ne '/^[[:space:]]/p')"
             return
             ;;
         --editor | --mua | --mbox-reader-cmd | -${noargopts}e)

--- a/completions/rpm
+++ b/completions/rpm
@@ -44,8 +44,10 @@ _comp_cmd_rpm__macros()
 # shellcheck disable=SC2120
 _comp_cmd_rpm__buildarchs()
 {
+    # Case-insensitive BRE to match "compatible build archs"
+    local regex_header='[cC][oO][mM][pP][aA][tT][iI][bB][lL][eE][[:space:]]\{1,\}[bB][uU][iI][lL][dD][[:space:]]\{1,\}[aA][rR][cC][hH][sS]'
     _comp_compgen_split -- "$("${1:-rpm}" --showrc | command sed -ne \
-        's/^[[:space:]]*compatible[[:space:]]\{1,\}build[[:space:]]\{1,\}archs[[:space:]]*:[[:space:]]*\(.*\)/\1/ p')"
+        "s/^[[:space:]]*${regex_header}[[:space:]]*:[[:space:]]*\(.*\)/\1/p")"
 }
 
 # shellcheck disable=SC2120

--- a/completions/rpm
+++ b/completions/rpm
@@ -45,7 +45,7 @@ _comp_cmd_rpm__macros()
 _comp_cmd_rpm__buildarchs()
 {
     _comp_compgen_split -- "$("${1:-rpm}" --showrc | command sed -ne \
-        's/^\s*compatible\s\s*build\s\s*archs\s*:\s*\(.*\)/\1/ p')"
+        's/^[[:space:]]*compatible[[:space:]]\{1,\}build[[:space:]]\{1,\}archs[[:space:]]*:[[:space:]]*\(.*\)/\1/ p')"
 }
 
 # shellcheck disable=SC2120

--- a/completions/rsync
+++ b/completions/rsync
@@ -65,7 +65,7 @@ _comp_cmd_rsync()
             # meaning before v3.2.0) contain the following unusual line in
             # --help:
             # "(-h) --help                  show this help (-h is --help only if used alone)"
-            _comp_compgen -Rv tmp help - <<<"$("$1" --help 2>&1 | sed -e 's/^([^)]*)//')"
+            _comp_compgen -Rv tmp help - <<<"$("$1" --help 2>&1 | command sed -e 's/^([^)]*)//')"
 
             _comp_compgen -- -W '"${tmp[@]}"
                 --daemon --old-d{,irs}

--- a/completions/scrub
+++ b/completions/scrub
@@ -14,7 +14,7 @@ _comp_cmd_scrub()
             ;;
         --pattern | -${noargopts}p)
             _comp_compgen_split -- "$("$1" --help 2>&1 |
-                awk '/^Available/{flag=1;next}/^ /&&flag{print $1}')"
+                _comp_awk '/^Available/{flag=1;next}/^ /&&flag{print $1}')"
             return
             ;;
         --freespace | -${noargopts}X)

--- a/completions/ssh
+++ b/completions/ssh
@@ -52,7 +52,7 @@ _comp_cmd_ssh__compgen_macs()
 # @since 2.12
 _comp_xfunc_ssh_compgen_options()
 {
-    # curl --silent https://raw.githubusercontent.com/openssh/openssh-portable/master/ssh_config.5 | awk '$1==".It" && $2=="Cm" && $3!="Host" && $3!="Match" {print "        "$3}' | sort
+    # curl --silent https://raw.githubusercontent.com/openssh/openssh-portable/master/ssh_config.5 | _comp_awk '$1==".It" && $2=="Cm" && $3!="Host" && $3!="Match" {print "        "$3}' | sort
     local _opts=(
         AddKeysToAgent AddressFamily BatchMode BindAddress BindInterface
         CanonicalDomains CanonicalizeFallbackLocal CanonicalizeHostname

--- a/completions/svk
+++ b/completions/svk
@@ -189,7 +189,7 @@ _comp_cmd_svk()
                     ;;
                 sync)
                     _comp_compgen_split -- "$("$1" mirror --list \
-                        2>/dev/null | awk '/^\//{print $1}')"
+                        2>/dev/null | _comp_awk '/^\//{print $1}')"
                     ;;
                 co | checkout | push | pull)
                     if [[ $cur == //*/* ]]; then

--- a/completions/synclient
+++ b/completions/synclient
@@ -15,7 +15,7 @@ _comp_cmd_synclient()
         _comp_compgen_usage
     elif [[ $cur != *=?* ]]; then
         _comp_compgen_split -S = -- "$("$1" -l 2>/dev/null |
-            awk '/^[ \t]/ { print $1 }')"
+            _comp_awk '/^[ \t]/ { print $1 }')"
         compopt -o nospace
     fi
 } &&

--- a/completions/tipc
+++ b/completions/tipc
@@ -43,7 +43,7 @@ _comp_cmd_tipc__bearer()
         case "$media" in
             "udp")
                 local names=$(
-                    tipc bearer list 2>/dev/null | _comp_awk -F: '/^udp:/ {print $2}'
+                    tipc bearer list 2>/dev/null | _comp_awk -F : '/^udp:/ {print $2}'
                 )
                 _comp_compgen -- -W '$names'
                 ;;

--- a/completions/tipc
+++ b/completions/tipc
@@ -43,7 +43,7 @@ _comp_cmd_tipc__bearer()
         case "$media" in
             "udp")
                 local names=$(
-                    tipc bearer list 2>/dev/null | awk -F: '/^udp:/ {print $2}'
+                    tipc bearer list 2>/dev/null | _comp_awk -F: '/^udp:/ {print $2}'
                 )
                 _comp_compgen -- -W '$names'
                 ;;
@@ -70,7 +70,7 @@ _comp_cmd_tipc__link()
     elif ((cword == optind + 1)); then
         # awk drops link state and last trailing :
         local links=$(tipc link list 2>/dev/null |
-            awk '{print substr($1, 0, length($1))}')
+            _comp_awk '{print substr($1, 0, length($1))}')
         local -a exclude
         [[ $filter == peers ]] && exclude=(-X broadcast-link)
         _comp_compgen -- "${exclude[@]}" -W '$links'

--- a/completions/tshark
+++ b/completions/tshark
@@ -36,7 +36,7 @@ _comp_cmd_tshark()
             return
             ;;
         -*i)
-            _comp_compgen_split -- "$("$1" -D 2>/dev/null | awk '{print $2}')"
+            _comp_compgen_split -- "$("$1" -D 2>/dev/null | _comp_awk '{print $2}')"
             return
             ;;
         -*y)
@@ -49,7 +49,7 @@ _comp_cmd_tshark()
             done
             # shellcheck disable=SC2086
             _comp_compgen_split -- "$("$1" $opts -L 2>/dev/null |
-                awk '/^  / { print $1 }')"
+                _comp_awk '/^  / { print $1 }')"
             return
             ;;
         -*[ab])
@@ -68,7 +68,7 @@ _comp_cmd_tshark()
             return
             ;;
         -*F)
-            _comp_compgen_split -- "$("$1" -F 2>&1 | awk '/^  / { print $1 }')"
+            _comp_compgen_split -- "$("$1" -F 2>&1 | _comp_awk '/^  / { print $1 }')"
             return
             ;;
         -*O)
@@ -79,12 +79,12 @@ _comp_cmd_tshark()
             return
             ;;
         -*T)
-            # Parse from: tshark -T . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
+            # Parse from: tshark -T . 2>&1 | _comp_awk -F \" '/^\t*"/ { print $2 }'
             _comp_compgen -- -W 'pdml ps psml json jsonraw ek tabs text fields'
             return
             ;;
         -*t)
-            # Parse from: tshark -t . 2>&1 | awk -F \" '/^\t*"/ { print $2 }'
+            # Parse from: tshark -t . 2>&1 | _comp_awk -F \" '/^\t*"/ { print $2 }'
             _comp_compgen -- -W 'a ad adoy d dd e r u ud udoy'
             return
             ;;
@@ -109,7 +109,7 @@ _comp_cmd_tshark()
             ;;
         -*G)
             _comp_compgen_split -- "$("$1" -G \? 2>/dev/null |
-                awk '/^[ \t]*-G / {
+                _comp_awk '/^[ \t]*-G / {
                     sub("^[[]","",$2); sub("[]]$","",$2); print $2
                 }')"
             return

--- a/completions/wodim
+++ b/completions/wodim
@@ -44,7 +44,7 @@ _comp_cmd_wodim()
                 ;;
             driver)
                 _comp_compgen_split -- "$("$1" driver=help 2>&1 |
-                    awk 'NR > 1 { print $1 }') help"
+                    _comp_awk 'NR > 1 { print $1 }') help"
                 ;;
             minbuf)
                 _comp_compgen -- -W '{25..95}'

--- a/completions/xdg-settings
+++ b/completions/xdg-settings
@@ -21,7 +21,7 @@ _comp_cmd_xdg_settings()
     if ((ret == 1)); then
         _comp_compgen -- -W "get check set"
     elif ((ret == 2)); then
-        _comp_compgen_split -- "$("$1" --list | awk '!/^Known/ { print $1 }')"
+        _comp_compgen_split -- "$("$1" --list | _comp_awk '!/^Known/ { print $1 }')"
     fi
 } &&
     complete -F _comp_cmd_xdg_settings xdg-settings

--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -8,7 +8,7 @@ _comp_cmd_xfreerdp()
     case $prev in
         -k)
             _comp_compgen_split -- "$("$1" --kbd-list |
-                awk '/^0x/ { print $1 }')"
+                _comp_awk '/^0x/ { print $1 }')"
             return
             ;;
         -a)
@@ -31,7 +31,7 @@ _comp_cmd_xfreerdp()
     case $cur in
         /kbd:*)
             _comp_compgen -c "${cur#/kbd:}" split -- "$("$1" /kbd-list |
-                awk '/^0x/ { print $1 }')"
+                _comp_awk '/^0x/ { print $1 }')"
             return
             ;;
         /bpp:*)
@@ -46,7 +46,7 @@ _comp_cmd_xfreerdp()
     if [[ $cur == /* ]]; then
         _comp_compgen_filedir rdp
         _comp_compgen -a split -- "$(
-            "$1" --help | awk '$1 ~ /^\// && $1 !~ /^.(flag$|option:)/ {
+            "$1" --help | _comp_awk '$1 ~ /^\// && $1 !~ /^.(flag$|option:)/ {
                 sub(":.*",":",$1); print $1 }'
         )"
         [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
@@ -54,7 +54,7 @@ _comp_cmd_xfreerdp()
         local char=${cur:0:1}
         local help="$("$1" --help)"
         if [[ $help == */help* ]]; then # new/slash syntax
-            _comp_compgen_split -- "$(awk '$1 ~ /^[+-]/ && $1 !~ /^.toggle$/ {
+            _comp_compgen_split -- "$(_comp_awk '$1 ~ /^[+-]/ && $1 !~ /^.toggle$/ {
                     sub("^.","'"$char"'",$1); print $1 }' <<<"$help")"
         else # old/dash syntax
             _comp_compgen -R help - <<<"$help"
@@ -64,7 +64,7 @@ _comp_cmd_xfreerdp()
     else
         _comp_compgen_filedir rdp
         _comp_compgen -a split -- "$(
-            awk '{print $1}' ~/.freerdp/known_hosts 2>/dev/null
+            _comp_awk '{print $1}' ~/.freerdp/known_hosts 2>/dev/null
         )"
     fi
 

--- a/completions/xrandr
+++ b/completions/xrandr
@@ -2,7 +2,7 @@
 
 _comp_cmd_xrandr__compgen_outputs()
 {
-    _comp_compgen_split -- "$("$1" -q 2>/dev/null | awk '/connected/ {print $1}')"
+    _comp_compgen_split -- "$("$1" -q 2>/dev/null | _comp_awk '/connected/ {print $1}')"
 }
 
 _comp_cmd_xrandr__compgen_monitors()

--- a/test/runLint
+++ b/test/runLint
@@ -46,6 +46,9 @@ gitgrep $cmdstart'[ef]grep\b' \
 gitgrep '(?<!command)'$cmdstart'(grep|ls|sed|cd)(\s|$)' \
     'invoke grep, ls, sed, and cd through "command", e.g. "command grep"'
 
+gitgrep '(?<!command)'$cmdstart'awk(\s|$)' \
+    'invoke awk through "_comp_awk"'
+
 gitgrep '<<<' 'herestrings use temp files, use some other way'
 
 filter_out='^(test/|bash_completion\.sh)' gitgrep ' \[ ' \

--- a/test/runLint
+++ b/test/runLint
@@ -21,8 +21,8 @@ fi
 cmdstart='(^|[[:space:];&|]|\()'
 filter_out=
 
-gitgrep "${cmdstart}awk\b.*-F([[:space:]]|[[:space:]]*[\"'][^\"']{2,})" \
-    'awk with -F char or -F ERE, use -Fchar instead (Solaris)'
+# Note: Since we started to use _comp_awk, we do not have care about the small
+# feature set of Solaris awk anymore.
 
 gitgrep "${cmdstart}(_comp_)?awk\b.*\[:[a-z]*:\]" \
     'awk with POSIX character class not supported in mawk-1.3.3-20090705 (Debian/Ubuntu)'

--- a/test/runLint
+++ b/test/runLint
@@ -6,47 +6,50 @@ gitgrep()
     local out=$(git grep -I -P -n "$1" |
         grep -E '^(bash_completion|completions/|test/)' |
         grep -Ev "^test/runLint\>${filter_out:+|$filter_out}")
-    if [ "$out" ]; then
+    if [[ $out ]]; then
         printf '***** %s\n' "$2"
         printf '%s\n\n' "$out"
     fi
 }
 
 unset -v CDPATH
-cd $(dirname "$0")/..
+if ! cd "$(dirname "$0")/.."; then
+    echo 'test/runLint: failed to cd into the working tree of bash-completion' >&2
+    exit 1
+fi
 
 cmdstart='(^|[[:space:];&|]|\()'
 filter_out=
 
-gitgrep $cmdstart"awk\b.*-F([[:space:]]|[[:space:]]*[\"'][^\"']{2,})" \
+gitgrep "${cmdstart}awk\b.*-F([[:space:]]|[[:space:]]*[\"'][^\"']{2,})" \
     'awk with -F char or -F ERE, use -Fchar instead (Solaris)'
 
-gitgrep $cmdstart"(_comp_)?awk\b.*\[:[a-z]*:\]" \
+gitgrep "${cmdstart}(_comp_)?awk\b.*\[:[a-z]*:\]" \
     'awk with POSIX character class not supported in mawk-1.3.3-20090705 (Debian/Ubuntu)'
 
-gitgrep $cmdstart'sed\b.*\\[?+]' \
+gitgrep "$cmdstart"'sed\b.*\\[?+]' \
     'sed with ? or +, use POSIX BRE instead (\{m,n\})'
 
-gitgrep $cmdstart'sed\b.*\\\|' \
+gitgrep "$cmdstart"'sed\b.*\\\|' \
     "sed with \|, use POSIX BRE (possibly multiple sed invocations) or another tool instead"
 
 # TODO: really nonportable? appears to work fine in Linux, FreeBSD, Solaris
 #gitgrep $cmdstart'sed\b.*;' \
 #    'sed with ;, use multiple -e options instead (POSIX?) (false positives?)'
 
-gitgrep $cmdstart'sed\b.*[[:space:]]-[^[:space:]]*[rE]' \
+gitgrep "$cmdstart"'sed\b.*[[:space:]]-[^[:space:]]*[rE]' \
     'sed with -r or -E, drop and use POSIX BRE instead'
 
-gitgrep $cmdstart'[ef]grep\b' \
+gitgrep "$cmdstart"'[ef]grep\b' \
     '[ef]grep, use grep -[EF] instead (historical/deprecated)'
 
 # TODO: $ in sed subexpression used as an anchor (POSIX BRE optional, not in
 #       Solaris/FreeBSD)
 
-gitgrep '(?<!command)'$cmdstart'(grep|ls|sed|cd)(\s|$)' \
+gitgrep '(?<!command)'"$cmdstart"'(grep|ls|sed|cd)(\s|$)' \
     'invoke grep, ls, sed, and cd through "command", e.g. "command grep"'
 
-gitgrep '(?<!command)'$cmdstart'awk(\s|$)' \
+gitgrep '(?<!command)'"$cmdstart"'awk(\s|$)' \
     'invoke awk through "_comp_awk"'
 
 gitgrep '<<<' 'herestrings use temp files, use some other way'
@@ -54,7 +57,7 @@ gitgrep '<<<' 'herestrings use temp files, use some other way'
 filter_out='^(test/|bash_completion\.sh)' gitgrep ' \[ ' \
     'use [[ ]] instead of [ ]'
 
-gitgrep $cmdstart'unset [^-]' 'Explicitly specify "unset -v/-f"'
+gitgrep "$cmdstart"'unset [^-]' 'Explicitly specify "unset -v/-f"'
 
-gitgrep $cmdstart'((set|shopt)\s+[+-][a-z]+\s+posix\b|(local\s+)?POSIXLY_CORRECT\b)' \
+gitgrep "$cmdstart"'((set|shopt)\s+[+-][a-z]+\s+posix\b|(local\s+)?POSIXLY_CORRECT\b)' \
     'fiddling with posix mode breaks keybindings with some bash versions'

--- a/test/runLint
+++ b/test/runLint
@@ -22,7 +22,7 @@ gitgrep $cmdstart"awk\b.*-F([[:space:]]|[[:space:]]*[\"'][^\"']{2,})" \
     'awk with -F char or -F ERE, use -Fchar instead (Solaris)'
 
 gitgrep $cmdstart"(_comp_)?awk\b.*\[:[a-z]*:\]" \
-    'awk with POSIX character class not supported in mawk (Debian/Ubuntu)'
+    'awk with POSIX character class not supported in mawk-1.3.3-20090705 (Debian/Ubuntu)'
 
 gitgrep $cmdstart'sed\b.*\\[?+]' \
     'sed with ? or +, use POSIX BRE instead (\{m,n\})'

--- a/test/update-test-cmd-list
+++ b/test/update-test-cmd-list
@@ -9,6 +9,6 @@ mydir=$(
 cat "$mydir"/t/test_*.py |
     tr -d '\n' |
     grep -Eo '@pytest.mark.complete\(([^)]*\<require_(cmd|longopt) *= *True\>[^)]*)\)' |
-    sed -ne 's/^[^"]*"\\\?\([^_][^[:space:]"]*\)[[:space:]"].*/\1/p' |
+    sed -ne 's/^[^"]*"\\\{0,1\}\([^_][^[:space:]"]*\)[[:space:]"].*/\1/p' |
     LC_ALL=C sort -u \
         >"$mydir"/test-cmd-list.txt


### PR DESCRIPTION
As discussed in https://github.com/scop/bash-completion/pull/1069#discussion_r1402672706.

In this PR, I change `awk` to `command awk` where Solaris awk works (65ea69942).

However, another possibility is that we entirely switch to `_comp_awk` so that we do not have to care about the feature set of Solaris awk. If you like this direction, I can adjust the PR.

There are additional changes:

- There are a few cases of directly calling `sed` without prefixing `command`, which were recently added.  I also fix these `sed` cases in this PR (2e382861c).
- In addition, there are several compatibility issues related to the implementations of `awk` (b207dfc38, 7b975fce9, a1c5c30dc) and `sed` (0d798df58, 17e6d83d8, 7bea087aa).
- I also apply `shfmt` and `shellcheck` to `test/runLint` similarly to #1071 for `test/fallback/update-fallback-links` (bae5ee80a).
