### PR TITLE
chore(perlcritic): Update perlcritic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         files: ^(helpers/perl|.+\.p[ml])$
 
   - repo: https://github.com/scop/pre-commit-perlcritic
-    rev: v1.144-1
+    rev: v1.156-1
     hooks:
       - id: perlcritic
         args: [--quiet, --verbose, "5"]


### PR DESCRIPTION
pre-commit CI runs started failing on the perlcritic step, so update to the last version of the perlcritic pre-commit hook, corresponding to perlcritic v1.156

It will be preferable to make renovate update this, but I'm not sure why it doesn't do it. Any thoughts @scop @akinomyoga ?