### PR TITLE
fix(cargo): removed local from a variable declaration outside a function

### DIFF
--- a/completions/_cargo
+++ b/completions/_cargo
@@ -2,8 +2,7 @@
 #
 # This serves as a fallback in case the completion is not installed otherwise.
 
-# shellcheck disable=SC2168 # "local" is ok, assume sourced by _comp_load
-local rustup="${1%cargo}rustup" # use rustup from same dir
+rustup="${1%cargo}rustup" # use rustup from same dir
 eval -- "$("$rustup" completions bash cargo 2>/dev/null)"
 
 # ex: filetype=sh


### PR DESCRIPTION
Ever since upgrading bash from 5.2.37 (released 2024-09-23) to  5.3.3 (released 2025-07-03), getting the warning:
```
-bash: local: can only be used in a function
```

This PR fixes that.