### PR TITLE
test: add missing files in `test/t/unit/Makefile.am`

### DIFF
--- a/test/fixtures/_comp_load/bin/cmd1
+++ b/test/fixtures/_comp_load/bin/cmd1
@@ -1,1 +1,0 @@
-../prefix1/bin/cmd1

--- a/test/fixtures/_comp_load/bin/cmd2
+++ b/test/fixtures/_comp_load/bin/cmd2
@@ -1,1 +1,0 @@
-../prefix1/sbin/cmd2

--- a/test/t/unit/Makefile.am
+++ b/test/t/unit/Makefile.am
@@ -3,6 +3,7 @@ EXTRA_DIST = \
 	test_unit_command_offset.py \
 	test_unit_compgen.py \
 	test_unit_compgen_commands.py \
+	test_unit_compgen_split.py \
 	test_unit_count_args.py \
 	test_unit_delimited.py \
 	test_unit_deprecate_func.py \
@@ -18,6 +19,7 @@ EXTRA_DIST = \
 	test_unit_initialize.py \
 	test_unit_ip_addresses.py \
 	test_unit_known_hosts.py \
+	test_unit_load.py \
 	test_unit_longopt.py \
 	test_unit_looks_like_path.py \
 	test_unit_parse_help.py \

--- a/test/t/unit/test_unit_load.py
+++ b/test/t/unit/test_unit_load.py
@@ -4,7 +4,7 @@ from conftest import assert_bash_exec, bash_env_saved
 
 
 @pytest.mark.bashcomp(cmd=None, cwd="_comp_load")
-class TestLoadCompletion:
+class TestCompLoad:
     def test_userdir_1(self, bash):
         with bash_env_saved(bash) as bash_env:
             bash_env.write_variable(

--- a/test/t/unit/test_unit_load.py
+++ b/test/t/unit/test_unit_load.py
@@ -1,12 +1,42 @@
 import pytest
+import os
 
-from conftest import assert_bash_exec, bash_env_saved
+from conftest import assert_bash_exec, bash_env_saved, prepare_fixture_dir
 
 
 @pytest.mark.bashcomp(cmd=None, cwd="_comp_load")
 class TestCompLoad:
-    def test_userdir_1(self, bash):
+    @pytest.fixture
+    def fixture_dir(self, request, bash):
+        """Construct the fixture directory in a temporary directory.
+
+        Some of the tests use specific setups of symbolic links.  However, if
+        we put the symbolic links in the static fixture directory, Automake
+        resolves them for tarballs.  As a result, the tests fail when the files
+        are extracted from the tarballs.  There does not seem to be any option
+        to change the behavior of Automake.
+
+        We instead manually set up all symbolic links needed for the tests
+        here.  The other normal files and directories are statically included
+        in the repository as "/test/fixtures/_comp_load".  We first copy the
+        statically included files and directories to a temporary directory and
+        set up symbolic links.
+        """
+
+        tmpdir, _, _ = prepare_fixture_dir(request, files=[], dirs=[])
+        assert_bash_exec(bash, "cp -R %s/* %s/" % (os.getcwd(), tmpdir))
+        assert_bash_exec(bash, "mkdir -p %s/bin" % tmpdir)
+        assert_bash_exec(
+            bash, "ln -sf ../prefix1/bin/cmd1 %s/bin/cmd1" % tmpdir
+        )
+        assert_bash_exec(
+            bash, "ln -sf ../prefix1/sbin/cmd2 %s/bin/cmd2" % tmpdir
+        )
+        return str(tmpdir)
+
+    def test_userdir_1(self, bash, fixture_dir):
         with bash_env_saved(bash) as bash_env:
+            bash_env.chdir(fixture_dir)
             bash_env.write_variable(
                 "BASH_COMPLETION_USER_DIR",
                 "$PWD/userdir1:$PWD/userdir2:$BASH_COMPLETION_USER_DIR",
@@ -24,8 +54,9 @@ class TestCompLoad:
             )
             assert output.strip() == "cmd2: sourced from userdir2"
 
-    def test_PATH_1(self, bash):
+    def test_PATH_1(self, bash, fixture_dir):
         with bash_env_saved(bash) as bash_env:
+            bash_env.chdir(fixture_dir)
             bash_env.write_variable(
                 "PATH", "$PWD/prefix1/bin:$PWD/prefix1/sbin", quote=False
             )
@@ -46,32 +77,35 @@ class TestCompLoad:
             )
             assert "/prefix1/sbin/cmd2" in output
 
-    def test_cmd_path_1(self, bash):
-        assert_bash_exec(bash, "complete -r cmd1 || :", want_output=None)
-        output = assert_bash_exec(
-            bash, "_comp_load prefix1/bin/cmd1", want_output=True
-        )
-        assert output.strip() == "cmd1: sourced from prefix1"
-        output = assert_bash_exec(
-            bash, 'complete -p "$PWD/prefix1/bin/cmd1"', want_output=True
-        )
-        assert "/prefix1/bin/cmd1" in output
-        assert_bash_exec(bash, "! complete -p cmd1", want_output=None)
-        output = assert_bash_exec(
-            bash, "_comp_load prefix1/sbin/cmd2", want_output=True
-        )
-        assert output.strip() == "cmd2: sourced from prefix1"
-        output = assert_bash_exec(
-            bash, "_comp_load bin/cmd1", want_output=True
-        )
-        assert output.strip() == "cmd1: sourced from prefix1"
-        output = assert_bash_exec(
-            bash, "_comp_load bin/cmd2", want_output=True
-        )
-        assert output.strip() == "cmd2: sourced from prefix1"
-
-    def test_cmd_path_2(self, bash):
+    def test_cmd_path_1(self, bash, fixture_dir):
         with bash_env_saved(bash) as bash_env:
