### PR TITLE
ci: Add permissions necessary for release-please

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,12 @@ jobs:
   distcheck:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # TODO: This is needed for release, maybe split the release steps to a different job?
+      # Permissions from https://github.com/googleapis/release-please-action?tab=readme-ov-file#basic-configuration
+      # TODO: This is only needed for release, maybe split the release steps to a different job?
+      contents: write
+      pull-requests: write
+      # Needed for adding labels for PRs, we shouldn't actually need this, see https://github.com/orgs/community/discussions/156181
+      issues: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Without this it fails with this error:
```
Error: release-please failed: Resource not accessible by integration
```
The `issues: write` permissions are needed to create labels on PRs, because of this issue: https://github.com/orgs/community/discussions/156181 Followup to https://github.com/scop/bash-completion/pull/1432