### PR TITLE
Run sshd in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,7 @@ jobs:
           --env BSD=${{matrix.bsd}}
           --env PYTESTFLAGS="--verbose -p no:cacheprovider"
           --env NETWORK=$NETWORK
+          --env BASH_COMPLETION_TEST_LIVE_SSH_HOST=localhost
           ${NETWORK:+--network $NETWORK}
           --volume $PWD:/usr/src/bash-completion
           --workdir /usr/src/bash-completion

--- a/test/docker/alpine/Dockerfile
+++ b/test/docker/alpine/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
         musl-dev \
         py3-pexpect \
         py3-pytest-xdist \
+        openssh-server \
         tar \
         xvfb \
         xvfb-run \

--- a/test/docker/centos7/Dockerfile
+++ b/test/docker/centos7/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x \
         # /usr/bin/which: https://bugzilla.redhat.com/show_bug.cgi?id=1443357 \
         /usr/bin/which \
         /usr/bin/xvfb-run \
+        openssh-server \
         python36-pexpect
 
 ADD test-cmd-list.txt \

--- a/test/docker/debian10/Dockerfile
+++ b/test/docker/debian10/Dockerfile
@@ -7,6 +7,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         autoconf \
         automake \
         make \
+        openssh-server \
         python3-pexpect \
         python3-pytest-xdist \
         xvfb xauth \

--- a/test/docker/entrypoint.sh
+++ b/test/docker/entrypoint.sh
@@ -13,6 +13,17 @@ oldpwd=$(pwd)
 cp -a . /work
 cd /work
 
+# Dependencies for running sshd and connecting to it
+ssh-keygen -A
+mkdir -p ~/.ssh/ /var/run/sshd
+echo "localhost $(cat /etc/ssh/ssh_host_ed25519_key.pub)" >>~/.ssh/known_hosts
+ssh-keygen -t ed25519 -N '' -f "$HOME/.ssh/id_ed25519"
+cat "$HOME/.ssh/id_ed25519.pub" >>"$HOME/.ssh/authorized_keys"
+
+# sshd forces you to run with the full path
+sshpath="$(command -v sshd)"
+$sshpath
+
 autoreconf -i
 ./configure
 make -j

--- a/test/docker/fedoradev/Dockerfile
+++ b/test/docker/fedoradev/Dockerfile
@@ -9,6 +9,7 @@ RUN echo install_weak_deps=False >> /etc/dnf/dnf.conf \
         /usr/bin/make \
         /usr/bin/xvfb-run \
         /usr/bin/pytest-3 \
+        openssh-server \
         python3-pexpect \
         python3-pytest-xdist \
     && ln -s $(type -P pytest-3) /usr/local/bin/pytest

--- a/test/docker/ubuntu14/Dockerfile
+++ b/test/docker/ubuntu14/Dockerfile
@@ -8,6 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         automake \
         make \
         software-properties-common \
+        openssh-server \
         xvfb \
     && python3.4 -c "import urllib.request; urllib.request.urlretrieve('https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable_v2.tar.gz', '/tmp/pyston.tar.gz')" \
     && tar xCf /usr/local /tmp/pyston.tar.gz --strip-components=1

--- a/test/t/test_scp.py
+++ b/test/t/test_scp.py
@@ -1,10 +1,13 @@
+import os
 from itertools import chain
 
 import pytest
 
 from conftest import assert_bash_exec, assert_complete, bash_env_saved
 
-LIVE_HOST = "bash_completion"
+LIVE_HOST = os.environ.get(
+    "BASH_COMPLETION_TEST_LIVE_SSH_HOST", default="bash_completion"
+)
 
 
 class TestScp:
@@ -76,7 +79,7 @@ class TestScp:
         Connection to it must open sufficiently quickly for the
         ConnectTimeout and sleep_after_tab settings.
         """
-        assert completion == f"{LIVE_HOST}:{live_pwd}/"
+        assert completion == f"{live_pwd}/"
 
     @pytest.mark.complete("scp -o Foo=")
     def test_option_arg(self, completion):


### PR DESCRIPTION
This should allow us to make better tests for remote files in scp and rsync completions.

CI in this PR fails because the images are only pushed after merging