### PR TITLE
feat(wine): complete with `*.bat` and `*.cmd`

### DIFF
--- a/completions/wine
+++ b/completions/wine
@@ -16,7 +16,7 @@ _comp_cmd_wine()
             _comp_compgen -- -W '--help --version'
             [[ ${COMPREPLY-} ]] && return
         fi
-        _comp_compgen_filedir '@([eE][xX][eE]?(.[sS][oO])|[cC][oO][mM]|[sS][cC][rR]|[mM][sS][iI])'
+        _comp_compgen_filedir '@([bB][aA][tT]|[cC][mM][dD]|[eE][xX][eE]?(.[sS][oO])|[cC][oO][mM]|[sS][cC][rR]|[mM][sS][iI])'
     else
         _comp_compgen_filedir
     fi


### PR DESCRIPTION
Closes https://github.com/scop/bash-completion/issues/1257