### PR TITLE
chore(renovate): use best-practices preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
     ":enablePreCommit",
     ":prConcurrentLimit20",
     ":preserveSemverRanges",
@@ -10,7 +10,8 @@
   "ignorePresets": [
     ":dependencyDashboard",
     ":ignoreModulesAndTests",
-    ":semanticPrefixFixDepsChoreOthers"
+    ":semanticPrefixFixDepsChoreOthers",
+    "docker:pinDigests"
   ],
   "semanticCommits": "enabled",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
Our previous "config:base" was actually these days called "config:recommended":
https://docs.renovatebot.com/presets-config/#configrecommended

"config:best-practices":
https://docs.renovatebot.com/presets-config/#configbest-practices