### PR TITLE
fix(cd): generate only cdable_vars containing valid directory paths

### DIFF
--- a/completions/cd
+++ b/completions/cd
@@ -1,5 +1,12 @@
 # cd(1) completion                                         -*- shell-script -*-
 
+_comp_cmd_cd__compgen_cdable_vars()
+{
+    shopt -q cdable_vars || return 1
+
+    _comp_compgen -- -v
+}
+
 # This generator function observes the CDPATH variable, to additionally
 # complete directories under those specified in CDPATH.
 _comp_cmd_cd__compgen_cdpath()
@@ -53,11 +60,8 @@ _comp_cmd_cd()
     fi
 
     compopt -o filenames
+    _comp_cmd_cd__compgen_cdable_vars
     _comp_cmd_cd__compgen_cdpath
     _comp_compgen -a filedir -d
 }
-if shopt -q cdable_vars; then
-    complete -v -F _comp_cmd_cd -o nospace cd pushd
-else
-    complete -F _comp_cmd_cd -o nospace cd pushd
-fi
+complete -F _comp_cmd_cd -o nospace cd pushd

--- a/completions/cd
+++ b/completions/cd
@@ -1,7 +1,46 @@
 # cd(1) completion                                         -*- shell-script -*-
 
-# This meta-cd function observes the CDPATH variable, so that `cd`
-# additionally completes on directories under those specified in CDPATH.
+# This generator function observes the CDPATH variable, to additionally
+# complete directories under those specified in CDPATH.
+_comp_cmd_cd__compgen_cdpath()
+{
+    local _p
+
+    # Generate CDPATH completions when the parameter does not start with /,
+    # ./ or ../
+    [[ ! ${CDPATH-} || $cur == ?(.)?(.)/* ]] && return 1
+
+    local _mark_dirs="" _mark_symdirs=""
+    _comp_readline_variable_on mark-directories && _mark_dirs=set
+    _comp_readline_variable_on mark-symlinked-directories && _mark_symdirs=set
+
+    local -a _cdpaths=()
+
+    # we have a CDPATH, so loop on its contents
+    local paths dirs _d
+    _comp_split -F : paths "$CDPATH"
+    for _p in "${paths[@]}"; do
+        # create an array of matched subdirs
+        _comp_compgen -v dirs -c "$_p/$cur" -- -d
+        for _d in "${dirs[@]}"; do
+            if [[ ($_mark_symdirs && -L $_d || $_mark_dirs && ! -L $_d) && ! -d ${_d#"$_p/"} ]]; then
+                _d+="/"
+            fi
+            _cdpaths+=("${_d#"$_p/"}")
+        done
+    done
+    _comp_unlocal paths dirs
+
+    if ((${#_cdpaths[@]} == 1)); then
+        _p=${_cdpaths[0]}
+        if [[ $_p == "$cur" && $_p != */ ]]; then
+            _cdpaths[0]=$_p/
+        fi
+    fi
+
+    _comp_compgen_set "${_cdpaths[@]}"
+}
+
 _comp_cmd_cd()
 {
     local cur prev words cword comp_args
@@ -13,44 +52,9 @@ _comp_cmd_cd()
         return
     fi
 
-    local i j k
-
     compopt -o filenames
-
-    # Use standard dir completion if no CDPATH or parameter starts with /,
-    # ./ or ../
-    if [[ ! ${CDPATH-} || $cur == ?(.)?(.)/* ]]; then
-        _comp_compgen_filedir -d
-        return
-    fi
-
-    local mark_dirs="" mark_symdirs=""
-    _comp_readline_variable_on mark-directories && mark_dirs=set
-    _comp_readline_variable_on mark-symlinked-directories && mark_symdirs=set
-
-    # we have a CDPATH, so loop on its contents
-    local paths dirs
-    _comp_split -F : paths "$CDPATH"
-    for i in "${paths[@]}"; do
-        # create an array of matched subdirs
-        k=${#COMPREPLY[@]}
-        _comp_compgen -v dirs -c "$i/$cur" -- -d
-        for j in "${dirs[@]}"; do
-            if [[ ($mark_symdirs && -L $j || $mark_dirs && ! -L $j) && ! -d ${j#"$i/"} ]]; then
-                j+="/"
-            fi
-            COMPREPLY[k++]=${j#"$i/"}
-        done
-    done
-
+    _comp_cmd_cd__compgen_cdpath
     _comp_compgen -a filedir -d
-
-    if ((${#COMPREPLY[@]} == 1)); then
-        i=${COMPREPLY[0]}
-        if [[ $i == "$cur" && $i != */ ]]; then
-            COMPREPLY[0]="${i}/"
-        fi
-    fi
 }
 if shopt -q cdable_vars; then
     complete -v -F _comp_cmd_cd -o nospace cd pushd

