### PR TITLE
fix(cryptsetup): add file completions to header option

### DIFF
--- a/completions/cryptsetup
+++ b/completions/cryptsetup
@@ -22,7 +22,7 @@ _comp_cmd_cryptsetup()
             --skip | --iter-time | --timeout | --tries | -${noargopts}[chslSbopitT])
             return
             ;;
-        --key-file | --master-key-file | --header-backup-file | -${noargopts}d)
+        --key-file | --master-key-file | --header | --header-backup-file | -${noargopts}d)
             _comp_compgen_filedir
             return
             ;;


### PR DESCRIPTION
An encrypted device's header should be stored in a file. This change enables filename completion for cryptsetup's --header option.