### PR TITLE
build: fix install-data-hook for bash_completion.d

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ EXTRA_DIST = CHANGELOG.md $(pkgdata_DATA) bash_completion.sh.in .dir-locals.el \
 
 install-data-hook:
 	tmpfile=`mktemp $${TMPDIR:-/tmp}/bash_completion.XXXXXX` && \
-	$(SED) -e 's|-/etc/bash_completion\.d|-$(compatdir)|' \
+	$(SED) -e 's|(/etc/bash_completion\.d|($(compatdir)|' \
 	    $(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion >$$tmpfile && \
 	cat $$tmpfile >$(DESTDIR)$(datadir)/$(PACKAGE)/bash_completion && \
 	rm $$tmpfile

--- a/bash_completion
+++ b/bash_completion
@@ -3490,6 +3490,7 @@ _comp__init_collect_startup_configs()
     if [[ ${BASH_COMPLETION_COMPAT_DIR-} ]]; then
         compat_dirs+=("$BASH_COMPLETION_COMPAT_DIR")
     else
+        # Keep in sync with install-data-hook at Makefile.am
         compat_dirs+=(/etc/bash_completion.d)
         # Similarly as for the "completions" dir, look up from relative to
         # bash_completion, primarily for installed-with-prefix and


### PR DESCRIPTION
It no longer matches bash_completion so it was not substituting for the actual compatdir due to a refactor.

Follow-up for cdd8a157abdbb4ce2e74df3fd8131a2b199152e6

Originally submitted as part of #1399 