### PR TITLE
fix: use `--` to pass an arbitrary string to builtins

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -649,7 +649,7 @@ _comp_compgen()
         else
             _generator=("_comp_compgen_$1")
         fi
-        if ! declare -F "${_generator[0]}" &>/dev/null; then
+        if ! declare -F -- "${_generator[0]}" &>/dev/null; then
             printf 'bash_completion: %s: unrecognized generator `%s'\'' (function %s not found)\n' "$FUNCNAME" "$1" "${_generator[0]}" >&2
             return 2
         fi
@@ -3281,7 +3281,7 @@ _comp_xfunc()
     local xfunc_name=$2
     [[ $xfunc_name == _* ]] ||
         xfunc_name=_comp_xfunc_${1//[^a-zA-Z0-9_]/_}_$xfunc_name
-    declare -F "$xfunc_name" &>/dev/null || _comp_load -- "$1"
+    declare -F -- "$xfunc_name" &>/dev/null || _comp_load -- "$1"
     "$xfunc_name" "${@:3}"
 }
 

--- a/bash_completion
+++ b/bash_completion
@@ -2765,18 +2765,18 @@ _comp_command_offset()
     else
         _comp_dequote "${COMP_WORDS[0]}" || REPLY=${COMP_WORDS[0]}
         local cmd=$REPLY compcmd=$REPLY
