### PR TITLE
test(perldoc): Test if real perldoc command exists

### DIFF
--- a/test/t/test_perldoc.py
+++ b/test/t/test_perldoc.py
@@ -9,7 +9,11 @@ class TestPerldoc:
         assert "fixtures/" not in completion  # Our fixtures/ dir
         assert not [x for x in completion if "File::File::" in x]
 
-    @pytest.mark.complete("perldoc -", require_cmd=True)
+    @pytest.mark.complete(
+        "perldoc -",
+        require_cmd=True,
+        skipif="! perldoc -V &>/dev/null",
+    )
     def test_2(self, completion):
         assert completion
 


### PR DESCRIPTION
On some systems the perldoc command exists, but only as a stub that prompts to install the "real" perl-doc pacakge. Skip the test that requires the command if only the stub exists (exits with exit code 1).