### PR TITLE
feat(rpm): rpmbuild short rebuild options

### DIFF
--- a/completions/rpm
+++ b/completions/rpm
@@ -309,7 +309,7 @@ _comp_cmd_rpmbuild()
                 ext='@(t?(ar.)@([gx]z|bz?(2))|tar?(.@(lzma|Z)))'
                 break
                 ;;
-            --rebuild | --recompile)
+            -r? | --rebuild | --recompile)
                 ext='@(?(no)src.r|s)pm'
                 break
                 ;;


### PR DESCRIPTION
While the `--rebuild` option isn't deprecated, [the man page now notes that the `-r?` options supersede it](https://www.man7.org/linux/man-pages/man8/rpmbuild.8.html).

Treats `-r?` as equivalent to `--rebuild` for determining which extensions to complete