### PR TITLE
test(ls): Allow empty output for non existing homedirs

### DIFF
--- a/test/t/test_ls.py
+++ b/test/t/test_ls.py
@@ -25,7 +25,7 @@ class TestLs:
                 bash,
                 "for u in $(compgen -u); do "
                 "eval test -d ~$u || echo $u; unset -v u; done",
-                want_output=True,
+                want_output=None,  # We might not find anything
             )
             .strip()
             .split()


### PR DESCRIPTION
If all users have a home directory that exists it doesn't return anything.
This failed for me in a distrobox container.