### PR TITLE
test: make the pytest option testcase require cmd

### DIFF
--- a/test/t/test_pytest.py
+++ b/test/t/test_pytest.py
@@ -8,7 +8,7 @@ class TestPytest:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("pytest -")
+    @pytest.mark.complete("pytest -", require_cmd=True)
     def test_2(self, completion):
         assert completion
 

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -303,6 +303,7 @@ pyflakes
 pylint
 pylint-3
 pyston
+pytest
 python
 python3
 qemu


### PR DESCRIPTION
It fails if the command doesn't exist, since the options are parsed from the command invocation.