### PR TITLE
test(debian10): work around openjdk/ca-certificates-java install issue

### DIFF
--- a/test/docker/debian10/install-packages.sh
+++ b/test/docker/debian10/install-packages.sh
@@ -53,6 +53,10 @@ EOF
 echo "resolvconf resolvconf/linkify-resolvconf boolean false" |
     debconf-set-selections
 
+# Work around https://bugs.debian.org/1040925
+apt-get -y --no-install-recommends install \
+    ca-certificates-java
+
 while read -r file; do
     case $file in
         /*) printf "%s\n" "$file" ;;


### PR DESCRIPTION
https://bugs.debian.org/1040925