### PR TITLE
add y4m and heic/heif/avif extensions to feh

### DIFF
--- a/completions/feh
+++ b/completions/feh
@@ -111,7 +111,7 @@ _comp_cmd_feh()
 
     # FIXME: It is hard to determine correct supported extensions.
     # feh can handle any format that imagemagick can plus some others
-    _comp_compgen_filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp'
+    _comp_compgen_filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp|y4m|avc[is]|hei[cf]?(s)|avif?(s)'
 } &&
     complete -F _comp_cmd_feh feh
 


### PR DESCRIPTION
* y4m supported in imlib2 since [1]
* heif Supported in feh through imlib2 since [2]

[1] https://git.enlightenment.org/old/legacy-imlib2/commit/be721b0335845f4d127f6c9041aa98a1d5e7ee22
[2] https://git.enlightenment.org/old/legacy-imlib2/commit/4b4f72c7ffd476df6e450d84f7acb078808cb931