### PR TITLE
lvm: improve completions for `lvremove`

### DIFF
--- a/completions/lvm
+++ b/completions/lvm
@@ -33,6 +33,8 @@ _comp_cmd_lvm__logicalvolumes()
         for i in "${!COMPREPLY[@]}"; do
             [[ ${COMPREPLY[i]} == */control ]] && unset -v 'COMPREPLY[i]'
         done
+    elif [[ $cur == /d* ]]; then
+	    COMPREPLY+="/dev/mapper"
     fi
 }
 


### PR DESCRIPTION
It should have a completion for `/dev/mapper` path.