### PR TITLE
fix(_umount,feh,sbopkg): check diretory name for `_comp_compgen -C`

### DIFF
--- a/completions/_umount.linux
+++ b/completions/_umount.linux
@@ -72,7 +72,7 @@ _comp_cmd_umount__linux_fstab()
             realcur="$(readlink -f "$cur." 2>/dev/null)/" ||
             realcur=$(readlink -f "$cur" 2>/dev/null)
         if [[ $realcur ]]; then
-            local dirrealcur="" dircur="" basecur
+            local dirrealcur="" dircur=. basecur
             if [[ $cur == */* ]]; then
                 dirrealcur="${realcur%/*}/"
                 dircur="${cur%/*}/"

--- a/completions/feh
+++ b/completions/feh
@@ -33,8 +33,10 @@ _comp_cmd_feh()
             for ((i = ${#words[@]} - 2; i > 0; i--)); do
                 if [[ ${words[i]} == -@(C|-fontpath) ]]; then
                     font_path="${words[i + 1]}"
-                    _comp_compgen -aC "$font_path" -- \
-                        -f -X "!*.@([tT][tT][fF])" -S /
+                    if [[ -d $font_path ]]; then
+                        _comp_compgen -aC "$font_path" -- \
+                            -f -X "!*.@([tT][tT][fF])" -S /
+                    fi
                 fi
             done
             compopt -o nospace

--- a/completions/feh
+++ b/completions/feh
@@ -30,7 +30,7 @@ _comp_cmd_feh()
             local font_path
             # font_path="$(imlib2-config --prefix 2>/dev/null)/share/imlib2/data/fonts"
             # _comp_compgen -C "$font_path" -- -f -X "!*.@([tT][tT][fF])" -S /
-            for ((i = ${#words[@]} - 1; i > 0; i--)); do
+            for ((i = ${#words[@]} - 2; i > 0; i--)); do
                 if [[ ${words[i]} == -@(C|-fontpath) ]]; then
                     font_path="${words[i + 1]}"
                     _comp_compgen -aC "$font_path" -- \

--- a/completions/sbopkg
+++ b/completions/sbopkg
@@ -63,7 +63,9 @@ _comp_cmd_sbopkg()
 
     _comp_compgen_split -l -- "$(command sed -ne "s/^SLACKBUILD NAME: //p" \
         "$file")"
-    _comp_compgen -aC "$QUEUEDIR" -- -f -X "!*.sqf"
+    if [[ -d ${QUEUEDIR-} ]]; then
+        _comp_compgen -aC "$QUEUEDIR" -- -f -X "!*.sqf"
+    fi
 } &&
     complete -F _comp_cmd_sbopkg sbopkg
 


### PR DESCRIPTION
Fixes #1260

This is an alternative fix to #1290. The fix suggested in #1290 was just to remove the error message, which I believe is not the right fix. This PR fixes it by checking the arguments at the caller side.

This includes an additional fix e9e665efd7623dd9ec6d72c25c5797c497d58f65 for `feh`. In the current `main` branch, an error message is printed on the TAB completion with the following command line:

```console
$ set -u
$ feh --font x[TAB] --fontpath
bash: words[i + 1]: unbound variable
```



