### PR TITLE
fix(brctl): fix quoting of the command name

### DIFF
--- a/completions/brctl
+++ b/completions/brctl
@@ -2,8 +2,10 @@
 
 _comp_cmd_brctl__interfaces()
 {
-    _comp_compgen_split -- "$(${1:-brctl} show ${2:+"$2"} 2>/dev/null | _comp_awk \
-        '(NR == 1) { next }; (/^\t/) { print $1; next }; { print $4 }')"
+    _comp_compgen_split -- "$(
+        "${1:-brctl}" show ${2:+"$2"} 2>/dev/null | _comp_awk \
+            '(NR == 1) { next }; (/^\t/) { print $1; next }; { print $4 }'
+    )"
 }
 
 _comp_cmd_brctl()


### PR DESCRIPTION
I had a "pending" review in #866 that I forgot to submit. This is a trivial fix, so let me just submit it here for the CI checking. If the test passes, I will soon merge. This quotes the command name `${1:-brctl}` as `"${1:-brctl}"`. This also changes the line folding because the line does not fit within 79 columns.