### PR TITLE
refactor: use `_comp_compgen -C` for service name generation

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -2216,7 +2216,7 @@ _comp_compgen_services()
     _comp_sysvdirs || return 1
 
     local services
-    _comp_expand_glob services '${sysvdirs[0]}/!($_comp_backup_glob|functions|README)'
+    _comp_compgen -v services -C "${sysvdirs[0]}" -- -f -X "@($_comp_backup_glob|functions|README)"
 
     local _generated=$({
         systemctl list-units --full --all ||
@@ -2230,7 +2230,7 @@ _comp_compgen_services()
     fi
 
     ((${#services[@]})) || return 1
-    _comp_compgen -U services -U sysvdirs -- -W '"${services[@]#${sysvdirs[0]}/}"'
+    _comp_compgen -U services -U sysvdirs -- -W '"${services[@]}"'
 }
 
 # This completes on a list of all available service scripts for the

--- a/bash_completion
+++ b/bash_completion
@@ -2209,28 +2209,30 @@ _comp_compgen_xinetd_services()
 
 # This function completes on services
 #
+# @return 0 if at least one completion is generated, or 1 otherwise.
 # @since 2.12
 _comp_compgen_services()
 {
     local sysvdirs
     _comp_sysvdirs || return 1
 
-    local services
-    _comp_compgen -v services -C "${sysvdirs[0]}" -- -f -X "@($_comp_backup_glob|functions|README)"
+    local status=1
+    _comp_compgen -U sysvdirs -C "${sysvdirs[0]}" -- -f -X "@($_comp_backup_glob|functions|README)" &&
+        status=0
 
     local _generated=$({
         systemctl list-units --full --all ||
             systemctl list-unit-files
     } 2>/dev/null |
         _comp_awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }')
-    _comp_split -la services "$_generated"
+    _comp_compgen -a split -l -- "$_generated" && status=0
 
     if [[ -x /sbin/upstart-udev-bridge ]]; then
-        _comp_split -la services "$(initctl list 2>/dev/null | cut -d' ' -f1)"
+        _comp_compgen -a split -l -- "$(initctl list 2>/dev/null | cut -d' ' -f1)" &&
+            status=0
     fi
 
-    ((${#services[@]})) || return 1
-    _comp_compgen -U services -U sysvdirs -- -W '"${services[@]}"'
+    return "$status"
 }
 
 # This completes on a list of all available service scripts for the

--- a/bash_completion
+++ b/bash_completion
@@ -2223,8 +2223,13 @@ _comp_compgen_services()
     local _generated=$({
         systemctl list-units --full --all ||
             systemctl list-unit-files
-    } 2>/dev/null |
-        _comp_awk '$1 ~ /\.service$/ { sub("\\.service$", "", $1); print $1 }')
+    } 2>/dev/null | _comp_awk '
+        # Example output from systemctl:
+        #   httpd.service       loaded    active   running  The Apache HTTP Server
+        # * iptables.service    not-found inactive dead     iptables.service
+        sub(/\.service$/, "", $1) { print $1; next }
+        sub(/\.service$/, "", $2) { print $2 }
+    ')
     _comp_compgen -a split -l -- "$_generated" && status=0
 
     if [[ -x /sbin/upstart-udev-bridge ]]; then

--- a/completions-core/invoke-rc.d.bash
+++ b/completions-core/invoke-rc.d.bash
@@ -7,7 +7,7 @@ _comp_cmd_invoke_rc_d()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local sysvdir services options
+    local sysvdir options
 
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
@@ -21,9 +21,8 @@ _comp_cmd_invoke_rc_d()
         local exclude="@(${words[*]})"
         _comp_unlocal IFS
         _comp_compgen -- -W '"${options[@]}"' -X "$exclude"
-
-        _comp_expand_glob services '"$sysvdir"/!(README*|*.sh|$_comp_backup_glob)' &&
-            _comp_compgen -a -- -W '"${services[@]#"$sysvdir"/}"'
+        # shellcheck disable=SC2154
+        _comp_compgen -aC "$sysvdir" -- -f -X "@(README*|*.sh|$_comp_backup_glob)"
     elif [[ -x $sysvdir/$prev ]]; then
         _comp_compgen_split -- "$(command sed -e 'y/|/ /' \
             -ne 's/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}"]*\).*$/\1/p' \

--- a/completions-core/update-rc.d.bash
+++ b/completions-core/update-rc.d.bash
@@ -12,8 +12,8 @@ _comp_cmd_update_rc_d()
     [[ -d /etc/rc.d/init.d ]] && sysvdir=/etc/rc.d/init.d ||
         sysvdir=/etc/init.d
 
-    _comp_expand_glob services '"$sysvdir"/!(README*|*.sh|$_comp_backup_glob)' &&
-        services=("${services[@]#$sysvdir/}")
+    # shellcheck disable=SC2154
+    _comp_compgen -v services -C "$sysvdir" -- -f -X "@(README*|*.sh|$_comp_backup_glob)"
     options=(-f -n)
 
     if [[ $cword -eq 1 || $prev == -* ]]; then


### PR DESCRIPTION
5e6dc86817f9d011223419e3643e937a5fefd349 and 655371b09ff9ba92e90ffa38847085261d8f34d2 use `_comp_compgen -C "$sysvdir" -- -f` instead of first generating filenames with `"$svsvdir"/*` and stripping the parent directory name by `"{tmp[@]#$sysvdir/}"`.

e21dbb87f and 354f9c522 are additional refactoring.