### PR TITLE
chore(mfiutil): clean up and ignore mrsasutil symlink

### DIFF
--- a/completions/.gitignore
+++ b/completions/.gitignore
@@ -277,6 +277,7 @@
 /montage
 /mozilla-firefox
 /mplayer2
+/mrsasutil
 /msgsnarf
 /_multi-gitter
 /muttng

--- a/completions/Makefile.am
+++ b/completions/Makefile.am
@@ -861,6 +861,7 @@ CLEANFILES = \
 	montage \
 	mozilla-firefox \
 	mplayer2 \
+	mrsasutil \
 	msgsnarf \
 	_multi-gitter \
 	muttng \


### PR DESCRIPTION
Missed from https://github.com/scop/bash-completion/pull/1241