### PR TITLE
chore(ci): Stop using apt-add-repository

### DIFF
--- a/test/docker/debian10/install-packages.sh
+++ b/test/docker/debian10/install-packages.sh
@@ -12,11 +12,9 @@ apt-get update
 apt-get -y upgrade
 
 apt-get -y --no-install-recommends install \
-    apt-file \
-    software-properties-common
+    apt-file
 
-apt-add-repository contrib
-apt-add-repository non-free
+sed -i -e 's/ main/ main non-free contrib/' /etc/apt/sources.list
 
 apt-get -y --no-install-recommends install \
     npm


### PR DESCRIPTION
We switched to using archive.debian.org in https://github.com/scop/bash-completion/pull/1469, but apt-add-repository adds the old ones itself even when not specified. Use sed to add `contrib` and `non-free` instead.