### PR TITLE
fix(dpkg): Add missing short option -R

### DIFF
--- a/completions/dpkg
+++ b/completions/dpkg
@@ -72,11 +72,11 @@ _comp_cmd_dpkg()
         done
     fi
 
-    local noargopts='!(-*|*[ciAIfexXbsplWSrVLPD]*)'
+    local noargopts='!(-*|*[ciAIfexXRbsplWSrVLPD]*)'
     # shellcheck disable=SC2254
     case $prev in
         --install | --unpack | --record-avail | --contents | --info | --fsys-tarfile | \
-            --field | --control | --extract | --vextract | --raw-extract | -${noargopts}[ciAIfexX])
+            --field | --control | --extract | --vextract | --raw-extract | -${noargopts}[ciAIfexXR])
             _comp_compgen_filedir '?(u|d)deb'
             return
             ;;


### PR DESCRIPTION
Completion for '--raw-extract' is already supported, however the equivalent short option '-R' was missing. Now fixed.

Cf. dpkg-deb help message:

```
dpkg-deb --help
[...]
  -R|--raw-extract <deb> <directory>
[...]
```