### PR TITLE
WIP: Support more bind9 utilities

### DIFF
--- a/completions/bind9
+++ b/completions/bind9
@@ -1,0 +1,205 @@
+# bash completion for nslookup                             -*- shell-script -*-
+# bind9 utilities completion
+
+_comp_cmd_rndc__list_commands()
+{
+	rndc 2>&1 | awk '/^  / {print $1}' | sort -u
+}
+
+_comp_cmd_rndc__list_parameters()
+{
+	local SUBCMD=$1
+	rndc 2>&1 | awk "/^  ${SUBCMD} / { print \$2 }"
+	if [[ $cur == @* ]]; then
+		_comp_compgen_known_hosts -- "$cur"
+		return
+	fi
+
+}
+
+# TODO: not used yet, useful for dnssec-signzone etc.
+_comp_cmd_named_checkconf__list_zones()
+{
+	named-checkconf -l | awk '{print $1}'
+}
+
+# TODO: named-rrchecker provides -T -C listings of supported query types.
+# should replace _comp_cmd_nslookup__queryclass, _comp_cmd_nslookup__querytype
+# when command is present.
+
+_comp_cmd_rndc()
+{
+	local cur prev words cword comp_args
+	_comp_initialize -n = -- "$@" || return
+
+	case $prev in
+		-c|-k)
+			_comp_compgen -a filedir
+			return
+			;;
+	esac
+
+	local REPLY
+	_comp_count_args
+	if [[ $cur == -* ]]; then
+		_comp_compgen_usage
+		return
+	fi
+	if ((REPLY == 1)); then
+		_comp_compgen -- -W "$(_comp_cmd_rndc__list_commands)"
+	fi
+	if ((REPLY == 2)); then
+		_comp_compgen -- -W "$(_comp_cmd_rndc__list_parameters $prev)"
+	fi
+} && complete -F _comp_cmd_rndc rndc
+
+_comp_cmd_dig__list_plusopts()
+{
+	local CMD=${1:-dig} # delv and mdig has similar style options
+	$CMD -h 2>&1 | awk '/^\s+\+\[no\]/ { sub("+\\[no\\]", "", $1); sub("=##+$", "=", $1); sub("\\[=##+\\]", "", $1); print "+"$1, "+no"$1} /^\s+\+[^[]/ {sub("=##+", "=", $1); print $1}'
+}
+
+_comp_cmd_dig()
+{
+	local cur prev words cword comp_args
+	_comp_initialize -n = -- "$@" || return
+
+	case $prev in
+		-c)
+			_comp_cmd_nslookup__queryclass
+			return
+			;;
+		-t)
+			_comp_cmd_nslookup__querytype
+			return
+			;;
+		-q)
+			_comp_compgen_known_hosts -- "$cur"
+			return
+			;;
+		-k|-f)
+			_comp_compgen -a filedir
+			return
+			;;
+		-x|-b)
+			_comp_compgen_ip_addresses -- "$cur"
+			return
+			;;
+	esac
+
+	if [[ $cur == @* ]]; then
+		_comp_compgen_known_hosts -- "$cur"
+		return
+	fi
+	if [[ $cur == -* ]]; then
+		_comp_compgen_usage
+		return
+	fi
+	if [[ $cur == +* ]]; then
+		_comp_compgen -- -W "$(_comp_cmd_dig__list_plusopts dig)"
+		[[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+
+	fi
+
+	# TODO: dig is tricky. It can accept hostname, queryclass or querytype without any parameter.
+	# Not sure how to autocomplete all of them.
+	_comp_compgen_known_hosts -- "$cur"
+} && complete -F _comp_cmd_dig dig
+
+_comp_cmd_mdig()
+{
+	local cur prev words cword comp_args
+	_comp_initialize -n = -- "$@" || return
+
+	case $prev in
+		-c)
+			_comp_cmd_nslookup__queryclass
+			return
+			;;
+		-t)
+			_comp_cmd_nslookup__querytype
+			return
+			;;
+		-q)
+			_comp_compgen_known_hosts -- "$cur"
+			return
+			;;
+		-f)
+			_comp_compgen -a filedir
+			return
+			;;
+		-x|-b)
+			_comp_compgen_ip_addresses -- "$cur"
+			return
+			;;
+	esac
+
+	if [[ $cur == -* ]]; then
+		_comp_compgen_usage
+		return
+	fi
+	if [[ $cur == @* ]]; then
+		_comp_compgen_known_hosts -- "$cur"
+		return
+	fi
+
+	if [[ $cur == +* ]]; then
+		_comp_compgen -- -W "$(_comp_cmd_dig__list_plusopts mdig)"
+		[[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+
+	fi
+
+	# TODO: dig is tricky. It can accept hostname, queryclass or querytype without any parameter.
+	# Not sure how to autocomplete all of them.
+	_comp_compgen_known_hosts -- "$cur"
+} && complete -F _comp_cmd_mdig mdig
+
+_comp_cmd_delv()
+{
+	local cur prev words cword comp_args
+	_comp_initialize -n = -- "$@" || return
+
+	case $prev in
+		-c)
+			_comp_cmd_nslookup__queryclass
+			return
+			;;
+		-t)
+			_comp_cmd_nslookup__querytype
+			return
+			;;
+		-q)
+			_comp_compgen_known_hosts -- "$cur"
+			return
+			;;
+		-a)
+			_comp_compgen -a filedir
+			return
+			;;
+		-x|-b)
+			_comp_compgen_ip_addresses -- "$cur"
+			return
+			;;
+	esac
+
+	if [[ $cur == -* ]]; then
+		_comp_compgen_usage
+		return
+	fi
+	if [[ $cur == @* ]]; then
+		_comp_compgen_known_hosts -- "$cur"
+		return
+	fi
+
+	if [[ $cur == +* ]]; then
+		_comp_compgen -- -W "$(_comp_cmd_dig__list_plusopts delv)"
+		[[ ${COMPREPLY-} == *= ]] && compopt -o nospace
+
+	fi
+
+	# TODO: dig is tricky. It can accept hostname, queryclass or querytype without any parameter.
+	# Not sure how to autocomplete all of them.
+	_comp_compgen_known_hosts -- "$cur"
+} && complete -F _comp_cmd_delv delv
+
+# ex: filetype=sh


### PR DESCRIPTION
host and nslookup are already supported. But dig is not, similarly with delv and others.