### PR TITLE
fix(ri): fix several problems and use `_comp_split`

### DIFF
--- a/completions/ri
+++ b/completions/ri
@@ -29,7 +29,7 @@ _comp_cmd_ri__methods()
             end' | sort -u)"
     fi
     ((${#COMPREPLY[@]})) &&
-        _comp_compgen -c "$method" -- "$prefix" -W '"${COMPREPLY[@]}"'
+        _comp_compgen -c "$method" -- -P "$prefix" -W '"${COMPREPLY[@]}"'
 }
 
 # needs at least Ruby 1.8.0 in order to use -W0
@@ -85,7 +85,7 @@ _comp_cmd_ri()
         class=${cur%"$separator"*}
         method=${cur#*"$separator"}
         classes=($class)
-        prefix="-P $class$separator"
+        prefix=$class$separator
         _comp_cmd_ri__methods
         return
     fi

--- a/completions/ri
+++ b/completions/ri
@@ -66,7 +66,7 @@ _comp_cmd_ri()
         return
     fi
 
-    local class method prefix ri_path ri_version ri_major separator IFS
+    local class method prefix="" ri_path ri_version ri_major="" separator IFS
     local -a classes
 
     ri_path=$(type -p ri)

--- a/completions/ri
+++ b/completions/ri
@@ -1,36 +1,39 @@
 # ri completion for Ruby documentation                     -*- shell-script -*-
 # by Ian Macdonald <ian@caliban.org>
 
-_comp_cmd_ri__methods()
+# @var[in] ri_version
+# @var[in] prefix
+# @var[in] classes
+_comp_cmd_ri__compgen_methods()
 {
-    local regex
+    local _regex
     local IFS=$' \t\n' # needed for ${classes[@]+"${classes[@]}"} in bash-5.2
 
+    local _methods
     if [[ $ri_version == integrated ]]; then
         if [[ ! $separator ]]; then
-            regex="(Instance|Class)"
+            _regex="(Instance|Class)"
         elif [[ $separator == "#" ]]; then
-            regex=Instance
+            _regex=Instance
         else
-            regex=Class
+            _regex=Class
         fi
 
-        _comp_split -la COMPREPLY \
+        _comp_split -la _methods \
             "$(ri ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
-                'if /^'"$regex"' methods:/.../^------------------|^$/ and \
+                'if /^'"$_regex"' methods:/.../^------------------|^$/ and \
             /^ / then print $_.split(/, |,$/).grep(/^[^\[]*$/).join("\n"); \
             end' 2>/dev/null | sort -u)"
     else
         # older versions of ri didn't distinguish between class/module and
         # instance methods
-        _comp_split -la COMPREPLY \
+        _comp_split -la _methods \
             "$(ruby -W0 "$ri_path" ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
                 'if /^-/.../^-/ and ! /^-/ and ! /^ +(class|module): / then \
             print $_.split(/, |,$| +/).grep(/^[^\[]*$/).join("\n"); \
             end' | sort -u)"
-    fi
-    ((${#COMPREPLY[@]})) &&
-        _comp_compgen -c "$method" -- -P "$prefix" -W '"${COMPREPLY[@]}"'
+    fi &&
+        _comp_compgen -- -P "$prefix" -W '"${_methods[@]}"'
 }
 
 # needs at least Ruby 1.8.0 in order to use -W0
@@ -87,7 +90,7 @@ _comp_cmd_ri()
         method=${cur#*"$separator"}
         classes=($class)
         prefix=$class$separator
-        _comp_cmd_ri__methods
+        _comp_compgen -c "$method" -i ri methods
         return
     fi
 
@@ -117,8 +120,7 @@ _comp_cmd_ri()
     fi
 
     # we're completing on methods
-    method=$cur
-    _comp_cmd_ri__methods
+    _comp_cmd_ri__compgen_methods
 } &&
     complete -F _comp_cmd_ri ri
 

--- a/completions/ri
+++ b/completions/ri
@@ -14,19 +14,19 @@ _comp_cmd_ri__methods()
             regex=Class
         fi
 
-        COMPREPLY+=(
+        _comp_split -la COMPREPLY \
             "$(ri ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
                 'if /^'"$regex"' methods:/.../^------------------|^$/ and \
             /^ / then print $_.split(/, |,$/).grep(/^[^\[]*$/).join("\n"); \
-            end' 2>/dev/null | sort -u)")
+            end' 2>/dev/null | sort -u)"
     else
         # older versions of ri didn't distinguish between class/module and
         # instance methods
-        COMPREPLY+=(
+        _comp_split -la COMPREPLY \
             "$(ruby -W0 "$ri_path" ${classes[@]+"${classes[@]}"} 2>/dev/null | ruby -ane \
                 'if /^-/.../^-/ and ! /^-/ and ! /^ +(class|module): / then \
             print $_.split(/, |,$| +/).grep(/^[^\[]*$/).join("\n"); \
-            end' | sort -u)")
+            end' | sort -u)"
     fi
     ((${#COMPREPLY[@]})) &&
         _comp_compgen -c "$method" -- "$prefix" -W '"${COMPREPLY[@]}"'

--- a/completions/ri
+++ b/completions/ri
@@ -3,7 +3,8 @@
 
 _comp_cmd_ri__methods()
 {
-    local regex IFS=$' \t\n'
+    local regex
+    local IFS=$' \t\n' # needed for ${classes[@]+"${classes[@]}"} in bash-5.2
 
     if [[ $ri_version == integrated ]]; then
         if [[ ! $separator ]]; then

--- a/completions/ri
+++ b/completions/ri
@@ -70,7 +70,7 @@ _comp_cmd_ri()
         return
     fi
 
-    local class method prefix="" ri_path ri_version ri_major="" separator IFS
+    local class method prefix="" ri_path ri_version ri_major="" separator
     local -a classes
 
     ri_path=$(type -p ri)
@@ -82,13 +82,12 @@ _comp_cmd_ri()
     [[ $ri_version =~ ri[[:space:]]v?([0-9]+) ]] && ri_major=${BASH_REMATCH[1]}
 
     # need to also split on commas
-    IFS=$', \n\t'
     if [[ $cur == [A-Z]*[#.]* ]]; then
         [[ $cur == *#* ]] && separator=# || separator=.
         # we're completing on class and method
         class=${cur%"$separator"*}
         method=${cur#*"$separator"}
-        classes=($class)
+        _comp_split -F $', \n\t' classes "$class"
         prefix=$class$separator
         _comp_compgen -c "$method" -i ri methods
         return
@@ -96,21 +95,20 @@ _comp_cmd_ri()
 
     if [[ $ri_version == integrated ]]; then
         # integrated ri from Ruby 1.9
-        classes=($(ri -c 2>/dev/null | ruby -ne 'if /^\s*$/..$stdin.eof then \
-        if /^ +[A-Z]/ then print; end; end' 2>/dev/null))
+        _comp_split -F $', \n\t' classes \
+            "$(ri -c 2>/dev/null | ruby -ne 'if /^\s*$/..$stdin.eof then \
+            if /^ +[A-Z]/ then print; end; end' 2>/dev/null)"
     elif [[ $ri_major && $ri_major -ge 3 ]]; then
-        classes=($(ri -l 2>/dev/null))
+        _comp_split -F $', \n\t' classes "$(ri -l 2>/dev/null)"
     elif [[ $ri_version == "ri 1.8a" ]]; then
-        classes=($(ruby -W0 "$ri_path" |
+        _comp_split -F $', \n\t' classes "$(ruby -W0 "$ri_path" |
             ruby -ne 'if /^'"'"'ri'"'"' has/..$stdin.eof then \
-            if /^ .*[A-Z]/ then print; end; end'))
+            if /^ .*[A-Z]/ then print; end; end')"
     else
-        classes=($(ruby -W0 "$ri_path" |
+        _comp_split -F $', \n\t' classes "$(ruby -W0 "$ri_path" |
             ruby -ne 'if /^I have/..$stdin.eof then \
-                if /^ .*[A-Z]/ then print; end; end'))
-    fi
-
-    ((${#classes[@]})) &&
+                if /^ .*[A-Z]/ then print; end; end')"
+    fi &&
         _comp_compgen -- -W '"${classes[@]}"'
     _comp_ltrim_colon_completions "$cur"
 


### PR DESCRIPTION
I'm now trying to apply `_comp_split` in `completions/*`, but I decided to submit the changes on `completions/ri` in a separate PR since this file `ri` has many fixes. See the commit message of each commit for the details.

In particular, commit 8c4510d4dfb1ac9897fe066b3eee31f2ec29537f needs double-checking from others. The existing code looks like `COMPREPLY+=("$(... | sort -u)")` where the entire result of the command substitution is quoted, but I suspected that the quoting is unneeded because the result should be separated. However, the quoting seems to have existed from the beginning.