### PR TITLE
fix(scp): fix a bug that `-F<prefix>[TAB]` did not complete at all

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -547,13 +547,13 @@ _comp_xfunc_scp_compgen_local_files()
     local files
     _comp_expand_glob files '"$cur"*' || return 0
     if [[ $_dirsonly ]]; then
-        _comp_compgen -U files split -l -- "$(
+        _comp_compgen -RU files split -l -- "$(
             command ls -aF1dL "${files[@]}" 2>/dev/null |
                 command sed -e "s/$_comp_cmd_scp__path_esc/\\\\&/g" \
                     -e '/[^\/]$/d' -e "s/^/${1-}/"
         )"
     else
-        _comp_compgen -U files split -l -- "$(
+        _comp_compgen -RU files split -l -- "$(
             command ls -aF1dL "${files[@]}" 2>/dev/null |
                 command sed -e "s/$_comp_cmd_scp__path_esc/\\\\&/g" \
                     -e 's/[*@|=]$//g' -e 's/[^\/]$/& /g' -e "s/^/${1-}/"

--- a/test/t/test_scp.py
+++ b/test/t/test_scp.py
@@ -58,6 +58,14 @@ class TestScp:
             "option requires an argument -- F" in x for x in completion
         )
 
+    @pytest.mark.complete("scp -Fconf", cwd="scp")
+    def test_capital_f_without_space_2(self, completion):
+        assert completion == "ig"
+
+    @pytest.mark.complete("scp -Fbi", cwd="scp")
+    def test_capital_f_without_space_3(self, completion):
+        assert completion == "n/"
+
     @pytest.fixture(scope="class")
     def live_pwd(self, bash):
         try:


### PR DESCRIPTION
This was a part of #1371 but was separated.

Details are described in the commit message.