### PR TITLE
Deprecate {ins,rm}mod and mod{info,probe}

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -139,7 +139,7 @@
 /_incus
 /_infracost
 /inotifywatch
-/insmod.static
+/_insmod.static
 /iperf3
 /_istioctl
 /javac

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -268,7 +268,7 @@ bashcomp_DATA = 2to3 \
 		mktemp \
 		mmsitepass \
 		_mock \
-		modinfo \
+		_modinfo \
 		modprobe \
 		_modules \
 		monodevelop \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -181,7 +181,7 @@ bashcomp_DATA = 2to3 \
 		info \
 		inject \
 		inotifywait \
-		insmod \
+		_insmod \
 		installpkg \
 		interdiff \
 		invoke-rc.d \
@@ -688,7 +688,7 @@ CLEANFILES = \
 	_incus \
 	_infracost \
 	inotifywatch \
-	insmod.static \
+	_insmod.static \
 	iperf3 \
 	_istioctl \
 	javac \
@@ -1108,8 +1108,8 @@ symlinks: $(DATA)
 		pinfo
 	$(ss) inotifywait \
 		inotifywatch
-	$(ss) insmod \
-		insmod.static
+	$(ss) _insmod \
+		_insmod.static
 	$(ss) iperf \
 		iperf3
 	$(ss) java \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -269,7 +269,7 @@ bashcomp_DATA = 2to3 \
 		mmsitepass \
 		_mock \
 		_modinfo \
-		modprobe \
+		_modprobe \
 		_modules \
 		monodevelop \
 		_mount \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -376,7 +376,7 @@ bashcomp_DATA = 2to3 \
 		_rg \
 		ri \
 		rmlist \
-		rmmod \
+		_rmmod \
 		route \
 		rpcdebug \
 		rpm \

--- a/completions/_insmod
+++ b/completions/_insmod
@@ -1,5 +1,8 @@
 # Linux insmod(8) completion                               -*- shell-script -*-
 
+# Use of this file is deprecated.
+# Upstream completion is available in kmod >= 34, use that instead.
+
 _comp_cmd_insmod()
 {
     local cur prev words cword comp_args

--- a/completions/_modinfo
+++ b/completions/_modinfo
@@ -1,5 +1,8 @@
 # Linux modinfo(8) completion                              -*- shell-script -*-
 
+# Use of this file is deprecated.
+# Upstream completion is expected to be available in kmod >= 35, use that instead.
+
 _comp_cmd_modinfo()
 {
     local cur prev words cword was_split comp_args

--- a/completions/_modprobe
+++ b/completions/_modprobe
@@ -1,5 +1,8 @@
 # Linux modprobe(8) completion                             -*- shell-script -*-
 
+# Use of this file is deprecated.
+# Upstream completion is expected to be available in kmod >= 35, use that instead.
+
 _comp_cmd_modprobe()
 {
     local cur prev words cword was_split comp_args

--- a/completions/_rmmod
+++ b/completions/_rmmod
@@ -1,6 +1,9 @@
 # Linux rmmod(8) completion.                               -*- shell-script -*-
 # This completes on a list of all currently installed kernel modules.
 
+# Use of this file is deprecated.
+# Upstream completion is available in kmod >= 34, use that instead.
+
 _comp_cmd_rmmod()
 {
     local cur prev words cword comp_args

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = \
 	gsctl \
 	hexdump \
 	hwclock \
+	insmod \
 	ionice \
 	jungle \
 	keyring \

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -23,6 +23,7 @@ EXTRA_DIST = \
 	mock \
 	modinfo \
 	modules \
+	modprobe \
 	mount \
 	mount.linux \
 	newgrp \

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST = \
 	renice \
 	repomanage \
 	reptyr \
+	rmmod \
 	rfkill \
 	rtcwake \
 	ruff \

--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -21,6 +21,7 @@ EXTRA_DIST = \
 	look \
 	mdbook \
 	mock \
+	modinfo \
 	modules \
 	mount \
 	mount.linux \

--- a/test/fallback/completions/insmod
+++ b/test/fallback/completions/insmod
@@ -1,0 +1,1 @@
+../../../completions/_insmod

--- a/test/fallback/completions/modinfo
+++ b/test/fallback/completions/modinfo
@@ -1,0 +1,1 @@
+../../../completions/_modinfo

--- a/test/fallback/completions/modprobe
+++ b/test/fallback/completions/modprobe
@@ -1,0 +1,1 @@
+../../../completions/_modprobe

--- a/test/fallback/completions/rmmmod
+++ b/test/fallback/completions/rmmmod
@@ -1,0 +1,1 @@
+../../../completions/_rmmod


### PR DESCRIPTION
I'm aiming to have these in the upstream project and having the ones in bash-completion means that distributions will get clashing files. 

Rename these with the fallback prefix and (try) to fix all the build magic ;-)