### PR TITLE
ci(renovate): Set rebaseWhen explicitly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
   ],
   "semanticCommits": "enabled",
   "commitMessageTopic": "{{depName}}",
+  "rebaseWhen": "conflicted",
   "dockerfile": {
     "enabled": false
   },


### PR DESCRIPTION
Setting it conflicted, see
https://docs.renovatebot.com/configuration-options/#rebasewhen

Hopefully this will stop it from rebasing everytime a PR is merged.
Ref: https://github.com/scop/bash-completion/pull/1416