### PR TITLE
ci: Stop running fedoradev with seccomp=unconfined

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,25 +62,21 @@ jobs:
       # some restrictions/oddities: changes root's $HOME to /github/home
       # without changing the actual home dir that can cause some problems,
       # and does not provide a way to run with --network none.
-      # fedoradev unconfined: https://bugzilla.redhat.com/1900021
       - name: Run main build
         run: >-
           docker run
           --rm
           --tty
           --env CI=true
-          --env DIST=${{matrix.dist}}
           --env BSD=${{matrix.bsd}}
           --env PYTESTFLAGS="--verbose -p no:cacheprovider"
           --env NETWORK=$NETWORK
           ${NETWORK:+--network $NETWORK}
-          $(test $DIST = fedoradev && echo --security-opt seccomp=unconfined)
           --volume $PWD:/usr/src/bash-completion
           --workdir /usr/src/bash-completion
           ghcr.io/scop/bash-completion/test:${{matrix.dist}}
           test/docker/entrypoint.sh
         env:
-          DIST: ${{matrix.dist}}
           NETWORK: ${{matrix.network}}
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This was added as a workaround for [0], but from reading [1] it seems this is fixed when running with libseccomp >= 2.4.4, which all supported ubuntu versions since March 2021 have [2]. CI runs with ubuntu-latest which is currently ubuntu-24.04, with 2.5.5. 
[0] https://bugzilla.redhat.com/show_bug.cgi?id=1900021
[1] https://bugzilla.redhat.com/show_bug.cgi?id=1900021#c26
[2] See 20.04 changelog: https://changelogs.ubuntu.com/changelogs/pool/main/libs/libseccomp/libseccomp_2.5.1-1ubuntu1~20.04.2/changelog

This reverts d19d24a3b4d7efeb24d7e0e6c94c248149510c37