### PR TITLE
fix(cargo): avoid local: can only be used in a function warning

### DIFF
--- a/completions/_cargo
+++ b/completions/_cargo
@@ -2,8 +2,7 @@
 #
 # This serves as a fallback in case the completion is not installed otherwise.
 
-# shellcheck disable=SC2168 # "local" is ok, assume sourced by _comp_load
-local rustup="${1%cargo}rustup" # use rustup from same dir
-eval -- "$("$rustup" completions bash cargo 2>/dev/null)"
+# use rustup from same dir
+eval -- "$("${1%cargo}rustup" completions bash cargo 2>/dev/null)"
 
 # ex: filetype=sh


### PR DESCRIPTION
when loading bash-completion currently, the following is printed

```
$ bash -l
bash: local: can only be used in a function
bash-5.2$ 
```

tracing this with `bash -x` points to the _cargo completion. it seems that this is not actually sourced by _comp_load and isn't in a function

elide this by inlining the variable use