### PR TITLE
Support sourcing bash_completion.d from /usr/share/ and move ours

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,7 @@ SUBDIRS = completions doc helpers test
 
 pkgdata_DATA = bash_completion
 
-# Empty, but here just to get the compat dir created with install
-compatdir = $(sysconfdir)/bash_completion.d
+compatdir = $(datadir)/bash-completion/compat
 compat_DATA = bash_completion.d/000_bash_completion_compat.bash
 
 profiledir = $(sysconfdir)/profile.d
@@ -34,9 +33,12 @@ EXTRA_DIST = CHANGELOG.md $(pkgdata_DATA) bash_completion.sh.in .dir-locals.el \
 	bash-completion-config-version.cmake.in setup-symlinks.sh \
 	$(compat_DATA)
 
+# Create and install empty directory for local completion scripts in sysconfdir
 install-data-hook:
 	tmpfile=`mktemp $${TMPDIR:-/tmp}/bash_completion.XXXXXX` && \
-	$(SED) -e 's|(/etc/bash_completion\.d|($(compatdir)|' \
+	$(SED) -e 's|(/etc/bash_completion\.d|($(sysconfdir)/bash_completion.d|' \
+	    -e 's|(/usr/share/bash-completion/compat|($(compatdir)|' \
 	    $(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion >$$tmpfile && \
 	cat $$tmpfile >$(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion && \
 	rm $$tmpfile
+	$(MKDIR_P) $(DESTDIR)$(sysconfdir)/bash_completion.d

--- a/bash_completion
+++ b/bash_completion
@@ -3492,6 +3492,7 @@ _comp__init_collect_startup_configs()
         compat_dirs+=("$BASH_COMPLETION_COMPAT_DIR")
     else
         # Keep in sync with Makefile.am install-data-hook
+        compat_dirs+=(/usr/share/bash-completion/compat)
         compat_dirs+=(/etc/bash_completion.d)
         # Similarly as for the "completions" dir, look up from relative to
         # bash_completion, primarily for installed-with-prefix and
@@ -3503,7 +3504,14 @@ _comp__init_collect_startup_configs()
         else
             compat_dir=$_comp__base_directory/bash_completion.d
         fi
-        [[ ${compat_dirs[0]} == "$compat_dir" ]] ||
+        local dir
+        for dir in "${compat_dirs[@]}"; do
+            if [[ $dir == "$compat_dir" ]]; then
+                compat_dir=""
+                break
+            fi
+        done
+        [[ $compat_dir ]] &&
             compat_dirs+=("$compat_dir")
     fi
     for compat_dir in "${compat_dirs[@]}"; do


### PR DESCRIPTION
In distributions we are in the process of moving data shipped
by upstream projects to /usr/ and out of /etc/, as the latter
is really meant to be for local changes, not for upstream
projects to ship programs/data.

Add support for sourcing compat scripts from /usr/share/bash_completion.d/
together with /etc/bash_completion.d, and move 000_bash_completion_compat.bash
to the former.