### PR TITLE
feat(java): enable .java filename completion for java command

### DIFF
--- a/completions/java
+++ b/completions/java
@@ -236,6 +236,9 @@ _comp_cmd_java()
         else
             # classes completion
             _comp_cmd_java__classes
+            # support for launching source-code
+            # programs (JEP 330, JEP 458)
+            _comp_compgen -a filedir 'java'
         fi
     fi
 

--- a/test/fixtures/java/JEP330.java
+++ b/test/fixtures/java/JEP330.java
@@ -1,0 +1,12 @@
+/**
+ * The java launcher is able to run a program
+ * supplied as a single file of Java source code.
+ *
+ * @see <a href="https://openjdk.java.net/jeps/330">JEP 330: Launch Single-File Source-Code Programs</a>
+ * @see <a href="https://openjdk.java.net/jeps/458">JEP 458: Launch Multi-File Source-Code Programs</a>
+ */
+class JEP330 {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}

--- a/test/t/test_java.py
+++ b/test/t/test_java.py
@@ -19,32 +19,40 @@ class TestJava:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.complete("java ")
+    @pytest.mark.complete("java ", cwd="java")
     def test_2(self, completion, can_list_jar):
         if can_list_jar:
-            assert completion == "b bashcomp.jarred c. toplevel".split()
+            assert (
+                completion
+                == "JEP330.java a/ b bashcomp.jarred c. toplevel".split()
+            )
         else:
-            assert completion == "b c.".split()
+            assert completion == "JEP330.java a/ b c.".split()
 
-    @pytest.mark.complete("java -classpath java/bashcomp.jar ")
+    @pytest.mark.complete("java -classpath bashcomp.jar ", cwd="java")
     def test_3(self, completion, can_list_jar):
         if can_list_jar:
-            assert completion == "bashcomp.jarred toplevel".split()
+            assert (
+                completion == "JEP330.java a/ bashcomp.jarred toplevel".split()
+            )
         else:
-            assert not completion
+            assert completion == "JEP330.java a/".split()
 
-    @pytest.mark.complete("java -cp java/bashcomp.jar:java/a/c ")
+    @pytest.mark.complete("java -cp bashcomp.jar:a/c ", cwd="java")
     def test_4(self, completion, can_list_jar):
         if can_list_jar:
-            assert completion == "bashcomp.jarred d toplevel".split()
+            assert (
+                completion
+                == "JEP330.java a/ bashcomp.jarred d toplevel".split()
+            )
         else:
-            assert completion == ["d"]
+            assert completion == "JEP330.java a/ d".split()
 
-    @pytest.mark.complete("java -cp '' ")
+    @pytest.mark.complete("java -cp '' ", cwd="java")
     def test_5(self, completion):
-        assert not completion
+        assert completion == "JEP330.java a/".split()
 
-    @pytest.mark.complete("java -jar java/")
+    @pytest.mark.complete("java -jar ", cwd="java")
     def test_6(self, completion):
         assert completion == "a/ bashcomp.jar bashcomp.war".split()
 


### PR DESCRIPTION
Modify java command completion scripts to also complete filenames with the .java extension. This adds support for
- JEP 330: Launch Single-File Source-Code Programs
- JEP 458: Launch Multi-File Source-Code Programs


----
edited by @akinomyoga

Fixes #1196
