### PR TITLE
ci(fedoradev): Qualify FROM to use fedora registry

### DIFF
--- a/test/docker/fedoradev/Dockerfile
+++ b/test/docker/fedoradev/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
 RUN echo install_weak_deps=False >> /etc/dnf/dnf.conf \
     && sed -i -e /tsflags=nodocs/d /etc/dnf/dnf.conf \


### PR DESCRIPTION
By default it seems to pull from docker hub, but the images on docker hub seem to be updated much less frequently then the registry.fedoraproject.org one (hosted on quay.io).

The specific difference which made me notice it is that on the rawhide image in docker hub the PATH includes */sbin parts: `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`, while the one on registry.fedoraproject.org only has 2 bin paths: `PATH=/usr/local/bin:/usr/bin`.

This caused a test failure for monodevelop, since it depends on the full path its run as, and running it as sbin fails with this error:
```
Cannot open assembly
'/usr/sbin/monodevelop/lib/monodevelop/bin/MonoDevelop.exe': Not a directory.
```