### PR TITLE
fix(fio): engines completion

### DIFF
--- a/completions/fio
+++ b/completions/fio
@@ -2,7 +2,7 @@
 
 _comp_cmd_fio__compgen_engines()
 {
-    _comp_compgen_split -l -- "$("$1" --enghelp 2>/dev/null | command sed -ne '/^[[:space:]]/p'))"
+    _comp_compgen_split -F $'\t\n' -- "$("$1" --enghelp 2>/dev/null | command sed -ne '/^[[:space:]]/p')"
 }
 
 _comp_cmd_fio()

--- a/test/t/test_fio.py
+++ b/test/t/test_fio.py
@@ -23,6 +23,8 @@ class TestFio:
     def test_enghelp(self, completion):
         """Test --enghelp parsing."""
         assert completion
+        assert all(x == x.strip() for x in completion)
+        assert all(")" not in x for x in completion)
 
     @pytest.mark.complete("fio --unlink=", require_cmd=True)
     def test_cmdhelp_boolean(self, completion):


### PR DESCRIPTION
Rows in `--enghelp` output that contain engine names start with a tab as of fio 3.35.

Remove spurious closing parenthesis introduced in commit a1dd4d0c8912a9e04952e88d96447585fe25572e.