### PR TITLE
fix(ip): Don't offer neighbour, only neighbor

### DIFF
--- a/completions/ip
+++ b/completions/ip
@@ -106,8 +106,9 @@ _comp_cmd_ip()
                         '/OBJECT := /,/}/!d' -e \
                         's/.*{//' -e \
                         's/}.*//' -e \
-                        's/|//g'
-                )"
+                        's/|//g' -e \
+                        's/neighbour/neighbor/g'
+                )" # We remove "neighbour" to only leave one option when completing `ip neig`
                 ;;
         esac
         return

--- a/test/t/test_ip.py
+++ b/test/t/test_ip.py
@@ -32,6 +32,14 @@ class TestIp:
         assert "stale" in completion
 
     @pytest.mark.complete(
+        "ip neig",
+        require_cmd=True,
+        skipif="ip neighbor help 2>/dev/null; (( $? != 255 ))",
+    )
+    def test_neigh_one_completion(self, completion):
+        assert len(completion) == 1
+
+    @pytest.mark.complete(
         "ip monitor ",
         require_cmd=True,
         skipif="ip monitor help 2>/dev/null; (( $? != 255 ))",


### PR DESCRIPTION
The previous state led to `ip neigh<TAB>` leading to this:
```
$ ip neighbo
neighbor   neighbour
```
choosing one to complete removes the need to choose between options that do the same thing, aligning with the CONTRIBUTING.md guidelines.

I chose `neighbor` because it's shorter, but it can be changed if someone wants to.