### PR TITLE
feat(openssl): Stop having subcommands hardcoded

### DIFF
--- a/completions/openssl
+++ b/completions/openssl
@@ -42,22 +42,11 @@ _comp_cmd_openssl()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local commands command formats
-
-    commands='asn1parse ca ciphers crl crl2pkcs7 dgst dh dhparam dsa dsaparam
-        ec ecparam enc engine errstr gendh gendsa genrsa nseq ocsp passwd
-        pkcs12 pkcs7 pkcs8 prime rand req rsa rsautl s_client s_server s_time
-        sess_id smime speed spkac storeutl verify version x509 md2 md4 md5 rmd160
-        sha sha1 aes-128-cbc aes-128-ecb aes-192-cbc aes-192-ecb aes-256-cbc
-        aes-256-ecb base64 bf bf-cbc bf-cfb bf-ecb bf-ofb camellia-128-cbc
-        camellia-128-ecb camellia-192-cbc camellia-192-ecb camellia-256-cbc
-        camellia-256-ecb cast cast-cbc cast5-cbc cast5-cfb cast5-ecb cast5-ofb
-        des des-cbc des-cfb des-ecb des-ede des-ede-cbc des-ede-cfb des-ede-ofb
-        des-ede3 des-ede3-cbc des-ede3-cfb des-ede3-ofb des-ofb des3 desx rc2
-        rc2-40-cbc rc2-64-cbc rc2-cbc rc2-cfb rc2-ecb rc2-ofb rc4 rc4-40
-        sha224 sha256 sha384 sha512 genpkey pkey pkeyparam pkeyutl'
+    local command formats
 
     if ((cword == 1)); then
+        local commands
+        commands="$("$1" help 2>&1 | command sed -e '/commands\|help:/d')"
         _comp_compgen -- -W "$commands"
     else
         command=${words[1]}

--- a/test/t/test_openssl.py
+++ b/test/t/test_openssl.py
@@ -2,9 +2,12 @@ import pytest
 
 
 class TestOpenssl:
-    @pytest.mark.complete("openssl ")
+    @pytest.mark.complete("openssl ", require_cmd=True)
     def test_1(self, completion):
         assert completion
+        assert all(
+            x in completion for x in "md5 x509 aes-128-cbc dgst pkey".split()
+        )
 
     @pytest.mark.complete("openssl pkey -cipher ", require_cmd=True)
     def test_2(self, completion):


### PR DESCRIPTION
Instead we get the command list by parsing openssl help, which also adds some subcommands that were missing, and removes some non-existant ones (at least on versions I have).
The parsing only happens when it's necessary, when the subcommand wasn't chosen.