### PR TITLE
ci: Make distcheck not cancel jobs once one fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
             network: none
           - dist: fedoradev
           - dist: ubuntu14
+      fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: googleapis/release-please-action@5792afc6b46e9bb55deda9eda973a18c226bc3fc # v4.1.5


### PR DESCRIPTION
It's pretty common that a specific distro fails the check, and since it currently cancels the rest of the matrix, you have to fix it first before seeing failures in other distros.

This enables the fail-fast option:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast