### PR TITLE
feat(tmux): complete target-session arguments

### DIFF
--- a/completions-core/tmux.bash
+++ b/completions-core/tmux.bash
@@ -111,6 +111,10 @@ _comp_cmd_tmux__value()
         file | *-file | path | *-path)
             _comp_compgen_filedir
             ;;
+        target-session)
+            _comp_compgen_split -l -- "$(_comp_cmd_tmux__run \
+                list-sessions -F '#{session_name}')"
+            ;;
     esac
 }
 


### PR DESCRIPTION
This adds completion for session names. Commands which take a running session's name as an argument, for example `attach-session`, can now have those options completable. For example:

```bash
$ tmux list-sessions -F '#{session_name}'
bash-cmp
nix-config
$ tmux attach-session -t <tab>
bash-cmp    nix-config
```

I checked the tmux repo, and they do not maintain bash completions, so I'm submitting this here.