### PR TITLE
fix(_comp_compgen): go to the original directory on compgen failure

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -809,6 +809,8 @@ if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 3)); t
         # pat, the effect of -X '' is overwritten by the specified one.
         IFS=$_ifs compgen -V _result -X '' "$@" ${_cur:+-- "$_cur"} || {
             _comp_compgen__error_fallback
+            # shellcheck disable=SC2164
+            [[ $_dir ]] && command cd -- "$_original_pwd"
             return
         }
 

--- a/test/config/bashrc
+++ b/test/config/bashrc
@@ -64,6 +64,12 @@ add_comp_wordbreak_char()
 
 _comp__test_get_env()
 {
+    # Note: PWD is supposed to reflect the current working directory, but the
+    # real current working directory of the process can be different, e.g. when
+    # PWD is manually altered.  Therefore, we also check the result of $(pwd)
+    # explicitly via a new variable `_comp_test_pwd`.
+    local _comp_test_pwd=$(pwd)
+
     (
         # Do not output the state of test variables "_comp__test_+([0-9])_*"
         # and internal mutable variables "_comp_*_mut_*".

--- a/test/t/unit/test_unit_compgen.py
+++ b/test/t/unit/test_unit_compgen.py
@@ -28,6 +28,11 @@ class TestUtilCompgen:
 
         assert_bash_exec(
             bash,
+            '_comp_cmd_fb() { _comp_compgen -c "$(_get_cword)" -C _filedir -- -f; }; '
+            "complete -F _comp_cmd_fb fb",
+        )
+        assert_bash_exec(
+            bash,
             '_comp_cmd_fc() { _comp_compgen -c "$(_get_cword)" -C _filedir filedir; }; '
             "complete -F _comp_cmd_fc fc; "
             "complete -F _comp_cmd_fc -o filenames fc2",
@@ -142,6 +147,10 @@ class TestUtilCompgen:
         # Note: we are not in the original directory that "b" exists, so Bash
         # will not suffix a slash to the directory name.
         assert completion == "b"
+
+    @pytest.mark.complete(r"fb nonexistent")
+    def test_6_option_C_5(self, bash, functions, completion):
+        assert not completion
 
     def test_7_icmd(self, bash, functions):
         with bash_env_saved(bash) as bash_env:


### PR DESCRIPTION
Commit b6de4915213377fb406be6fe0cfdd3b944f667f9 adds a check for the current working directory. Checking `PWD` isn't sufficient because `PWD` can be different from the actual current working directory.

Then, the second commit fixes the issue reported at #1426. `command cd -- "$_original_pwd"` was missing for the early return with the completion error by `builtin compgen`.

Fixes #1426.
