### PR TITLE
feat(unzip,zipinfo): generate *.crx for Google Chrome Extension's ZIP archives

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -3157,7 +3157,7 @@ _comp__init_install_xspec()
 }
 # bzcmp, bzdiff, bz*grep, bzless, bzmore intentionally not here, see Debian: #455510
 _comp__init_install_xspec '!*.?(t)bz?(2)' bunzip2 bzcat pbunzip2 pbzcat lbunzip2 lbzcat
-_comp__init_install_xspec '!*.@(zip|[aegjkswx]ar|exe|pk3|wsz|zargo|xpi|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|cbz|apk|apk[ms]|aab|xapk|ipa|hap|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|vsix|whl|[Ff][Cc][Ss]td)' unzip zipinfo
+_comp__init_install_xspec '!*.@(zip|[aegjkswx]ar|exe|pk3|wsz|zargo|xpi|crx|s[tx][cdiw]|sx[gm]|o[dt][tspgfc]|od[bm]|oxt|?(o)xps|epub|cbz|apk|apk[ms]|aab|xapk|ipa|hap|do[ct][xm]|p[op]t[mx]|xl[st][xm]|pyz|vsix|whl|[Ff][Cc][Ss]td)' unzip zipinfo
 _comp__init_install_xspec '*.Z' compress znew
 # zcmp, zdiff, z*grep, zless, zmore intentionally not here, see Debian: #455510
 _comp__init_install_xspec '!*.@(Z|[gGd]z|t[ag]z)' gunzip zcat


### PR DESCRIPTION
See the commit message.

> https://github.com/scop/bash-completion/pull/1404#issuecomment-3147310228
>
> I don't see a problem adding more of them. crx would fit in well if it's a zip, we have xpi already which is corresponding thing for Firefox.
>
> https://github.com/scop/bash-completion/pull/1404#issuecomment-3147329632
>
> But re these, would be great to provide URLs to some sample files with which reviewers could verify that they work with these tools. 

I've included the reference URL in the commit message as usual, but it might be harder to track the changes later because many extensions are included in a single line where `git blame` isn't useful to identify a commit that added a specific filename extension. Maybe we should include the reference information directly in the code comment inside the source code `bash_completion`. What do you think?