### PR TITLE
fix(gdb): fix regression that fails to generate command names

### DIFF
--- a/completions/gdb
+++ b/completions/gdb
@@ -26,7 +26,7 @@ _comp_cmd_gdb()
             # functions and aliases. Thus we need to retrieve the program
             # names manually.
             local path_array
-            _comp_compgen -Rv path_array split -X '' -- "$PATH"
+            _comp_compgen -Rv path_array split -F : -X '' -- "$PATH"
             _comp_compgen_split -o plusdirs -- "$(
                 find ${path_array[@]+"${path_array[@]}"} . -mindepth 1 \
                     -maxdepth 1 -not -type d -executable -printf '%f\n' \

--- a/test/t/test_gdb.py
+++ b/test/t/test_gdb.py
@@ -12,3 +12,13 @@ class TestGdb:
             "core core.12345 "
             "core.weston.1000.deadbeef.5308.1555362132000000".split()
         )
+
+    @pytest.mark.complete("gdb aw")
+    def test_3(self, completion):
+        """Check that the completion can generate command names"""
+        assert completion == ["k"] or "awk" in completion
+
+    @pytest.mark.complete("gdb built")
+    def test_4(self, completion):
+        """Check that the completion does not generate builtin names"""
+        assert not (completion == ["in"] or "builtin" in completion)


### PR DESCRIPTION
The current version fails to generate any command names for the first word after the command name "gdb".  This is a regression introduced in https://github.com/scop/bash-completion/pull/1086 and pointed out in the comment: https://github.com/scop/bash-completion/commit/73c5292b7a39a2f3d1ae01057e0afd3aa24c8a32#r138406647.