### PR TITLE
test(fprintd): xfail --finger in container

### DIFF
--- a/test/t/test_fprintd_enroll.py
+++ b/test/t/test_fprintd_enroll.py
@@ -1,5 +1,7 @@
 import pytest
 
+from conftest import in_container
+
 
 @pytest.mark.bashcomp(
     cmd="fprintd-enroll",
@@ -13,6 +15,9 @@ class TestFprintdEnroll:
     def test_options(self, completion):
         assert completion
 
+    @pytest.mark.skipif(
+        in_container(), reason="Probably no fingerprint readers in container"
+    )
     @pytest.mark.complete("fprintd-enroll --finger ", require_cmd=True)
     def test_finger(self, completion):
         assert completion


### PR DESCRIPTION
Containers usually don't have fingerprint readers