-        local cspec=$(complete -p "$cmd" 2>/dev/null)
+        local cspec=$(complete -p -- "$cmd" 2>/dev/null)
 
         # If we have no completion for $cmd yet, see if we have for basename
         if [[ ! $cspec && $cmd == */* ]]; then
-            cspec=$(complete -p "${cmd##*/}" 2>/dev/null)
+            cspec=$(complete -p -- "${cmd##*/}" 2>/dev/null)
             [[ $cspec ]] && compcmd=${cmd##*/}
         fi
         # If still nothing, just load it for the basename
         if [[ ! $cspec ]]; then
             compcmd=${cmd##*/}
             _comp_load -D -- "$compcmd"
-            cspec=$(complete -p "$compcmd" 2>/dev/null)
+            cspec=$(complete -p -- "$compcmd" 2>/dev/null)
         fi
 
         local retry_count=0
@@ -2809,7 +2809,7 @@ _comp_command_offset()
                         # state of COMPREPLY is discarded.
                         COMPREPLY=()
 
-                        cspec=$(complete -p "$compcmd" 2>/dev/null)
+                        cspec=$(complete -p -- "$compcmd" 2>/dev/null)
 
                         # Note: When completion spec is removed after 124, we
                         # do not generate any completions including the default
@@ -3147,7 +3147,7 @@ _comp_load()
     if [[ $cmd == \\* ]]; then
         cmd=${cmd:1}
         # If we already have a completion for the "real" command, use it
-        $(complete -p "$cmd" 2>/dev/null || echo false) "\\$cmd" && return 0
+        $(complete -p -- "$cmd" 2>/dev/null || echo false) "\\$cmd" && return 0
         backslash=\\
     fi
 
@@ -3222,18 +3222,18 @@ _comp_load()
                 elif [[ -e $compfile ]] && . "$compfile" "$cmd" "$@"; then
                     # At least $cmd is expected to have a completion set when
                     # we return successfully; see if it already does
-                    if compspec=$(complete -p "$cmd" 2>/dev/null); then
+                    if compspec=$(complete -p -- "$cmd" 2>/dev/null); then
                         # $cmd is the case in which we do backslash processing
                         [[ $backslash ]] && eval "$compspec \"\$backslash\$cmd\""
                         # If invoked without path, that one should be set, too
                         # ...but let's not overwrite an existing one, if any
                         [[ $origcmd != */* ]] &&
-                            ! complete -p "$origcmd" &>/dev/null &&
+                            ! complete -p -- "$origcmd" &>/dev/null &&
                             eval "$compspec \"\$origcmd\""
                         return 0
                     fi
                     # If not, see if we got one for $cmdname
-                    if [[ $cmdname != "$cmd" ]] && compspec=$(complete -p "$cmdname" 2>/dev/null); then
+                    if [[ $cmdname != "$cmd" ]] && compspec=$(complete -p -- "$cmdname" 2>/dev/null); then
                         # Use that for $cmd too, if we have a full path to it
                         [[ $cmd == /* ]] && eval "$compspec \"\$cmd\""
                         return 0

--- a/bash_completion
+++ b/bash_completion
@@ -3281,7 +3281,7 @@ _comp_xfunc()
     local xfunc_name=$2
     [[ $xfunc_name == _* ]] ||
         xfunc_name=_comp_xfunc_${1//[^a-zA-Z0-9_]/_}_$xfunc_name
-    declare -F "$xfunc_name" &>/dev/null || _comp_load "$1"
+    declare -F "$xfunc_name" &>/dev/null || _comp_load -- "$1"
     "$xfunc_name" "${@:3}"
 }
 

--- a/completions/_nox
+++ b/completions/_nox
@@ -4,8 +4,8 @@
 # This serves as a fallback in case the completion is not installed otherwise.
 
 eval -- "$(
-    bin_path=$(type -P "$1" 2>/dev/null | command sed 's,/[^/]*$,,')
-    [[ $bin_path ]] && PATH=$bin_path${PATH:+:$PATH}
+    pathcmd=$(type -P "$1" 2>/dev/null | command sed 's,/[^/]*$,,')
+    [[ $pathcmd ]] && PATH=$pathcmd${PATH:+:$PATH}
     register-python-argcomplete --shell bash "$1" 2>/dev/null ||
         register-python-argcomplete3 --shell bash "$1" 2>/dev/null
 )"

--- a/completions/_nox
+++ b/completions/_nox
@@ -4,7 +4,7 @@
 # This serves as a fallback in case the completion is not installed otherwise.
 
 eval -- "$(
-    pathcmd=$(type -P "$1" 2>/dev/null | command sed 's,/[^/]*$,,')
+    pathcmd=$(type -P -- "$1" 2>/dev/null | command sed 's,/[^/]*$,,')
     [[ $pathcmd ]] && PATH=$pathcmd${PATH:+:$PATH}
     register-python-argcomplete --shell bash "$1" 2>/dev/null ||
         register-python-argcomplete3 --shell bash "$1" 2>/dev/null

--- a/completions/add_members
+++ b/completions/add_members
@@ -24,7 +24,7 @@ _comp_cmd_add_members()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_xfunc list_lists mailman_lists
     fi
 

--- a/completions/apt-get
+++ b/completions/apt-get
@@ -33,7 +33,7 @@ _comp_cmd_apt_get()
             source)
                 # Prefer `apt-cache` in the same dir as command
                 local pathcmd
-                pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+                pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
                 _comp_compgen -x apt-cache packages
                 _comp_compgen -a split -- "$(apt-cache dumpavail |
                     _comp_awk '$1 == "Source:" { print $2 }' | sort -u)"
@@ -79,7 +79,7 @@ _comp_cmd_apt_get()
         --target-release | --default-release | -${noargopts}t)
             # Prefer `apt-cache` in the same dir as command
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen_split -- "$(apt-cache policy | command sed -ne \
                 's/^ *release.*[ ,]o=\(Debian\|Ubuntu\),a=\(\w*\).*/\2/p')"
             return

--- a/completions/arch
+++ b/completions/arch
@@ -34,7 +34,7 @@ _comp_have_command mailmanctl &&
                 1)
                     # Prefer `list_lists` in the same dir as command
                     local pathcmd
-                    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+                    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
                     _comp_compgen -x list_lists mailman_lists
                     ;;
                 2)

--- a/completions/change_pw
+++ b/completions/change_pw
@@ -9,7 +9,7 @@ _comp_cmd_change_pw()
         -l | --listname)
             # Prefer `list_lists` in the same dir as command
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen -x list_lists mailman_lists
             return
             ;;

--- a/completions/check_db
+++ b/completions/check_db
@@ -10,7 +10,7 @@ _comp_cmd_check_db()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/clone_member
+++ b/completions/clone_member
@@ -9,7 +9,7 @@ _comp_cmd_clone_member()
         -l | --listname)
             # Prefer `list_lists` in the same dir as command
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen -x list_lists mailman_lists
             return
             ;;

--- a/completions/config_list
+++ b/completions/config_list
@@ -20,7 +20,7 @@ _comp_cmd_config_list()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_xfunc list_lists mailman_lists
     fi
 

--- a/completions/find_member
+++ b/completions/find_member
@@ -9,7 +9,7 @@ _comp_cmd_find_member()
         -l | -x | --listname | --exclude)
             # Prefer `list_lists` in the same dir as command
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen -x list_lists mailman_lists
             return
             ;;

--- a/completions/inject
+++ b/completions/inject
@@ -9,7 +9,7 @@ _comp_cmd_inject()
         -l | --listname)
             # Prefer `list_lists` in the same dir as command
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen -x list_lists mailman_lists
             return
             ;;

--- a/completions/list_admins
+++ b/completions/list_admins
@@ -10,7 +10,7 @@ _comp_cmd_list_admins()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/list_members
+++ b/completions/list_members
@@ -28,7 +28,7 @@ _comp_cmd_list_members()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/list_owners
+++ b/completions/list_owners
@@ -10,7 +10,7 @@ _comp_cmd_list_owners()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/mysql
+++ b/completions/mysql
@@ -24,7 +24,7 @@ _comp_cmd_mysql()
 
     # Prefer `mysqlshow` in the same dir as the command
     local pathcmd
