### PR TITLE
chore(committed): increase subject length to 72

### DIFF
--- a/.config/committed.toml
+++ b/.config/committed.toml
@@ -1,3 +1,4 @@
 style = "conventional"
 ignore_author_re = '\[bot\]'
+subject_length = 72
 subject_capitalized = false


### PR DESCRIPTION
50 is a tad too short, 72 reaps benefits well enough. 72 is what we had with gitlint, too.

Note that we'll still have 72 for commit body lines (I think we used to have 80). 72 is a better default for that, as it keeps the message display tidy on 80-char terminal, taking git log indentation into account.