### PR TITLE
refactor(pkgutil): load on solaris only

### DIFF
--- a/completions/pkgutil
+++ b/completions/pkgutil
@@ -1,6 +1,9 @@
 # pkgutil completion                                       -*- shell-script -*-
 # Copyright 2006 Yann Rouillard <yann@opencsw.org>
 
+# At least macOS pkgutil is different
+[[ $OSTYPE == *solaris* ]] || return 1
+
 _comp_cmd_pkgutil__url2catalog()
 {
     local filename="$1"


### PR DESCRIPTION
At least macOS pkgutil is different.

Refs https://github.com/macports/macports-ports/blob/87e757609b6599eda48fedf3afd918d37cf8a85d/sysutils/bash-completion/files/patch-remove-pkgutil.diff