### PR TITLE
test(mod{probe,info}): Don't expect intel completion

### DIFF
--- a/test/t/test_modinfo.py
+++ b/test/t/test_modinfo.py
@@ -8,9 +8,9 @@ class TestModinfo:
     def test_1(self, completion):
         assert completion
 
-    # "in": intel*, ...
+    # "du": dummy, ...
     @pytest.mark.complete(
-        "modinfo in",
+        "modinfo du",
         xfail="! ls /lib/modules/%s &>/dev/null"
         % subprocess.check_output(
             "uname -r 2>/dev/null || " "echo non-existent-kernel", shell=True
@@ -21,8 +21,8 @@ class TestModinfo:
     def test_2(self, completion):
         assert completion
 
-    # "in": intel*, ...
-    @pytest.mark.complete("modinfo -k non-existent-kernel in")
+    # "du": dummy, ...
+    @pytest.mark.complete("modinfo -k non-existent-kernel du")
     def test_3(self, completion):
         assert not completion
 

--- a/test/t/test_modprobe.py
+++ b/test/t/test_modprobe.py
@@ -8,9 +8,9 @@ class TestModprobe:
     def test_1(self, completion):
         assert completion == "l"
 
-    # "in": intel*, ...
+    # "du": dummy, ...
     @pytest.mark.complete(
-        "modprobe in",
+        "modprobe du",
         xfail="! ls /lib/modules/%s &>/dev/null"
         % subprocess.check_output(
             "uname -r 2>/dev/null || " "echo non-existent-kernel", shell=True
@@ -21,8 +21,8 @@ class TestModprobe:
     def test_2(self, completion):
         assert completion
 
-    # "in": intel*, ...
-    @pytest.mark.complete("modprobe -S non-existent-kernel in")
+    # "du": dummy, ...
+    @pytest.mark.complete("modprobe -S non-existent-kernel du")
     def test_3(self, completion):
         assert not completion
 


### PR DESCRIPTION
These tests failed on WSL, which doesn't complete anything that starts with intel. I don't have a machine to test, but I expect this will also fail on arm or amd machines.

Instead, we expect it to complete "dummy", a network driver.