### PR TITLE
chore(pre-commit): avoid stage name deprecation warning

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,4 +1,4 @@
 -r ../test/requirements-dev.txt
 
 gitlint==0.19.1
-pre-commit>=2.4.0
+pre-commit>=3.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-default_stages: [commit]
-minimum_pre_commit_version: 2.4.0
+default_stages: [pre-commit]
+minimum_pre_commit_version: 3.2.0 # for "default_stages" names
 
 repos:
 


### PR DESCRIPTION
pre-commit 4.0.1 warns:

> top-level `default_stages` uses deprecated stage names (commit)
> which will be removed in a future version.

Use new names, means pre-commit >= 3.2.0 is required now.