### PR TITLE
fix(cryptsetup): add file completions to header option

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -763,10 +763,11 @@ _comp_compgen_split()
     local -a _compgen_options=()
 
     local OPTIND=1 OPTARG="" OPTERR=0 _opt
-    while getopts ':lF:X:S:P:o:' _opt "$@"; do
+    while getopts ':lF:c:X:S:P:o:' _opt "$@"; do
         case $_opt in
             l) _ifs=$'\n' ;;
             F) _ifs=$OPTARG ;;
+            c) _cur=$OPTARG ;;
             [XSPo]) _compgen_options+=("-$_opt" "$OPTARG") ;;
             *)
                 printf 'bash_completion: usage: %s [-l|-F sep] [--] str\n' "$FUNCNAME" >&2
@@ -782,7 +783,7 @@ _comp_compgen_split()
     fi
 
     local input=$1 IFS=$' \t\n'
-    _comp_compgen -F "$_ifs" -U input -- ${_compgen_options[@]+"${_compgen_options[@]}"} -W '$input'
+    _comp_compgen -F "$_ifs" ${_cur:+-c "$_cur"} -U input -- ${_compgen_options[@]+"${_compgen_options[@]}"} -W '$input'
 }
 
 # Check if the argument looks like a path.

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -22,7 +22,7 @@ _comp_cmd_cryptsetup()
             --skip | --iter-time | --timeout | --tries | -${noargopts}[chslSbopitT])
             return
             ;;
-        --key-file | --master-key-file | --header-backup-file | -${noargopts}d)
+        --key-file | --master-key-file | --header | --header-backup-file | -${noargopts}d)
             _comp_compgen_filedir
             return
             ;;

--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -5,11 +5,6 @@ _comp_cmd_cryptsetup__name()
     _comp_compgen_split -X control -- "$(command ls /dev/mapper)"
 }
 
-_comp_cmd_cryptsetup__device()
-{
-    _comp_compgen -c "${cur:-/dev/}" filedir
-}
-
 _comp_cmd_cryptsetup()
 {
     local cur prev words cword was_split comp_args
@@ -23,6 +18,7 @@ _comp_cmd_cryptsetup()
             return
             ;;
         --key-file | --master-key-file | --header | --header-backup-file | -${noargopts}d)
+
             _comp_compgen_filedir
             return
             ;;
@@ -34,67 +30,25 @@ _comp_cmd_cryptsetup()
 
     [[ $was_split ]] && return
 
-    local REPLY
-    if _comp_get_first_arg; then
-        local arg=$REPLY
-        _comp_count_args -a "-${noargopts}[chslSbopitTdM]"
-        local args=$REPLY
-        case $arg in
-            open | create | luksOpen | loopaesOpen | tcryptOpen)
-                case $args in
-                    2)
-                        _comp_cmd_cryptsetup__device
-                        ;;
-                    3)
-                        _comp_cmd_cryptsetup__name
-                        ;;
-                esac
-                ;;
-            close | remove | luksClose | loopaesClose | tcryptClose | status | resize | \
-                luksSuspend | luksResume)
-                case $args in
-                    2)
-                        _comp_cmd_cryptsetup__name
-                        ;;
-                esac
-                ;;
-            luksFormat | luksAddKey | luksRemoveKey | luksChangeKey)
-                case $args in
-                    2)
-                        _comp_cmd_cryptsetup__device
-                        ;;
-                    3)
-                        _comp_compgen_filedir
-                        ;;
-                esac
-                ;;
-            luksKillSlot | luksDelKey | luksUUID | isLuks | luksDump)
-                case $args in
-                    2)
-                        _comp_cmd_cryptsetup__device
-                        ;;
-                esac
-                ;;
-            luksHeaderBackup | luksHeaderRestore)
-                case $args in
-                    2)
-                        _comp_cmd_cryptsetup__device
-                        ;;
-                    3)
-                        COMPREPLY=('--header-backup-file')
-                        ;;
-                esac
-                ;;
-        esac
+    local arg
+    _get_first_arg
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen_help
+        [[ ${COMPREPLY- } == *= ]] && compopt -o nospace
+        return
+    fi
+
+    if [[ ! $arg ]]; then
+        _comp_compgen -- -W 'open close resize status benchmark repair
+            erase luksFormat luksAddKey luksRemoveKey luksChangeKey
+            luksKillSlot luksUUID isLuks luksDump tcryptDump luksSuspend
+            luksResume luksHeaderBackup luksHeaderRestore'
     else
-        if [[ $cur == -* ]]; then
-            _comp_compgen_help
-            [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+        if [[ $arg == +(*[cC]lose|remove|status|resize|luksSuspend|luksResume) ]]; then
+            _comp_cmd_cryptsetup__name
         else
-            _comp_compgen -- -W 'open close resize status benchmark repair
-                erase luksFormat luksAddKey luksRemoveKey luksChangeKey
-                luksKillSlot luksUUID isLuks luksDump tcryptDump luksSuspend
-                luksResume luksHeaderBackup luksHeaderRestore'
+            _comp_compgen_filedir
         fi
     fi
 

--- a/completions/ssh
+++ b/completions/ssh
@@ -474,9 +474,7 @@ _comp_xfunc_scp_compgen_remote_files()
     local _userhost=${cur%%?(\\):*}
     local _path=${cur#*:}
 
-    # unescape (3 backslashes to 1 for chars we escaped)
-    # shellcheck disable=SC2090
-    _path=$(command sed -e 's/\\\\\\\('"$_comp_cmd_scp__path_esc"'\)/\\\1/g' <<<"$_path")
+    _cur=$(command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\&/g' <<<"$_path")
 
     # default to home dir of specified user on remote host
     if [[ ! $_path ]]; then
@@ -489,17 +487,17 @@ _comp_xfunc_scp_compgen_remote_files()
         # shellcheck disable=SC2090
         _files=$(ssh -o 'Batchmode yes' "$_userhost" \
             command ls -aF1dL "$_path*" 2>/dev/null |
-            command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\\\\\&/g' -e '/[^\/]$/d')
+            command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\&/g' -e '/[^\/]$/d')
     else
         # escape problematic characters; remove executables, aliases, pipes
         # and sockets; add space at end of file names
         # shellcheck disable=SC2090
         _files=$(ssh -o 'Batchmode yes' "$_userhost" \
             command ls -aF1dL "$_path*" 2>/dev/null |
-            command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\\\\\&/g' -e 's/[*@|=]$//g' \
+            command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\&/g' -e 's/[*@|=]$//g' \
                 -e 's/[^\/]$/& /g')
     fi
-    _comp_compgen_split -l -- "$_files"
+    _comp_compgen_split -l ${_cur:+-c "$_cur"} -- "$_files"
 }
 
 # @deprecated 2.12 use `_comp_compgen -ax ssh remote_files` instead


### PR DESCRIPTION
An encrypted device's header should be stored in a file so this change adds file completions to cryptsetup's --header option.