### PR TITLE
Fedoradev image: don't install vpnc, update for dnf5

### DIFF
--- a/test/docker/fedoradev/Dockerfile
+++ b/test/docker/fedoradev/Dockerfile
@@ -19,4 +19,4 @@ ADD test-cmd-list.txt \
 
 RUN /tmp/install-packages.sh </tmp/test-cmd-list.txt \
     && dnf -Cy clean all \
-    && rm -r /tmp/* /var/lib/dnf/history.sqlite* /var/lib/dnf/repos/*
+    && rm -r /tmp/* /usr/lib/sysimage/libdnf5/transaction_history.sqlite* /var/lib/dnf/repos/*

--- a/test/docker/fedoradev/install-packages.sh
+++ b/test/docker/fedoradev/install-packages.sh
@@ -19,7 +19,7 @@ while read -r file; do
         *) printf "%s\n" {/usr,}/{,s}bin/"$file" ;;
     esac
 done |
-    xargs dnf --skip-broken -y install
+    xargs dnf -y install --skip-unavailable --skip-broken
 # --skip-broken: avoid failing on not found packages. Also prevents actually
 # broken packages from failing the install which is not what we want, but
 # there doesn't seem to be way to cleanly just skip the not found ones.

--- a/test/docker/fedoradev/install-packages.sh
+++ b/test/docker/fedoradev/install-packages.sh
@@ -18,8 +18,10 @@ while read -r file; do
         /*) printf "%s\n" "$file" ;;
         *) printf "%s\n" {/usr,}/{,s}bin/"$file" ;;
     esac
-done |
+done | grep -vxF /usr/bin/vpnc |
     xargs dnf -y install --skip-unavailable --skip-broken
+# /usr/bin/vpnc installs vpnc-consoleuser, which as of 2025-04-16 fails to install in
+# rawhide (f42): bugzilla.redhat.com/show_bug.cgi?id=2341517
 # --skip-broken: avoid failing on not found packages. Also prevents actually
 # broken packages from failing the install which is not what we want, but
 # there doesn't seem to be way to cleanly just skip the not found ones.


### PR DESCRIPTION
vpnc causes this error:
```
Running transaction
Transaction failed: Rpm transaction failed.
  - file /usr/bin/vpnc conflicts between attempted installs of vpnc-consoleuser-0.5.3-48.svn550.fc41.x86_64 and vpnc-0.5.3-48.svn550.fc41.x86_64
  - file /usr/bin/vpnc-disconnect conflicts between attempted installs of vpnc-consoleuser-0.5.3-48.svn550.fc41.x86_64 and vpnc-0.5.3-48.svn550.fc41.x86_64
```