--- a/completions/cd
+++ b/completions/cd
@@ -4,7 +4,18 @@ _comp_cmd_cd__compgen_cdable_vars()
 {
     shopt -q cdable_vars || return 1
 
-    _comp_compgen -- -v
+    local vars
+    _comp_compgen -v vars -- -v || return "$?"
+
+    # Remove variables that do not contain a valid directory path.
+    local _i
+    for _i in "${!vars[@]}"; do
+        # Note: ${!vars[_i]} produces the "nounset" error when vars[_i] is an
+        # empty array name.
+        [[ -d ${!vars[_i]-} ]] || unset -v 'vars[_i]'
+    done
+
+    _comp_compgen -U vars set "${vars[@]}"
 }
 
 # This generator function observes the CDPATH variable, to additionally

--- a/completions/cd
+++ b/completions/cd
@@ -47,7 +47,7 @@ _comp_cmd_cd()
 
     if ((${#COMPREPLY[@]} == 1)); then
         i=${COMPREPLY[0]}
-        if [[ $i == "$cur" && $i != "*/" ]]; then
+        if [[ $i == "$cur" && $i != */ ]]; then
             COMPREPLY[0]="${i}/"
         fi
     fi

--- a/test/t/test_cd.py
+++ b/test/t/test_cd.py
@@ -1,5 +1,7 @@
 import pytest
 
+from conftest import assert_complete, bash_env_saved
+
 
 @pytest.mark.bashcomp(ignore_env=r"^\+CDPATH=$")
 class TestCd:
@@ -28,3 +30,15 @@ class TestCd:
     @pytest.mark.complete("cd -")
     def test_options(self, completion):
         assert completion
+
+    def test_cdable_vars(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.shopt("cdable_vars", True)
+            bash_env.write_variable("foo1", "shared")
+            bash_env.write_variable("foo2", "shared/default")
+            bash_env.write_variable("foo3", "nonexistent")
+            bash_env.write_variable("foo4", "nonexistent")
+            bash_env.write_variable("foo5", "shared/default/foo")
+            bash_env.write_variable("foo6", "shared/default/bar")
+            completion = assert_complete(bash, "cd f")
+            assert completion == ["foo1", "foo2"]


### PR DESCRIPTION
When `shopt -s cdable_vars` is set, all the variable names are generated as completions. For example, in my environment,

```console
$ shopt -s cdable_vars
$ cd [TAB][TAB]
Display all 177 possibilities? (y or n)
_                               bleopt_connect_tty              CPLUS_INCLUDE_PATH              GUESTFISH_PS1                   MAIL                            prefix                          test/
_append                         BLE_SESSION_ID                  _cur                            GUESTFISH_RESTORE               MAILCHECK                       prev                            test2/
archive/                        _ble_util_fdlist_cloexec        cur                             _has_ifs                        MANPATH                         PS1                             TEXMFHOME
autom4te.cache/                 _ble_util_fdvars_export         CVS_RSH                         helpers/                        MODULEPATH                      PS2                             TIME_STYLE
_backup_glob                    CARGO_HOME                      cword                           HISTCMD                         MODULES_CMD                     PS4                             UID
base                            CARGO_PROFILE_RELEASE_LTO       DBUS_SESSION_BUS_ADDRESS        HISTCONTROL                     MODULESHOME                     PWD                             _upvars
BASH                            C_INCLUDE_PATH                  DEBUGINFOD_IMA_CERT_PATH        HISTFILE                        __MODULES_LMINIT                .pytest_cache/                  USER
BASH_ALIASES                    COLUMNS                         DEBUGINFOD_URLS                 HISTFILESIZE                    MODULES_RUN_QUARANTINE          RANDOM                          _var
BASH_ARGC                       comp_args                       _dir                            HISTSIZE                        __MODULES_SHARE_MANPATH         READLINE_LINE                   venv/
BASH_ARGV                       compatdir                       DIRSTACK                        HOME                            MOTD_SHOWN                      READLINE_POINT                  VIRTUAL_ENV
BASH_ARGV0                      _comp_backup_glob               DISPLAY                         HOSTNAME                        MOZ_GMP_PATH                    _result                         VIRTUAL_ENV_PROMPT
BASH_CMDS                       _comp__base_directory           doc/                            HOSTTYPE                        MWGDIR                          .ruff_cache/                    wiki/
BASH_COMMAND                    COMP_CWORD                      EPOCHREALTIME                   _icmd                           MWG_LOGINTERM                   SECONDS                         WINDOW
BASH_COMPLETION_COMPAT_DIR      _comp_dequote__regex_safe_word  EPOCHSECONDS                    _ifs                            .mypy_cache/                    SHELL                           words
bash_completion.d/              COMP_FILEDIR_FALLBACK           EUID                            IFS                             old/                            SHELLOPTS                       work/
BASH_COMPLETION_VERSINFO        COMP_KEY                        ext/                            KDEDIRS                         _old_nocasematch                SHLVL                           _xcmd
BASH_LINENO                     COMP_KNOWN_HOSTS_WITH_AVAHI     FUNCNAME                        LANG                            OLDPWD                          SOURCE_HIGHLIGHT_DATADIR        XDG_DATA_DIRS
BASH_LOADABLES_PATH             COMP_KNOWN_HOSTS_WITH_HOSTFILE  GCC_COLORS                      LD_LIBRARY_PATH                 _opt                            SRANDOM                         XDG_RUNTIME_DIR
BASH_MONOSECONDS                completions/                    .git/                           LESSOPEN                        OPTERR                          SSH_ASKPASS                     XDG_SESSION_CLASS
BASHOPTS                        COMP_LINE                       .git.20220224/                  LIBRARY_PATH                    OPTIND                          SSH_CLIENT                      XDG_SESSION_ID
BASHPID                         COMP_POINT                      .github/                        LINENO                          OSTYPE                          SSH_CONNECTION                  XDG_SESSION_TYPE
BASH_REMATCH                    COMPREPLY                       GOPATH                          LINES                           patches/                        SSH_TTY
BASH_SOURCE                     COMP_TYPE                       GPG_TTY                         LOADEDMODULES                   PATH                            STY
BASH_SUBSHELL                   COMP_WORDBREAKS                 GROUPS                          LOGNAME                         PIPESTATUS                      t/
BASH_VERSINFO                   COMP_WORDS                      GUESTFISH_INIT                  LS_COLORS                       PKG_CONFIG_PATH                 TERM
BASH_VERSION                    _comp_xspecs                    GUESTFISH_OUTPUT                MACHTYPE                        PPID                            TERMCAP
```

However, most of them do not contain valid directory names, so they  do not work even if they are specified to the argument of `cd`. In this PR, I try to filter only the variables that contain a valid directory path. After this change, the above result is changed to the following:

```console
$ cd
archive/                    CARGO_HOME                  doc/                        GOPATH                      MOZ_GMP_PATH                patches/                    t/                          VIRTUAL_ENV
autom4te.cache/             compatdir                   ext/                        helpers/                    MWGDIR                      PWD                         test/                       VIRTUAL_ENV_PROMPT
base                        _comp__base_directory       .git/                       HOME                        .mypy_cache/                .pytest_cache/              test2/                      wiki/
BASH_COMPLETION_COMPAT_DIR  completions/                .git.20220224/              KDEDIRS                     old/                        .ruff_cache/                TEXMFHOME                   work/
bash_completion.d/          DIRSTACK                    .github/                    MODULESHOME                 OLDPWD                      SOURCE_HIGHLIGHT_DATADIR    venv/                       XDG_RUNTIME_DIR
```

---

I also include other minor fixes and refactoring in separate commits.
