### PR TITLE
fix(scp remote_files): do not filter generated paths with "$cur"

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -469,7 +469,7 @@ _comp_cmd_scp__path_esc='[][(){}<>"'"'"',:;^&!$=?`\\|[:space:]]'
 _comp_xfunc_scp_compgen_remote_files()
 {
     # remove backslash escape from the first colon
-    cur=${cur/\\:/:}
+    local cur=${cur/\\:/:}
 
     local _userhost=${cur%%?(\\):*}
     local _path=${cur#*:}

--- a/completions/ssh
+++ b/completions/ssh
@@ -499,7 +499,7 @@ _comp_xfunc_scp_compgen_remote_files()
             command sed -e 's/'"$_comp_cmd_scp__path_esc"'/\\\\\\&/g' -e 's/[*@|=]$//g' \
                 -e 's/[^\/]$/& /g')
     fi
-    _comp_compgen_split -l -- "$_files"
+    _comp_compgen -R split -l -- "$_files"
 }
 
 # @deprecated 2.12 use `_comp_compgen -ax ssh remote_files` instead


### PR DESCRIPTION
Fixes #1157

The explanation is in the commit message. I haven't added a test since it is related to the remote configuration. It reminds me of the mechanism `LIVE_HOST` discussed in #910, which I'm not sure of.

There is an additional fix to localize the change to `cur`.
