### PR TITLE
pkgutil: don't install on platforms where it cannot be used

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -120,7 +120,6 @@ bashcomp_DATA = 2to3 \
 		firefox \
 		flake8 \
 		_flamegraph \
-		freebsd-update \
 		freeciv \
 		freeciv-server \
 		function \
@@ -215,8 +214,6 @@ bashcomp_DATA = 2to3 \
 		_keyring \
 		kill \
 		killall \
-		kldload \
-		kldunload \
 		koji \
 		_kontena \
 		ktutil \
@@ -324,7 +321,6 @@ bashcomp_DATA = 2to3 \
 		_pipenv \
 		pkg-config \
 		pkg-get \
-		pkg_delete \
 		pkgadd \
 		pkgrm \
 		pkgtool \
@@ -333,9 +329,6 @@ bashcomp_DATA = 2to3 \
 		pm-is-supported \
 		pm-powersave \
 		pngfix \
-		portinstall \
-		portsnap \
-		portupgrade \
 		postcat \
 		postconf \
 		postfix \
@@ -506,6 +499,21 @@ bashcomp_DATA = 2to3 \
 if SOLARIS
 bashcomp_DATA += pkgutil
 endif
+
+if BSD
+bashcomp_DATA += pkg_delete
+endif
+
+if FREEBSD
+bashcomp_DATA += \
+		freebsd-update \
+		kldload \
+		kldunload \
+		portinstall \
+		portsnap \
+		portupgrade
+endif
+
 
 EXTRA_DIST = $(bashcomp_DATA)
 
@@ -770,8 +778,6 @@ CLEANFILES = \
 	ping4 \
 	ping6 \
 	_pip3 \
-	pkg_deinstall \
-	pkg_info \
 	pkgconf \
 	pkill \
 	plzip \
@@ -1159,8 +1165,10 @@ symlinks: $(DATA)
 		_black _blackd _flask _httpx
 	$(ss) pkg-config \
 		pkgconf
+if BSD
 	$(ss) pkg_delete \
 		pkg_deinstall pkg_info
+endif
 	$(ss) pgrep \
 		pkill
 	$(ss) pm-hibernate \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -328,7 +328,6 @@ bashcomp_DATA = 2to3 \
 		pkgadd \
 		pkgrm \
 		pkgtool \
-		pkgutil \
 		plague-client \
 		pm-hibernate \
 		pm-is-supported \
@@ -502,6 +501,11 @@ bashcomp_DATA = 2to3 \
 		yum-arch \
 		zopfli \
 		zopflipng
+
+
+if SOLARIS
+bashcomp_DATA += pkgutil
+endif
 
 EXTRA_DIST = $(bashcomp_DATA)
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,12 +14,22 @@ fi
 
 AC_CANONICAL_HOST
 
+build_bsd=
+build_freebsd=
 build_solaris=
 case ${host_os} in
+    *bsd*)
+        build_bsd=yes
+        case ${host_os} in
+            *freebsd*)
+                build_freebsd=yes ;;
+        esac ;;
     *solaris*)
         build_solaris=yes ;;
 esac
 
+AM_CONDITIONAL([BSD], [test "${build_bsd}" = yes])
+AM_CONDITIONAL([FREEBSD], [test "${build_freebsd}" = yes])
 AM_CONDITIONAL([SOLARIS], [test "${build_solaris}" = yes])
 
 AC_CONFIG_FILES([

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,17 @@ AC_ARG_WITH([pytest],[  --with-pytest=executable],[PYTEST="$withval"])
 if test "x$PYTEST" = x; then
     AC_CHECK_PROGS([PYTEST],[pytest pytest-3],[pytest])
 fi
+
+AC_CANONICAL_HOST
+
+build_solaris=
+case ${host_os} in
+    *solaris*)
+        build_solaris=yes ;;
+esac
+
+AM_CONDITIONAL([SOLARIS], [test "${build_solaris}" = yes])
+
 AC_CONFIG_FILES([
 Makefile
 completions/Makefile


### PR DESCRIPTION
In commit 0e3a17df7eac79ff386891945a951a23134373b0, a short-circuit was added that causes the completion to return 1 if the host OS is not solaris.

On Gentoo, this triggers a warning:

```
 * QA Notice: Problems with installed bash completions were found:
 *
 * 	pkgutil: does not define any completions (failed to source?).
 *
 * For more details on installing bash-completions, please see:
 * https://wiki.gentoo.org/wiki/Bash/Installing_completion_files
```

The purpose of the check is to find broken completions that need to be fixed by their respective upstreams, and in this case the completion is "intentionally broken". It seems straightforward to respect that at an earlier level, which both avoids the QA check and ensures that unneeded files don't get installed on any distro.

And... it also means that macOS users can ship their own pkgutil completion without worrying about file clashes with the bash-completion project. The entire reason for the short-circuit was because there's a *different* pkgutil there.

Fixes: 0e3a17df7eac79ff386891945a951a23134373b0