### PR TITLE
comp_compgen: option -C no longer checks if OPTARG is empty

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -594,13 +594,7 @@ _comp_compgen()
                 ;;
             c) _cur=$OPTARG ;;
             R) _cur="" ;;
-            C)
-                if [[ ! $OPTARG ]]; then
-                    printf 'bash_completion: %s: -C: invalid directory name `%s'\''\n' "$FUNCNAME" "$OPTARG" >&2
-                    return 2
-                fi
-                _dir=$OPTARG
-                ;;
+            C) _dir=$OPTARG ;;
             l) _has_ifs=set _ifs=$'\n' ;;
             F) _has_ifs=set _ifs=$OPTARG ;;
             [ix])


### PR DESCRIPTION
The `-C` option in _comp_compgen, similar to the `-P` option in bash's compgen, should support passing an empty string, for example: `compgen -P ""-f`

fix https://github.com/scop/bash-completion/issues/1260