### PR TITLE
test: fix test failures

### DIFF
--- a/completions/xfreerdp
+++ b/completions/xfreerdp
@@ -30,8 +30,12 @@ _comp_cmd_xfreerdp()
 
     case $cur in
         /kbd:*)
-            _comp_compgen -c "${cur#/kbd:}" split -- "$("$1" /kbd-list |
-                _comp_awk '/^0x/ { print $1 }')"
+            local kbd_list
+            kbd_list=$("$1" /kbd-list 2>/dev/null) ||
+                kbd_list=$("$1" /list:kbd 2>/dev/null)
+            _comp_compgen -c "${cur#/kbd:}" split -- "$(
+                _comp_awk '/^0x/ { print $1 }' <<<"$kbd_list"
+            )"
             return
             ;;
         /bpp:*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.ruff]
 line-length = 79
 target-version = "py37"
-select = ["E", "F", "B"]
-ignore = [
+lint.select = ["E", "F", "B"]
+lint.ignore = [
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     # (keep order of ignores here same as ^there for maintainability)
     "W191",
@@ -23,6 +23,6 @@ ignore = [
 ]
 fix = true
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["conftest"]
 known-third-party = ["pexpect", "pytest"]

--- a/test/t/test_who.py
+++ b/test/t/test_who.py
@@ -2,8 +2,6 @@ import pytest
 
 
 class TestWho:
-    @pytest.mark.complete(
-        "who --", require_cmd=True, xfail="! who --help &>/dev/null"
-    )
+    @pytest.mark.complete("who --", require_longopt=True)
     def test_1(self, completion):
         assert completion


### PR DESCRIPTION
The CI test for the `who` command started to fail in the `alpine` container around #1101. However, the changes in #1101 do not seem to be related to the completion of the `who` command. I investigated it and found that the `who` command in the `alpine` container seems to have been replaced by the BusyBox `who` at some point. The detail of the test failure is explained in the commit message. The output of `who --help` in the `alpine` container looks like

```
BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.

Usage: who [-aH]

Show who is logged on

-a	Show all
-H	Print column headers
```

I also include another commit in this PR to fix the pre-commit error from `ruff-format`, which prevented creating any commits related to tests.
