### PR TITLE
chore(tar): Remove already fixed FIXME

### DIFF
--- a/completions/tar
+++ b/completions/tar
@@ -29,7 +29,6 @@
 #        - check for no global variable pollution
 # FIXME: why PS4='$BASH_SOURCE:$LINENO: ' shows sometimes negative lines?
 # FIXME: timeout on tarball listing
-# FIXME: cache 'tar --help' parsing results into global variables
 # FIXME: at least 'tar -<tab>' should show some helping text (apart from just
 #        pure option advice)
 # FIXME: short option completion should be more intuitive


### PR DESCRIPTION
It was already done in b030e07f10 "perf(tar): parse the GNU tar help on initialization" (https://github.com/scop/bash-completion/pull/1362)