### PR TITLE
[Waiting for #1397] fix(rsync,scp): remove file-type marks from "ls -F" properly

### DIFF
--- a/completions/ssh
+++ b/completions/ssh
@@ -519,7 +519,8 @@ _comp_xfunc_scp_compgen_remote_files()
         # shellcheck disable=SC2090
         _files=$(ssh -o 'Batchmode yes' "$_userhost" \
             command ls -aF1dL "$_path*" 2>/dev/null |
-            command sed -e 's/'"$_comp_cmd_scp__path_esc"'/'"$_escape_replacement"'/g' -e 's/[*@|=]$//g' \
+            command sed -e 's/[*@|=]$//g' \
+                -e 's/'"$_comp_cmd_scp__path_esc"'/'"$_escape_replacement"'/g' \
                 -e 's/[^/]$/& /g')
     fi
     _comp_compgen -R split -l -- "$_files"
@@ -555,8 +556,9 @@ _comp_xfunc_scp_compgen_local_files()
     else
         _comp_compgen -RU files split -l -- "$(
             command ls -aF1dL "${files[@]}" 2>/dev/null |
-                command sed -e "s/$_comp_cmd_scp__path_esc/\\\\&/g" \
-                    -e 's/[*@|=]$//g' -e 's/[^/]$/& /g' -e "s/^/${1-}/"
+                command sed -e 's/[*@|=]$//g' \
+                    -e "s/$_comp_cmd_scp__path_esc/\\\\&/g" \
+                    -e 's/[^/]$/& /g' -e "s/^/${1-}/"
         )"
     fi
 }


### PR DESCRIPTION
This was a part of #1371 but was separated. Waiting for #1397.

Details are described in the commit message.