### PR TITLE
test: Remove /usr/bin/which installation

### DIFF
--- a/test/docker/centos7/Dockerfile
+++ b/test/docker/centos7/Dockerfile
@@ -9,8 +9,6 @@ RUN set -x \
         /usr/bin/autoconf \
         /usr/bin/automake \
         /usr/bin/make \
-        # /usr/bin/which: https://bugzilla.redhat.com/show_bug.cgi?id=1443357 \
-        /usr/bin/which \
         /usr/bin/xvfb-run \
         python36-pexpect
 


### PR DESCRIPTION
This was added when fedoradev still had it, in
537c9a0e9d59c699927a2eeb04d87c05a3638490, but that was dropped in 53feba31e9b49340605304258e18ff06baacaa22.