### PR TITLE
feat(feh): deassociate with avci/avcs

### DIFF
--- a/completions/feh
+++ b/completions/feh
@@ -111,7 +111,7 @@ _comp_cmd_feh()
 
     # FIXME: It is hard to determine correct supported extensions.
     # feh can handle any format that imagemagick can plus some others
-    _comp_compgen_filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp|y4m|avc[is]|hei[cf]?(s)|avif?(s)'
+    _comp_compgen_filedir 'xpm|tif?(f)|png|p[npgba]m|iff|?(i)lbm|jp?(e)g|jfi?(f)|gif|bmp|arg?(b)|tga|xcf|ani|ico|?(e)ps|pdf|dvi|txt|svg?(z)|cdr|[ot]tf|ff?(.gz|.bz2)|webp|y4m|hei[cf]?(s)|avif?(s)'
 } &&
     complete -F _comp_cmd_feh feh
 


### PR DESCRIPTION
feh supports several HEIF sub-types through imlib2, which gets the support from libheif. The latter does not support avci/avcs yet.