### PR TITLE
fix(ip): Remove non-existent route completion

### DIFF
--- a/completions/ip
+++ b/completions/ip
@@ -207,7 +207,7 @@ _comp_cmd_ip()
                 get)
                     # TODO
                     ;;
-                a | add | d | del | change | append | r | replace | monitor)
+                a | add | d | del | change | append | r | replace)
                     if [[ $prev == via ]]; then
                         _comp_compgen_split -- "$(
                             {
@@ -232,7 +232,7 @@ _comp_cmd_ip()
                 *)
                     ((cword == subcword)) &&
                         _comp_compgen -- -W 'help list flush get add del change
-                            append replace monitor'
+                            append replace'
                     ;;
             esac
             ;;


### PR DESCRIPTION
The ip route usage used to mention monitor as a subcommand, but this was removed in https://github.com/iproute2/iproute2/commit/c0c44bfedda05e52572cc16c9d7777e1077d86cf

Remove it from the completions