### PR TITLE
fix(gdb): use POSIX-compatible find expression

### DIFF
--- a/completions/gdb
+++ b/completions/gdb
@@ -31,7 +31,7 @@ _comp_cmd_gdb()
                 IFS=$' \t\n'
                 find ${path_array[@]+"${path_array[@]}"} . -name . -o \
                     -type d -prune -o -perm -u+x -print 2>/dev/null |
-                    command sed 's|^.*/||'
+                    command sed 's|^.*/||' | sort -u
             )"
         fi
     elif ((cword == 2)); then

--- a/completions/gdb
+++ b/completions/gdb
@@ -15,7 +15,6 @@ _comp_cmd_gdb()
 
     # gdb [options] [executable-file [core-file or process-id]]
     if ((cword == 1)); then
-        local IFS
         compopt -o filenames
         if _comp_looks_like_path "$cur"; then
             # compgen -c works as expected if $cur contains any slashes.
@@ -28,6 +27,8 @@ _comp_cmd_gdb()
             local path_array
             _comp_compgen -Rv path_array split -F : -X '' -- "$PATH"
             _comp_compgen_split -o plusdirs -- "$(
+                # Note: ${v+"$@"} does not work with empty IFS in bash < 4.4
+                IFS=$' \t\n'
                 find ${path_array[@]+"${path_array[@]}"} . -mindepth 1 \
                     -maxdepth 1 -not -type d -executable -printf '%f\n' \
                     2>/dev/null

--- a/completions/gdb
+++ b/completions/gdb
@@ -25,13 +25,13 @@ _comp_cmd_gdb()
             # functions and aliases. Thus we need to retrieve the program
             # names manually.
             local path_array
-            _comp_compgen -Rv path_array split -F : -X '' -- "$PATH"
+            _comp_compgen -Rv path_array split -F : -X '' -S /. -- "$PATH"
             _comp_compgen_split -o plusdirs -- "$(
                 # Note: ${v+"$@"} does not work with empty IFS in bash < 4.4
                 IFS=$' \t\n'
-                find ${path_array[@]+"${path_array[@]}"} . -mindepth 1 \
-                    -maxdepth 1 -not -type d -executable -printf '%f\n' \
-                    2>/dev/null
+                find ${path_array[@]+"${path_array[@]}"} . -name . -o \
+                    -type d -prune -o -perm -u+x -print 2>/dev/null |
+                    command sed 's|^.*/||'
             )"
         fi
     elif ((cword == 2)); then


### PR DESCRIPTION
This fixes the issue reported in https://github.com/scop/bash-completion/pull/1101#issuecomment-1933865055. There are additional fixes 41236da411794133d08792df28207e2a77271c57 and 532fc05a73b415369ce1987463d82d791ee72dc0.