### PR TITLE
fix(convert): Try calling magick, for IM7

### DIFF
--- a/completions/convert
+++ b/completions/convert
@@ -49,7 +49,13 @@ _comp_cmd_convert__common_options()
             return
             ;;
         -format)
-            _comp_compgen_split -- "$(convert -list format | _comp_awk \
+            # FIXME: We should probably accept the actual command being used
+            # here and run that, instead of calling `magick` or `convert`
+            # explicitly.
+            # `magick` is the new way to call the command in ImageMagick 7
+            _comp_compgen_split -- "$({
+                magick -list format 2>/dev/null || convert -list format
+            } | _comp_awk \
                 '/ [r-][w-][+-] / { sub("[*]$","",$1); print tolower($1) }')"
             return
             ;;


### PR DESCRIPTION
In image magick 7 running `convert` prints a warning. Try running magick first.

```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```

Another alternative is to just swallow the warning from `convert`, but this seems a bit more future proof.