### PR TITLE
feat(smartctl): update for smartmontools 7.5

### DIFF
--- a/completions/smartctl
+++ b/completions/smartctl
@@ -1,32 +1,32 @@
 # bash completion for smartctl(8)                          -*- shell-script -*-
+# Updated for smartmontools 7.5 (released 2025-04-30)
 
 _comp_cmd_smartctl__device()
 {
     case $cur in
-        areca* | 3ware* | megaraid* | cciss*)
+        3ware,* | cciss,* | areca,* | megaraid,*)
             _comp_compgen -- -W '${cur%%,*},{0..31}'
             ;;
-        hpt*)
+        aacraid,*)
+            _comp_compgen -- -W 'aacraid,{0..1},{0..1},{0..7}'
+            ;;
+        hpt,*)
             _comp_compgen -- -W 'hpt,{1..4}/{1..8} hpt,{1..4}/{1..8}/{1..5}'
             ;;
+        sssraid,*)
+            _comp_compgen -- -W 'sssraid,{0..1},{0..31}'
+            ;;
+        jmb39x,* | jmb39x-q,* | jmb39x-q2,* | jms56x,*)
+            _comp_compgen -- -W '${cur%%,*},{0..4}'
+            ;;
         *)
-            _comp_compgen -- -W 'ata scsi sat usbcypress usbjmicron usbsunplus
-                marvell areca 3ware hpt megaraid cciss auto test'
-            case "${COMPREPLY[@]}" in
-                areca | 3ware | hpt | megaraid | cciss)
-                    compopt -o nospace
-                    ;;
-            esac
+            _comp_compgen -- -W 'auto test ata scsi nvme{,\,}
+                sat{,\,auto}{,\,12} usb{jmicron,prolific,sunplus}
+                snt{asmedia,jmicron,realtek}{,/sat} 3ware, aacraid, areca,
+                cciss, hpt, megaraid, sssraid, jmb39x{,-q,-q2}, jms56x,'
+            [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
             ;;
     esac
-}
-_comp_cmd_smartctl__test()
-{
-    [[ $cur == @(pending|scttempint|vendor), ]] && return
-    _comp_compgen -- -W 'offline short long conveyance select, select,redo
-        select,next afterselect,on afterselect,off pending, scttempint,
-        vendor,'
-    [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
 }
 _comp_cmd_smartctl__drivedb()
 {
@@ -38,13 +38,42 @@ _comp_cmd_smartctl__drivedb()
     _comp_compgen_filedir h && [[ $prefix ]] &&
         _comp_compgen -Rv COMPREPLY -- -P "$prefix" -W '"${COMPREPLY[@]}"'
 }
+_comp_cmd_smartctl__vendorattribute()
+{
+    local fmt
+    case $cur in
+        [1-9N],*|[1-9][0-9],*|1[0-9][0-9],*|2[0-4][0-9],*|25[0-5],*)
+            fmt='raw{8,16,48,56,64},hex{48,56,64},raw24/raw{24,32}'
+            fmt+=',msec24hour32,{sec,min,halfmin}2hour,temp10x,tempminmax'
+            _comp_compgen -- -W '${cur%%,*},{'"$fmt"'}{,\,,}'
+            ;;
+        [1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
+            _comp_compgen -- -W '${cur}, {100..255},'
+            ;;
+        [1-9])
+            _comp_compgen -- -W '${cur}, ${cur}{0..9}'
+            ;;
+        *)
+            _comp_compgen -- -W '{1..9} N, help'
+            ;;
+    esac
+    [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
+}
+_comp_cmd_smartctl__set()
+{
+    _comp_compgen -- -W 'aam,{,off} apm,{,off} dsn,{on,off}
+        lookahead,{on,off} rcache,{on,off} security-freeze standby,{,off,now}
+        wcache,{on,off} wcache-sct,{ata,on,off}{,\,p}
+        wcreorder,{on,off}{,\,p} '"$1"
+    [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
+}
 
 _comp_cmd_smartctl()
 {
     local cur prev words cword was_split comp_args
     _comp_initialize -s -- "$@" || return
 
-    local noargopts='!(-*|*[qdTbrnsoSlvFPBt]*)'
+    local noargopts='!(-*|*[qdTbrnoSlvFPBtfgs]*)'
     # shellcheck disable=SC2254
     case $prev in
         --quietmode | -${noargopts}q)
@@ -64,32 +93,34 @@ _comp_cmd_smartctl()
             return
             ;;
         --report | -${noargopts}r)