+            bash_env.chdir(fixture_dir)
+            assert_bash_exec(bash, "complete -r cmd1 || :", want_output=None)
+            output = assert_bash_exec(
+                bash, "_comp_load prefix1/bin/cmd1", want_output=True
+            )
+            assert output.strip() == "cmd1: sourced from prefix1"
+            output = assert_bash_exec(
+                bash, 'complete -p "$PWD/prefix1/bin/cmd1"', want_output=True
+            )
+            assert "/prefix1/bin/cmd1" in output
+            assert_bash_exec(bash, "! complete -p cmd1", want_output=None)
+            output = assert_bash_exec(
+                bash, "_comp_load prefix1/sbin/cmd2", want_output=True
+            )
+            assert output.strip() == "cmd2: sourced from prefix1"
+            output = assert_bash_exec(
+                bash, "_comp_load bin/cmd1", want_output=True
+            )
+            assert output.strip() == "cmd1: sourced from prefix1"
+            output = assert_bash_exec(
+                bash, "_comp_load bin/cmd2", want_output=True
+            )
+            assert output.strip() == "cmd2: sourced from prefix1"
+
+    def test_cmd_path_2(self, bash, fixture_dir):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.chdir(fixture_dir)
             bash_env.write_variable("PATH", "$PWD/bin:$PATH", quote=False)
             output = assert_bash_exec(
                 bash, "_comp_load cmd1", want_output=True
@@ -82,12 +116,13 @@ class TestCompLoad:
             )
             assert output.strip() == "cmd2: sourced from prefix1"
 
-    def test_cmd_intree_precedence(self, bash):
+    def test_cmd_intree_precedence(self, bash, fixture_dir):
         """
         Test in-tree, i.e. completions/$cmd relative to the main script
         has precedence over location derived from PATH.
         """
         with bash_env_saved(bash) as bash_env:
+            bash_env.chdir(fixture_dir)
             bash_env.write_variable("PATH", "$PWD/prefix1/bin", quote=False)
             # The in-tree `sh` completion should be loaded here,
             # and cause no output, unlike our `$PWD/prefix1/bin/sh` canary.


### PR DESCRIPTION
I separate a PR for the test for `_comp_load` from #1131.

----

_Originally posted by @akinomyoga in https://github.com/scop/bash-completion/issues/1131#issuecomment-1987099039_

Tests in `test_unit_load_completion.py` fail. Somehow, the symbolic link and the target are reversed in the tar ball.

```bash
$ LANG=C find test/fixtures/_comp_load -name cmd1 -ls
998988373      0 lrwxrwxrwx   1 murase   murase         19 Dec 25 05:23 test/fixtures/_comp_load/bin/cmd1 -> ../prefix1/bin/cmd1
1015156558      4 -rwxr-xr-x   1 murase   murase         10 Dec 25 05:23 test/fixtures/_comp_load/prefix1/bin/cmd1
1048877481      4 -rw-r--r--   1 murase   murase         56 Dec 25 05:23 test/fixtures/_comp_load/prefix1/share/bash-completion/completions/cmd1
1065355955      4 -rw-r--r--   1 murase   murase         57 Dec 25 05:23 test/fixtures/_comp_load/userdir1/completions/cmd1
$ LANG=C tar tvf bash-completion-2.12.0.tar.xz --no-anchored cmd1
-rwxr-xr-x murase/murase    10 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1
hrwxr-xr-x murase/murase     0 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/bin/cmd1 link to bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1
-rw-r--r-- murase/murase    56 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/share/bash-completion/completions/cmd1
-rw-r--r-- murase/murase    57 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/userdir1/completions/cmd1
```

Automake seems to specify the option `-h` (resolves symbolic links) to `tar` to create a tar ball.

```bash
tar --format=posix -chf - bash-completion-2.12.0
```

<!--

The file contents generated by `make distdir-am` seem to be fine.

```bash
$ make distdir-am
$ LANG=C find bash-completion-2.12.0/test/fixtures/_comp_load -name cmd1 -ls
2214615788      0 lrwxrwxrwx   1 murase   murase         19 Dec 25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1 -> ../prefix1/bin/cmd1
2231393180      4 -rwxr-xr-x   1 murase   murase         10 Dec 25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/bin/cmd1
2265139732      4 -rw-r--r--   1 murase   murase         56 Dec 25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/share/bash-completion/completions/cmd1
2281716244      4 -rw-r--r--   1 murase   murase         57 Dec 25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/userdir1/completions/cmd1
```

It seems to be caused by the option `-h` specified to `tar` to create the tar ball:

```bash
$ tar --format=posix -chf a.tar bash-completion-2.12.0
$ LANG=C tar tvf a.tar --no-anchored cmd1
-rwxr-xr-x murase/murase    10 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1
hrwxr-xr-x murase/murase     0 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/bin/cmd1 link to bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1
-rw-r--r-- murase/murase    56 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/share/bash-completion/completions/cmd1
-rw-r--r-- murase/murase    57 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/userdir1/completions/cmd1
$ tar --format=posix -cf a.tar bash-completion-2.12.0
$ LANG=C tar tvf a.tar --no-anchored cmd1
lrwxrwxrwx murase/murase     0 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/bin/cmd1 -> ../prefix1/bin/cmd1
-rwxr-xr-x murase/murase    10 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/bin/cmd1
-rw-r--r-- murase/murase    56 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/prefix1/share/bash-completion/completions/cmd1
-rw-r--r-- murase/murase    57 2023-12-25 05:23 bash-completion-2.12.0/test/fixtures/_comp_load/userdir1/completions/cmd1
```

The option `-h` follows symbolic links and replaces the links with the actual content.

```bash
  -h, --dereference          follow symlinks; archive and dump the files they
                             point to
```

-->

