### PR TITLE
Make pytest fail when tests marked as xfail pass

### DIFF
--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -3,6 +3,7 @@ minversion = 3.6
 markers =
     bashcomp
     complete
+xfail_strict=true
 
 [mypy]
 python_version = 3.6

--- a/test/t/test_alias.py
+++ b/test/t/test_alias.py
@@ -10,7 +10,6 @@ class TestAlias:
     def test_1(self, completion):
         assert completion == "bar foo".split()
 
-    @pytest.mark.xfail  # TODO: Would like this completion to work
     @pytest.mark.complete("alias foo=")
     def test_2(self, completion):
         assert completion == "foo='bar'"

--- a/test/t/test_mkdir.py
+++ b/test/t/test_mkdir.py
@@ -10,11 +10,9 @@ class TestMkdir:
     def test_2(self, completion):
         assert completion == ["bar", "bar bar.d/", "foo", "foo.d/"]
 
-    @pytest.mark.xfail  # TODO: why path in completion, basename in .output?
     @pytest.mark.complete("mkdir shared/default/foo.d/")
     def test_3(self, completion):
-        assert completion.output == "foo"
-        assert completion == [completion.output]
+        assert completion == ["foo"]
 
     @pytest.mark.complete("mkdir -", require_longopt=True)
     def test_options(self, completion):

--- a/test/t/unit/test_unit_compgen_filedir.py
+++ b/test/t/unit/test_unit_compgen_filedir.py
@@ -230,7 +230,6 @@ class TestUnitCompgenFiledir:
         )
         assert completion == 'h"'
 
-    @pytest.mark.xfail(reason="TODO: non-ASCII issues with test suite?")
     @pytest.mark.parametrize("funcname", "f f2".split())
     def test_27(self, bash, functions, funcname, utf8_ctype):
         completion = assert_complete(bash, "%s aé/" % funcname, cwd="_filedir")

--- a/test/t/unit/test_unit_compgen_ip_addresses.py
+++ b/test/t/unit/test_unit_compgen_ip_addresses.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import assert_bash_exec, in_container
+from conftest import assert_bash_exec
 
 
 @pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+COMPREPLY=")
@@ -41,7 +41,6 @@ class TestUnitCompgenIpAddresses:
         assert completion
         assert all("." in x for x in completion)
 
-    @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
     @pytest.mark.complete("ia6 ")
     def test_4(self, functions, completion):
         """_comp_compgen_ip_addresses -6 should complete ipv6 addresses."""

--- a/test/t/unit/test_unit_get_cword.py
+++ b/test/t/unit/test_unit_get_cword.py
@@ -140,7 +140,6 @@ class TestUnitGetCword(TestUnitBase):
         output = self._test(bash, '(a "\'b&c")', 1, "a 'b&c", 6)
         assert output == "'b&c"
 
-    @pytest.mark.xfail(reason="TODO: non-ASCII issues with test suite?")
     def test_24(self, bash):
         """Index shouldn't drop below 0"""
         bash.send("scp ääää§ se\t\r\n")


### PR DESCRIPTION
There are currently six tests that "xpass" (at least in a recent job I checked). All of them pass correctly locally for me as well.
This removes the specific xfail markers for the passing tests and sets `xfail_strict` to true so CI will fail if any other ones will succeed by accident.

More info about xfails vs xpasses: https://docs.pytest.org/en/stable/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail

This is split into 3 commits for different parts of this, the first one just includes some cleanup of test_mkdir.py as well as xfail removal.