### PR TITLE
chore(renovate): extend scop/common preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":enablePreCommit",
-    ":prConcurrentLimit20",
-    ":preserveSemverRanges",
-    ":semanticPrefixChore"
+    "github>scop/common"
   ],
   "ignorePresets": [
-    ":dependencyDashboard",
     ":ignoreModulesAndTests",
-    ":semanticPrefixFixDepsChoreOthers",
     "docker:pinDigests"
   ],
-  "semanticCommits": "enabled",
-  "commitMessageTopic": "{{depName}}",
   "rebaseWhen": "conflicted",
   "dockerfile": {
     "enabled": false


### PR DESCRIPTION
I'm consolidating my Renovate configs (and soon some other common things) to a common repo, cf. ref https://github.com/scop/common/blob/main/default.json

No plans to make any drastic changes and I'll update extending projects if I figure out I may be doing something in the common that conflicts with them.