### PR TITLE
test(mtr): add fallback completion symlink

### DIFF
--- a/test/fallback/completions/Makefile.am
+++ b/test/fallback/completions/Makefile.am
@@ -26,6 +26,7 @@ EXTRA_DIST = \
 	modprobe \
 	mount \
 	mount.linux \
+	mtr \
 	newgrp \
 	nmcli \
 	nox \

--- a/test/fallback/completions/mtr
+++ b/test/fallback/completions/mtr
@@ -1,0 +1,1 @@
+../../../completions/_mtr


### PR DESCRIPTION
Missed from 231a39d428c5a76b0fd02faf0ee0bbb3cf9f17c1.