### PR TITLE
ci(release-please): switch to googleapis/release-please-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           - dist: ubuntu14
     steps:
       - uses: actions/checkout@v4
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json


### PR DESCRIPTION
google-github-actions/release-please-action is deprecated and archived.