### PR TITLE
fix(ip): Don't stop at proxy and nomaster in neigh

### DIFF
--- a/completions/ip
+++ b/completions/ip
@@ -367,7 +367,7 @@ _comp_cmd_ip()
                         dev)
                             _comp_compgen_available_interfaces
                             ;;
-                        nomaster | proxy | to | vrf) # TODO - Maybe we can complete vrf here?
+                        to | vrf) # TODO - Maybe we can complete vrf here?
                             :
                             ;;
                         *)


### PR DESCRIPTION
These values don't take any arguments, so we can keep completing right after them.