### PR TITLE
test(ifup, ifdown): Require cmd for completions

### DIFF
--- a/test/t/test_ifdown.py
+++ b/test/t/test_ifdown.py
@@ -11,7 +11,7 @@ class TestIfdown:
         reason="There won't be any configured interfaces without network",
     )
     @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
-    @pytest.mark.complete("ifdown ")
+    @pytest.mark.complete("ifdown ", require_cmd=True)
     def test_1(self, completion):
         assert completion
 

--- a/test/t/test_ifup.py
+++ b/test/t/test_ifup.py
@@ -11,7 +11,7 @@ class TestIfup:
         reason="There won't be any configured interfaces without network",
     )
     @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
-    @pytest.mark.complete("ifup ")
+    @pytest.mark.complete("ifup ", require_cmd=True)
     def test_1(self, completion):
         assert completion
 

--- a/test/test-cmd-list.txt
+++ b/test/test-cmd-list.txt
@@ -149,6 +149,7 @@ hwclock
 iconv
 identify
 idn
+ifdown
 ifstat
 iftop
 ifup


### PR DESCRIPTION
fedora 43 doesn't seem to have ifup. Presumably it didn't fail in CI because we have an xfail for containers.