### PR TITLE
test(scp): Add unit tests for getting remote files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: shfmt
         types: [text]
-        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
+        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fixtures/.+/bin/.+|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
@@ -22,7 +22,7 @@ repos:
       - id: shellcheck
         args: [-f, gcc]
         types: [text]
-        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
+        files: ^(bash_completion(\.d/[^/]+\.bash)?|completions/.+|test/(config/bashrc|fixtures/.+/bin/.+|fallback/update-fallback-links|runLint|update-test-cmd-list)|.+\.sh(\.in)?)$
         exclude: ^completions/(\.gitignore|Makefile.*)$
         require_serial: false  # We disable SC1090 anyway, so parallel is ok
 

--- a/test/fixtures/mount/bin/showmount
+++ b/test/fixtures/mount/bin/showmount
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ "$1" = -e ] && [ "$2" = mocksrv ]; then
+if [[ $1 == -e && $2 == "mocksrv" ]]; then
     echo "Header line"
     echo "/test/path"
     echo "/test/path2"

--- a/test/fixtures/scp/bin/ssh
+++ b/test/fixtures/scp/bin/ssh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu
+args=("$@")
+while true; do
+    arg="${args[0]-}"
+    case "$arg" in
+        -o)
+            args=("${args[@]:2}")
+            ;;
+        local)
+            args=("${args[@]:1}")
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+#shellcheck disable=SC2068
+${args[@]}


### PR DESCRIPTION
Since there doesn't seem to be any unit tests for xfuncs, I'm not sure if the naming here makes sense, or if I should make some more directories, for example a `unit/xfunc` or `fixtures/xfunc`?

I did this since there seems to be a lot of issues with this function, as seen in https://github.com/scop/bash-completion/pull/910 and https://github.com/scop/bash-completion/pull/765#issuecomment-1173097965
This should be a first good step to make fixing the issues easier IMO.
