### PR TITLE
refactor(mtr): deprecate our completion, upstream >= 0.88 has one

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2697,7 +2697,7 @@ _comp_compgen_known_hosts__impl()
     _comp_compgen -v known_hosts -c "$prefix$cur" ltrim_colon "${known_hosts[@]}"
 }
 complete -F _comp_complete_known_hosts traceroute traceroute6 \
-    fping fping6 telnet rsh rlogin ftp dig drill mtr ssh-installkeys showmount
+    fping fping6 telnet rsh rlogin ftp dig drill ssh-installkeys showmount
 
 # Convert the word index in `words` to the index in `COMP_WORDS`.
 # @param $1           Index in the array WORDS.

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -275,6 +275,7 @@ bashcomp_DATA = 2to3 \
 		mplayer \
 		mr \
 		msynctool \
+		_mtr \
 		mtx \
 		munindoc \
 		munin-node-configure \

--- a/completions/_mtr
+++ b/completions/_mtr
@@ -1,0 +1,8 @@
+# mtr(8) completion                                        -*- shell-script -*-
+
+# Use of this file is deprecated.
+# Upstream completion is available in mtr >= 0.88, use that instead.
+
+complete -F _comp_complete_known_hosts mtr
+
+# ex: filetype=sh

--- a/test/t/Makefile.am
+++ b/test/t/Makefile.am
@@ -390,6 +390,7 @@ EXTRA_DIST = \
 	test_mr.py \
 	test_msgsnarf.py \
 	test_msynctool.py \
+	test_mtr.py \
 	test_mtx.py \
 	test_munin_node_configure.py \
 	test_munin_run.py \

--- a/test/t/test_mtr.py
+++ b/test/t/test_mtr.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+class TestMtr:
+    @pytest.mark.complete("mtr ")
+    def test_basic(self, completion):
+        assert completion


### PR DESCRIPTION
https://github.com/traviscross/mtr/tree/v0.95/bash-completion

While at it, add basic test.