### PR TITLE
test(docker): upgrade ubuntu14 Python to standalone 3.13.3

### DIFF
--- a/test/docker/ubuntu14/Dockerfile
+++ b/test/docker/ubuntu14/Dockerfile
@@ -10,8 +10,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         software-properties-common \
         openssh-server \
         xvfb \
-    && python3.4 -c "import urllib.request; urllib.request.urlretrieve('https://github.com/pyston/pyston/releases/download/pyston_2.3.1/pyston_2.3.1_portable_v2.tar.gz', '/tmp/pyston.tar.gz')" \
-    && tar xCf /usr/local /tmp/pyston.tar.gz --strip-components=1
+    && : 20250517/3.13.3+20250517 was latest found working as of 2025-10-12 \
+    && python3.4 -c "import urllib.request; urllib.request.urlretrieve('https://github.com/astral-sh/python-build-standalone/releases/download/20250517/cpython-3.13.3+20250517-x86_64_v2-unknown-linux-gnu-install_only_stripped.tar.gz', '/tmp/python.tar.gz')" \
+    && tar xCf /usr/local /tmp/python.tar.gz --strip-components=1
 
 ADD test-cmd-list.txt \
     requirements.txt \
@@ -19,7 +20,7 @@ ADD test-cmd-list.txt \
     /tmp/
 
 RUN set -x \
-    && pyston3 -m pip install -Ir /tmp/requirements.txt
+    && python3 -m pip install -Ir /tmp/requirements.txt
 
 RUN /tmp/install-packages.sh </tmp/test-cmd-list.txt \
     && rm -r /tmp/* /root/.cache/pip /var/lib/apt/lists/*


### PR DESCRIPTION
20250517/3.13.3+20250517 was latest found working as of today.

This is mainly to get a currently supported one for tests and tooling. In particular, current mypy no longer supports < 3.9 as python_version.

But depending on what we do with bash version support soon, chances are that we don't need to go here at all, https://github.com/scop/bash-completion/discussions/1479