### PR TITLE
doc({completions,helpers}/README): normalize Markdown style for rundl

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -1,6 +1,6 @@
 # External completions directory - bash-completion
 
-This directory `completions` is the place to put *external* completion files,
+This directory `completions` is the place to put _external_ completion files,
 i.e., ones not shipped with the bash-completion project.  They are loaded by
 [bash-completion](https://github.com/scop/bash-completion) on demand.
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,6 +1,6 @@
 # External helpers directory - bash-completion
 
-This directory `helpers` is the place to put *external* helper scripts.  i.e.,
+This directory `helpers` is the place to put _external_ helper scripts.  i.e.,
 ones not shipped with the bash-completion project.  They are used by external
 completion files in the `completions` directory, written for
 [bash-completion](https://github.com/scop/bash-completion).


### PR DESCRIPTION
#1536 was merged after #1543 (switching to rumdl) but hasn't considered the rumdl style. This PR adjusts the style for rumdl.