### PR TITLE
fix(available_interfaces): strip only trailing colon from entries

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1737,7 +1737,7 @@ _comp_compgen_available_interfaces()
         fi
     } 2>/dev/null | _comp_awk \
         '/^[^ \t]/ { if ($1 ~ /^[0-9]+:/) { print $2 } else { print $1 } }')" &&
-        _comp_compgen -U generated set "${generated[@]%%[[:punct:]]*}"
+        _comp_compgen -U generated set "${generated[@]%:}"
 }
 
 # Echo number of CPUs, falling back to 1 on failure.

--- a/test/t/unit/test_unit_compgen_available_interfaces.py
+++ b/test/t/unit/test_unit_compgen_available_interfaces.py
@@ -22,4 +22,4 @@ class TestUtilCompgenAvailableInterfaces:
             "_comp__test_compgen available_interfaces",
             want_output=True,
         )
-        assert ":" not in output.strip()
+        assert ":>" not in output.strip()


### PR DESCRIPTION
Leave other punctuation alone, at least for now.

Closes https://github.com/scop/bash-completion/issues/1133

See also discussion starting from https://github.com/scop/bash-completion/pull/1131#discussion_r1518797675