### PR TITLE
doc improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Also, please bear the following coding guidelines in mind:
 
   can be replaced by:
 
-  ```shell
+  ```bash
   bar=${foo//bar/baz}
   ```
 
@@ -132,7 +132,7 @@ Also, please bear the following coding guidelines in mind:
   expansions will be unexpectedly performed, which becomes a vulnerability.  In
   the latter case, checks by shellcheck and shfmt will not be performed inside
   `'...'`.  Also, `_comp_compgen_split` is `IFS`-safe.
-  
+
   Avoid using `_comp_compgen -- -G "pattern"` to generate completions.  The
   result is not filtered by the current word `cur` due to the Bash design of
   `compgen`.  Also, this cannot be used to generate filenames with a specified

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ need to source it from either `/etc/bashrc` or `~/.bashrc` (or any
 other file sourcing those). If you have _only_ bash >= 4.2 installed, you can
 do this by simply using:
 
-```shell
+```bash
 # Use bash-completion, if available
 [[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
     . /usr/share/bash-completion/bash_completion
@@ -70,7 +70,7 @@ standard way is to configure `~/.bash_profile` to source `~/.bashrc` and write
 interactive settings in `~/.bashrc`.  You can source `~/.bashrc` in
 `~/.bash_profile` in the following way:
 
-```shell
+```bash
 # ~/.bash_profile
 
 if [[ -f ~/.bashrc ]]; then
@@ -90,7 +90,7 @@ the entry point of `bash-completion` to
 `$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh`.  We can source it by
 adding the following to our startup file `~/.bashrc`:
 
-```shell
+```bash
 if [[ -s $HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh ]]; then
   . "$HOMEBREW_PREFIX/etc/profile.d/bash_completion.sh"
 fi

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ list of operating system distributions, package names, and available versions.
 Depending on the package, you may still
 need to source it from either `/etc/bashrc` or `~/.bashrc` (or any
 other file sourcing those). If you have _only_ bash >= 4.2 installed, you can
-do this by simply using:
+do this by using:
 
 ```bash
-# Use bash-completion, if available
-[[ $PS1 && -f /usr/share/bash-completion/bash_completion ]] && \
+# Use bash-completion, if available, and avoid double-sourcing
+[[ $PS1 &&
+  ! ${BASH_COMPLETION_VERSINFO:-} &&
+  -f /usr/share/bash-completion/bash_completion ]] &&
     . /usr/share/bash-completion/bash_completion
 ```
 


### PR DESCRIPTION
- change markdown code-block lang-tags from `shell` to `bash` (only where appropriate)
- check if completions are already sourced in example `.bashrc` (in `README`)

fixes #1443