### PR TITLE
openssl: Fix completions for MacOS, don't complete algorithms as subcommands

### DIFF
--- a/completions/openssl
+++ b/completions/openssl
@@ -111,6 +111,11 @@ _comp_cmd_openssl()
                 dgst | req | x509)
                     _comp_compgen -a -i openssl digests "$1"
                     ;;
+                enc)
+                    # The -list option was added in openssl 1.1.1e, so we ignore the error here.
+                    # We do get some of the ciphers "by accident", since some are detected in the help output.
+                    _comp_compgen -a split -- "$("$1" enc -list 2>/dev/null | command sed '/Supported ciphers:/d')"
+                    ;;
             esac
         else
             if [[ $command == speed ]]; then

--- a/completions/openssl
+++ b/completions/openssl
@@ -46,7 +46,8 @@ _comp_cmd_openssl()
 
     if ((cword == 1)); then
         local commands
-        commands="$("$1" help 2>&1 | command sed -e '/commands\|help:/d')"
+        # We only want the standard commands, so we delete everything starting after and including "Message Digest commands"
+        commands="$("$1" help 2>&1 | command sed -e '/Standard commands/d;/help:/d' -e '/Message Digest commands/,$d')"
         _comp_compgen -- -W "$commands"
     else
         command=${words[1]}

--- a/test/t/test_openssl.py
+++ b/test/t/test_openssl.py
@@ -5,9 +5,7 @@ class TestOpenssl:
     @pytest.mark.complete("openssl ", require_cmd=True)
     def test_1(self, completion):
         assert completion
-        assert all(
-            x in completion for x in "md5 x509 aes-128-cbc dgst pkey".split()
-        )
+        assert all(x in completion for x in "x509 dgst enc pkey".split())
 
     @pytest.mark.complete("openssl pkey -cipher ", require_cmd=True)
     def test_2(self, completion):

--- a/test/t/test_openssl.py
+++ b/test/t/test_openssl.py
@@ -15,3 +15,8 @@ class TestOpenssl:
     def test_3(self, completion):
         assert completion
         assert any(x.startswith("-sha") for x in completion)
+
+    @pytest.mark.complete("openssl enc -a", require_cmd=True)
+    def test_4(self, completion):
+        assert completion
+        assert any(x.startswith("-aes") for x in completion)


### PR DESCRIPTION
This should fix https://github.com/scop/bash-completion/issues/1324

This replaces https://github.com/scop/bash-completion/pull/1325, which doesn't work on some openssl versions