### PR TITLE
ci(lint): add shell linter - Differential ShellCheck GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,24 @@ jobs:
           source venv/bin/activate
           pre-commit run --color=always --all-files --show-diff-on-failure
 
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   distcheck:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
I see that you are using shellcheck in pre-commit, but I think you might find this useful or interesting.

Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on shell scripts changed via PR and reports results directly in PR.

Your script is in great shape, but  I think that you might find the `differential-shellcheck` action useful. It is able to produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, please see below.

![image](https://github.com/debezium/debezium/assets/2879818/e0f16691-907f-486d-a20e-4b569322e860)

![image](https://github.com/debezium/debezium/assets/2879818/cc842adf-04b6-425c-ae7d-c39b8dffa09b)

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or option. I'm always happy to extend functionality.