### PR TITLE
docs: add SPDX license identifier

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -19,6 +19,8 @@
 #   along with this program; if not, write to the Free Software Foundation,
 #   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+#   SPDX-License-Identifier: GPL-2.0-or-later
+#
 #   The latest version of this software can be obtained here:
 #
 #   https://github.com/scop/bash-completion


### PR DESCRIPTION
Related docs are not specific whether any amount of whitespace is acceptable before the id stanza, but I suppose it is. Going with more than one as it aligns better with the other commentary we have.

* https://spdx.dev/learn/handling-license-info/#how
* https://github.com/spdx/using/blob/17d56be4f4b99df87a52ae4a352810214707f861/docs/using-SPDX-short-identifiers-in-source-files.md

Closes https://github.com/scop/bash-completion/issues/1389