### PR TITLE
Fix: SysVInit services targets parsing

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2230,7 +2230,7 @@ _comp_complete_service()
     else
         local sysvdirs
         _comp_sysvdirs || return 1
-        _comp_compgen_split -l -- "$(command sed -e 'y/|/ /' \
+        _comp_compgen_split -- "$(command sed -e 'y/|/ /' \
             -ne 's/^.*\(U\|msg_u\)sage.*{\(.*\)}.*$/\2/p' \
             "${sysvdirs[0]}/${prev##*/}" 2>/dev/null) start stop"
     fi


### PR DESCRIPTION
Fixes #1498

Removes the `-l` option to the call to `_comp_compgen_split`, which incorrectly restricted IFS from ` \t\n` to merely `\n` during SysVInit services targets parsing.