### PR TITLE
build: Include OS specific completions in tarball

### DIFF
--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -799,6 +799,8 @@ CLEANFILES = \
 	ping4 \
 	ping6 \
 	_pip3 \
+	pkg_deinstall \
+	pkg_info \
 	pkgconf \
 	pkill \
 	plzip \

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -1,5 +1,4 @@
-bashcompdir = $(datadir)/$(PACKAGE)/completions
-bashcomp_DATA = 2to3 \
+cross_platform = 2to3 \
 		7z \
 		a2x \
 		abook \
@@ -501,27 +500,37 @@ bashcomp_DATA = 2to3 \
 		zopfli \
 		zopflipng
 
+solaris_extra = pkgutil
 
-if SOLARIS
-bashcomp_DATA += pkgutil
-endif
+bsd_extra = pkg_delete
 
-if BSD
-bashcomp_DATA += pkg_delete
-endif
-
-if FREEBSD
-bashcomp_DATA += \
+freebsd_extra = \
 		freebsd-update \
 		kldload \
 		kldunload \
 		portinstall \
 		portsnap \
 		portupgrade
+
+# We include all the files in the tarball
+EXTRA_DIST = $(cross_platform) \
+	     $(solaris_extra) \
+	     $(bsd_extra) \
+	     $(freebsd_extra)
+
+bashcompdir = $(datadir)/$(PACKAGE)/completions
+bashcomp_DATA = $(cross_platform)
+# We add only the completions that are relevant for the current platform we're
+# installing on.
+if SOLARIS
+bashcomp_DATA += $(solaris_extra)
 endif
-
-
-EXTRA_DIST = $(bashcomp_DATA)
+if BSD
+bashcomp_DATA += $(bsd_extra)
+endif
+if FREEBSD
+bashcomp_DATA += $(freebsd_extra)
+endif
 
 CLEANFILES = \
 	7za \

--- a/configure.ac
+++ b/configure.ac
@@ -14,23 +14,23 @@ fi
 
 AC_CANONICAL_HOST
 
-build_bsd=
-build_freebsd=
-build_solaris=
+install_bsd=
+install_freebsd=
+install_solaris=
 case ${host_os} in
     *bsd*)
-        build_bsd=yes
+        install_bsd=yes
         case ${host_os} in
             *freebsd*)
-                build_freebsd=yes ;;
+                install_freebsd=yes ;;
         esac ;;
     *solaris*)
-        build_solaris=yes ;;
+        install_solaris=yes ;;
 esac
 
-AM_CONDITIONAL([BSD], [test "${build_bsd}" = yes])
-AM_CONDITIONAL([FREEBSD], [test "${build_freebsd}" = yes])
-AM_CONDITIONAL([SOLARIS], [test "${build_solaris}" = yes])
+AM_CONDITIONAL([BSD], [test "${install_bsd}" = yes])
+AM_CONDITIONAL([FREEBSD], [test "${install_freebsd}" = yes])
+AM_CONDITIONAL([SOLARIS], [test "${install_solaris}" = yes])
 
 AC_CONFIG_FILES([
 Makefile


### PR DESCRIPTION
This should fix https://github.com/scop/bash-completion/issues/1282, although still doesn't deal with the issue of including tests for them or not.

I will love if people who actually know Makefile/autotools will look at this :)
I'm not really sure about the variables naming, open for suggestions.