### PR TITLE
support Android  app bundles as 'unzip' file type (XAPK/APKM/APKS)

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -3153,7 +3153,7 @@ _comp__init_install_xspec()
 }
 # bzcmp, bzdiff, bz*grep, bzless, bzmore intentionally not here, see Debian: #455510
 _comp__init_install_xspec '!*.?(t)bz?(2)' bunzip2 bzcat pbunzip2 pbzcat lbunzip2 lbzcat
-_comp__init_install_xspec '!*.@(zip|[aegjkswx]ar|exe|pk3|wsz|zargo|xpi|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|cbz|apk|aab|ipa|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|vsix|whl|[Ff][Cc][Ss]td)' unzip zipinfo
+_comp__init_install_xspec '!*.@(zip|[aegjkswx]ar|exe|pk3|wsz|zargo|xpi|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|cbz|apk|apk[ms]|aab|xapk|ipa|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|vsix|whl|[Ff][Cc][Ss]td)' unzip zipinfo
 _comp__init_install_xspec '*.Z' compress znew
 # zcmp, zdiff, z*grep, zless, zmore intentionally not here, see Debian: #455510
 _comp__init_install_xspec '!*.@(Z|[gGd]z|t[ag]z)' gunzip zcat


### PR DESCRIPTION
XAPK/APKM/APKS are all ZIP containers for shipping Android apps.

* APKS https://developer.android.com/tools/bundletool#generate_apks
* XAPK https://openxapkfile.net/structure.html
* APKM https://fileinfo.com/extension/apkm