-            _comp_compgen -- -W 'ioctl ataioctl scsiioctl'
+            _comp_compgen -- -W '{,ata,scsi,nvme}ioctl{,\,2}'
             return
             ;;
         --nocheck | -${noargopts}n)
-            _comp_compgen -- -W 'never sleep standby idle'
+            _comp_compgen -- -W 'never sleep{,\,} standby{,\,} idle{,\,}'
+            [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
             return
             ;;
-        --smart | --offlineauto | --saveauto | -${noargopts}[soS])
+        --smart | --offlineauto | --saveauto | -${noargopts}[oS])
             _comp_compgen -- -W 'on off'
             return
             ;;
         --log | -${noargopts}l)
-            _comp_compgen -- -W 'error selftest selective directory background
-                sasphy sasphy,reset sataphy sataphy,reset scttemp scttempsts
-                scttemphist scterc gplog smartlog xerror xselftest'
+            _comp_compgen -- -W 'background defects{,\,} devstat{,\,}
+                directory{,\,g,\,s} envrep error farm genstats gplog, nvmelog,
+                sasphy{,\,reset} sataphy{,\,reset} scterc{,\,,\,p,\,reset}
+                scttemp{,sts,int\,,hist} selective selftest smartlog, ssd
+                tapealert tapedevstat xerror{,\,,\,error}
+                xselftest{,\,,\,selftest} zdevstat'
+            [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
             return
             ;;
         --vendorattribute | -${noargopts}v)
-            _comp_compgen -- -W 'help 9,minutes 9,seconds 9,halfminutes 9,temp
-                192,emergencyretractcyclect 193,loadunload 194,10xCelsius
-                194,unknown 198,offlinescanuncsectorct 200,writeerrorcount
-                201,detectedtacount 220,temp'
+            _comp_cmd_smartctl__vendorattribute
             return
             ;;
         --firmwarebug | -${noargopts}F)
-            _comp_compgen -- -W 'none samsung samsung2 samsung3 swapid'
+            _comp_compgen -- -W 'none nologdir samsung{,2,3} swapid xerrorlba'
             return
             ;;
         --presets | -${noargopts}P)
@@ -101,7 +132,26 @@ _comp_cmd_smartctl()
             return
             ;;
         --test | -${noargopts}t)
-            _comp_cmd_smartctl__test
+            _comp_compgen -- -W 'afterselect,{on,off} conveyance force long
+                offline pending, scttempint, select,{,redo,next} short vendor,'
+            [[ ${COMPREPLY-} == *, ]] && compopt -o nospace
+            return
+            ;;
+        --format | -${noargopts}f)
+            _comp_compgen -- -W 'brief hex{,\,id,\,val} old'
+            return
+            ;;
+        --get | -${noargopts}g)
+            _comp_compgen -- -W 'aam all apm dsn lookahead rcache security
+                wcache{,-sct} wcreorder'
+            return
+            ;;
+        --set)
+            _comp_cmd_smartctl__set ''
+            return
+            ;;
+        -${noargopts}s) # -s {on,off}: --smart {on,off}; -s OTHER: --set OTHER
+            _comp_cmd_smartctl__set 'on off'
             return
             ;;
     esac
@@ -109,7 +159,14 @@ _comp_cmd_smartctl()
     [[ $was_split ]] && return
 
     if [[ $cur == -* ]]; then
-        _comp_compgen_help
+        # _comp_compgen_help # not used because result is incomplete
+        _comp_compgen -- -W '--abort --all --attributes --badsum=
+            --capabilities --captive --device= --drivedb= --firmwarebug=
+            --format= --get= --health --help --identify{,=} --info --json{,=}
+            --log= --nocheck= --offlineauto= --presets= --quietmode= --report=
+            --saveauto= --scan{,-open} --set= --smart= --test= --tolerance=
+            --vendorattribute= --version --xall -A -B -C -F -H -P -S -T -V -X
+            -a -b -c -d -f -g -h -i -j -l -n -o -q -r -s -t -v -x'
         [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
     else
         _comp_compgen -c "${cur:-/dev/}" filedir


### PR DESCRIPTION
Backward compatible with even 5.* (<= 2012) versions of smartctl, except for the newly added options.
