### PR TITLE
feat(openssl): openssl list -commands, not help

### DIFF
--- a/completions/openssl
+++ b/completions/openssl
@@ -46,7 +46,7 @@ _comp_cmd_openssl()
 
     if ((cword == 1)); then
         local commands
-        commands="$("$1" help 2>&1 | command sed -e '/commands\|help:/d')"
+        commands="$("$1" list -commands)"
         _comp_compgen -- -W "$commands"
     else
         command=${words[1]}

--- a/test/t/test_openssl.py
+++ b/test/t/test_openssl.py
@@ -5,9 +5,7 @@ class TestOpenssl:
     @pytest.mark.complete("openssl ", require_cmd=True)
     def test_1(self, completion):
         assert completion
-        assert all(
-            x in completion for x in "md5 x509 aes-128-cbc dgst pkey".split()
-        )
+        assert all(x in completion for x in "x509 dgst pkey enc".split())
 
     @pytest.mark.complete("openssl pkey -cipher ", require_cmd=True)
     def test_2(self, completion):


### PR DESCRIPTION
In https://github.com/scop/bash-completion/pull/1256 we started parsing the help output. Get the list instead from the `openssl list -commands` command.

This also stops completing the encryption and digest algorithms, since those are usually used with the `enc` and `dgst` subcommands.

Suggested-By: Michael Newton
Fixes: https://github.com/scop/bash-completion/issues/1324