### PR TITLE
chore(git): ignore config.guess and config.sub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,10 @@ Makefile
 Makefile.in
 /aclocal.m4
 /autom4te.cache/
+/config.guess
 /config.log
 /config.status
+/config.sub
 /configure
 /configure.lineno
 /install-sh


### PR DESCRIPTION
`autoreconf -i` on at least Ubuntu 24.04 adds them.