### PR TITLE
Add completion for mfiutil(8)

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -261,6 +261,7 @@ bashcomp_DATA = 2to3 \
 		_mdbook \
 		mdtool \
 		medusa \
+		mfiutil \
 		mii-diag \
 		mii-tool \
 		minicom \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -1151,7 +1151,7 @@ symlinks: $(DATA)
 		mdecrypt
 	$(ss) _mdbook \
 		_deno _diesel _dprint _starship
-	$(ss) mfilutil \
+	$(ss) mfiutil \
 		mrsasutil
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -1151,6 +1151,8 @@ symlinks: $(DATA)
 		mdecrypt
 	$(ss) _mdbook \
 		_deno _diesel _dprint _starship
+	$(ss) mfilutil \
+		mrsasutil
 	$(ss) mplayer \
 		gmplayer kplayer mencoder mplayer2
 	$(ss) mutt \

--- a/completions/mfiutil
+++ b/completions/mfiutil
@@ -1,0 +1,124 @@
+[[ $OSTYPE == *@(freebsd|dragonflybsd|darwin|linux|solaris)* ]] || return 1
+
+_comp_cmd_mfiutil() {
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    if [[ $cur == -* ]]; then
+        # Complete global options
+        local options="-u -d -e"
+        case "$OSTYPE" in
+            *freebsd*)
+                options="$options -D -t"
+                ;;
+            *dragonflybsd*|*solaris*)
+                options="$options -t"
+                ;;
+        esac
+        local end_of_options=
+        local w
+        for w in "${words[@]:1:cword-1}"; do
+            case "$w" in
+                --)
+                    end_of_options=1
+                    break
+                    ;;
+                -*)
+                    ;;
+                *)
+                    end_of_options=1
+                    break
+                    ;;
+            esac
+        done
+        if [[ ! $end_of_options ]]; then
+            _comp_compgen -- -W '$options'
+            return
+        fi
+    fi
+
+    local REPLY
+    _comp_count_args -a "-*[Dtu]"
+    case $REPLY in
+        0)
+            # Complete argument to global options
+            case "$prev" in
+                -D)
+                    _comp_compgen_filedir
+                    ;;
+                -t)
+                    case "$OSTYPE" in
+                        *freebsd*|*dragonflybsd*)
+                            _comp_compgen -- -W 'mfi mrsas'
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+        1)
+            _comp_compgen -- -W '
+                version show fail good rebuild syspd drive start abort locate
+                cache name volume clear create delete add remove patrol stop
+                foreign flash bbu ctrlprop'
+            ;;
+        2)
+            case "$prev" in
+                show)
+                    _comp_compgen -- -W '
+                        adapter battery config drives events firmware foreign
+                        logstate volumes patrol progress'
+                    ;;
+                drive)
+                    _comp_compgen -- -W 'progress clear'
+                    ;;
+                start)
+                    _comp_compgen -- -W 'rebuild patrol learn'
+                    ;;
+                abort)
+                    _comp_compgen -- -W 'rebuild'
+                    ;;
+                volume)
+                    _comp_compgen -- -W 'progress'
+                    ;;
+                create)
+                    _comp_compgen -- -W '
+                        jbod raid0 raid1 raid5 raid6 raid10 raid50 raid60 concat'
+                    ;;
+                patrol)
+                    _comp_compgen -- -W 'disable auto manual'
+                    ;;
+                stop)
+                    _comp_compgen -- -W 'patrol'
+                    ;;
+                foreign)
+                    _comp_compgen -- -W 'scan clear diag preview import'
+                    ;;
+                flash)
+                    _comp_compgen_filedir
+                    ;;
+                bbu)
+                    _comp_compgen -- -W 'learn-delay autolearn-mode bbu-mode'
+                    ;;
+                ctrlprop)
+                    _comp_compgen -- -W 'rebuild alarm'
+                    ;;
+            esac
+            ;;
+        3)
+            case "${words[cword-2]}.$prev" in
+                locate.*)
+                    _comp_compgen -- -W 'on off'
+                    ;;
+                cache.*)
+                    _comp_compgen -- -W '
+                        enable disable reads writes write-back write-through
+                        read-ahead bad-bbu-write-cache write-cache'
+                    ;;
+                ctrlprop.alarm)
+                    _comp_compgen -- -W 'on off 1 0'
+                    ;;
+            esac
+            ;;
+    esac
+}
+complete -F _comp_cmd_mfiutil mfiutil mrsasutil