-    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
 
     local noargopts='!(-*|*[uDhSPeI]*)'
     # shellcheck disable=SC2254

--- a/completions/newlist
+++ b/completions/newlist
@@ -19,7 +19,7 @@ _comp_cmd_newlist()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 } &&

--- a/completions/perl
+++ b/completions/perl
@@ -107,7 +107,7 @@ _comp_cmd_perldoc()
 
     # Prefer `perl` in the same dir in utility functions
     local pathcmd
-    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
 
     case $prev in
         -*[hVnoMwL])

--- a/completions/pydoc
+++ b/completions/pydoc
@@ -25,7 +25,7 @@ _comp_cmd_pydoc()
     if ! _comp_looks_like_path "$cur"; then
         # Prefer python in the same dir for resolving modules
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -ax python modules
     fi
 

--- a/completions/remove_members
+++ b/completions/remove_members
@@ -20,7 +20,7 @@ _comp_cmd_remove_members()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/rmlist
+++ b/completions/rmlist
@@ -10,7 +10,7 @@ _comp_cmd_rmlist()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/rpm
+++ b/completions/rpm
@@ -262,7 +262,7 @@ _comp_cmd_rpmbuild()
         --target | --eval | -${noargopts}E | --buildpolicy)
             # Prefer `rpm` in the same dir in utility functions
             local pathcmd
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             ;;&
         --target)
             _comp_cmd_rpm__buildarchs

--- a/completions/ssh
+++ b/completions/ssh
@@ -404,7 +404,7 @@ _comp_cmd_sftp()
 
     # Prefer `ssh` from same dir for resolving options, etc
     local pathcmd
-    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
 
     _comp_xfunc_ssh_compgen_suboption_check && return
 
@@ -556,7 +556,7 @@ _comp_cmd_scp()
 
     # Prefer `ssh` from same dir for resolving options, remote files, etc
     local pathcmd
-    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
 
     _comp_xfunc_ssh_compgen_suboption_check && {
         ((${#COMPREPLY[@]})) && COMPREPLY=("${COMPREPLY[@]/%/ }")

--- a/completions/ssh-copy-id
+++ b/completions/ssh-copy-id
@@ -7,7 +7,7 @@ _comp_cmd_ssh_copy_id()
 
     # Prefer `ssh` from same dir for resolving options, etc
     local pathcmd
-    pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+    pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
 
     _comp_compgen -x ssh suboption_check && return
 

--- a/completions/ssh-keygen
+++ b/completions/ssh-keygen
@@ -101,7 +101,7 @@ _comp_cmd_ssh_keygen()
         -*t)
             # Prefer `ssh` from same dir for resolving options, etc
             local pathcmd protocols
-            pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+            pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
             _comp_compgen -v protocols -x ssh query protocol-version
             local types='dsa ecdsa ecdsa-sk ed25519 ed25519-sk rsa'
             if [[ ${protocols[*]} == *1* ]]; then

--- a/completions/sync_members
+++ b/completions/sync_members
@@ -24,7 +24,7 @@ _comp_cmd_sync_members()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/completions/withlist
+++ b/completions/withlist
@@ -10,7 +10,7 @@ _comp_cmd_withlist()
     else
         # Prefer `list_lists` in the same dir as command
         local pathcmd
-        pathcmd=$(type -P "$1") && local PATH=${pathcmd%/*}:$PATH
+        pathcmd=$(type -P -- "$1") && local PATH=${pathcmd%/*}:$PATH
         _comp_compgen -x list_lists mailman_lists
     fi
 

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -382,7 +382,7 @@ def load_completion_for(bash: pexpect.spawn, cmd: str) -> bool:
         # Allow _comp_load to fail so we can test completions
         # that are directly loaded in bash_completion without a separate file.
         assert_bash_exec(bash, "_comp_load -- %s || :" % cmd)
-        assert_bash_exec(bash, "complete -p %s &>/dev/null" % cmd)
+        assert_bash_exec(bash, "complete -p -- %s &>/dev/null" % cmd)
     except AssertionError:
         return False
     return True

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -381,7 +381,7 @@ def load_completion_for(bash: pexpect.spawn, cmd: str) -> bool:
     try:
         # Allow _comp_load to fail so we can test completions
         # that are directly loaded in bash_completion without a separate file.
-        assert_bash_exec(bash, "_comp_load %s || :" % cmd)
+        assert_bash_exec(bash, "_comp_load -- %s || :" % cmd)
         assert_bash_exec(bash, "complete -p %s &>/dev/null" % cmd)
     except AssertionError:
         return False


### PR DESCRIPTION
These are fixes for the builtins receiving arbitrary strings as strings (but not as options). This generalizes the `type -P` fix in #1118.