### PR TITLE
fix(available_interfaces): fix regression of unwanted trailing colons

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1737,7 +1737,7 @@ _comp_compgen_available_interfaces()
         fi
     } 2>/dev/null | _comp_awk \
         '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }')" &&
-        _comp_compgen -U generated set "${generated[@]}"
+        _comp_compgen -U generated set "${generated[@]%%[[:punct:]]*}"
 }
 
 # Echo number of CPUs, falling back to 1 on failure.

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -2,6 +2,7 @@ EXTRA_DIST = \
 	test_unit_abspath.py \
 	test_unit_command_offset.py \
 	test_unit_compgen.py \
+	test_unit_compgen_available_interfaces.py \
 	test_unit_compgen_commands.py \
 	test_unit_count_args.py \
 	test_unit_delimited.py \

--- a/test/t/unit/test_unit_compgen_available_interfaces.py
+++ b/test/t/unit/test_unit_compgen_available_interfaces.py
@@ -1,0 +1,25 @@
+import pytest
+
+from conftest import assert_bash_exec
+
+
+@pytest.mark.bashcomp(cmd=None)
+class TestUtilCompgenAvailableInterfaces:
+    @pytest.fixture
+    def functions(self, bash):
+        assert_bash_exec(
+            bash,
+            "_comp__test_dump() { ((${#arr[@]})) && printf '<%s>' \"${arr[@]}\"; echo; }",
+        )
+        assert_bash_exec(
+            bash,
+            '_comp__test_compgen() { local -a arr=(00); _comp_compgen -v arr "$@"; _comp__test_dump; }',
+        )
+
+    def test_1_trailing_colons(self, bash, functions):
+        output = assert_bash_exec(
+            bash,
+            "_comp__test_compgen available_interfaces",
+            want_output=True,
+        )
+        assert ":" not in output.strip()


### PR DESCRIPTION
Fixes #1129

~~I noticed some files are not added in `test/t/unit/Makefile.am`. I added them in the second commit.~~ (**edit**: moved to #1132)