--- a/completions/mfiutil
+++ b/completions/mfiutil
@@ -1,6 +1,9 @@
+# mfiutil completion                                       -*- shell-script -*-
+
 [[ $OSTYPE == *@(freebsd|dragonflybsd|darwin|linux|solaris)* ]] || return 1
 
-_comp_cmd_mfiutil() {
+_comp_cmd_mfiutil()
+{
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
@@ -11,7 +14,7 @@ _comp_cmd_mfiutil() {
             *freebsd*)
                 options="$options -D -t"
                 ;;
-            *dragonflybsd*|*solaris*)
+            *dragonflybsd* | *solaris*)
                 options="$options -t"
                 ;;
         esac
@@ -23,8 +26,7 @@ _comp_cmd_mfiutil() {
                     end_of_options=1
                     break
                     ;;
-                -*)
-                    ;;
+                -*) ;;
                 *)
                     end_of_options=1
                     break
@@ -48,7 +50,7 @@ _comp_cmd_mfiutil() {
                     ;;
                 -t)
                     case "$OSTYPE" in
-                        *freebsd*|*dragonflybsd*)
+                        *freebsd* | *dragonflybsd*)
                             _comp_compgen -- -W 'mfi mrsas'
                             ;;
                     esac
@@ -105,7 +107,7 @@ _comp_cmd_mfiutil() {
             esac
             ;;
         3)
-            case "${words[cword-2]}.$prev" in
+            case "${words[cword - 2]}.$prev" in
                 locate.*)
                     _comp_compgen -- -W 'on off'
                     ;;
@@ -120,5 +122,5 @@ _comp_cmd_mfiutil() {
             esac
             ;;
     esac
-}
-complete -F _comp_cmd_mfiutil mfiutil mrsasutil
+} &&
+    complete -F _comp_cmd_mfiutil mfiutil mrsasutil

--- a/completions/mfiutil
+++ b/completions/mfiutil
@@ -12,10 +12,10 @@ _comp_cmd_mfiutil()
         local options="-u -d -e"
         case "$OSTYPE" in
             *freebsd*)
-                options="$options -D -t"
+                options+=" -D -t"
                 ;;
             *dragonflybsd* | *solaris*)
-                options="$options -t"
+                options+=" -t"
                 ;;
         esac
         local end_of_options=
@@ -23,12 +23,12 @@ _comp_cmd_mfiutil()
         for w in "${words[@]:1:cword-1}"; do
             case "$w" in
                 --)
-                    end_of_options=1
+                    end_of_options=set
                     break
                     ;;
                 -*) ;;
                 *)
-                    end_of_options=1
+                    end_of_options=set
                     break
                     ;;
             esac

--- a/test/t/Makefile.am
+++ b/test/t/Makefile.am
@@ -372,6 +372,7 @@ EXTRA_DIST = \
 	test_mdtool.py \
 	test_medusa.py \
 	test_mencoder.py \
+	test_mfiutil.py \
 	test_mii_diag.py \
 	test_mii_tool.py \
 	test_minicom.py \

--- a/test/t/test_mfiutil.py
+++ b/test/t/test_mfiutil.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+class TestMfiUtil:
+    @pytest.mark.complete("mfiutil -")
+    def test_global_options(self, completion):
+        assert completion
+
+    @pytest.mark.complete("mfiutil show ")
+    def test_show_subcommand(self, completion):
+        assert completion
+
+    @pytest.mark.complete("mfiutil show -")
+    def test_options_after_subcommands(self, completion):
+        assert not completion
+
+    @pytest.mark.complete("mfiutil -e show dri")
+    def test_show_drives_subcommand_with_global_option(self, completion):
+        assert completion == ["ves"]
+
+    @pytest.mark.complete("mfiutil locate 1 ")
+    def test_locate_subcommand(self, completion):
+        assert completion == ["off", "on"]


### PR DESCRIPTION
[**mfiutil(8)**](https://man.freebsd.org/cgi/man.cgi?query=mfiutil&manpath=FreeBSD+14.1-RELEASE) is available as a part of FreeBSD base system; [a portable version](https://sourceforge.net/projects/mfiutil/) is also available for a few other operating systems.
