### PR TITLE
test(service): Skip if we don't have init tools or dirs

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -144,6 +144,7 @@ _comp_userland()
 _comp_sysvdirs()
 {
     sysvdirs=()
+    [[ -d ${_comp__test_inetd_dir-} ]] && sysvdirs+=("$_comp__test_inetd_dir")
     [[ -d /etc/rc.d/init.d ]] && sysvdirs+=(/etc/rc.d/init.d)
     [[ -d /etc/init.d ]] && sysvdirs+=(/etc/init.d)
     # Slackware uses /etc/rc.d

--- a/test/t/test_service.py
+++ b/test/t/test_service.py
@@ -2,12 +2,19 @@ import sys
 
 import pytest
 
+from conftest import assert_complete, bash_env_saved
+
 
 class TestService:
     @pytest.mark.xfail(
         sys.platform == "darwin",
         reason="Service completion not available on macOS",
     )
-    @pytest.mark.complete("service ")
-    def test_1(self, completion):
-        assert completion
+    def test_1(self, bash):
+        with bash_env_saved(bash) as bash_env:
+            bash_env.write_variable(
+                "_comp__test_inetd_dir",
+                "%s/_comp_compgen_xinetd_services/xinetd.d" % bash.cwd,
+            )
+            completion = assert_complete(bash, "service ")
+            assert all(x in completion for x in ("arp", "ifconfig"))


### PR DESCRIPTION
Fails in a container without any services or init related tools.