### PR TITLE
chore(ci): generate GitHub artifact attestations on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
       pull-requests: write
       # Needed for adding labels for PRs, we shouldn't actually need this, see https://github.com/orgs/community/discussions/156181
       issues: write
+      # attestations and id-token for attest-build-provenance
+      attestations: write
+      id-token: write
     strategy:
       matrix:
         include:
@@ -102,4 +105,8 @@ jobs:
         env:
           GH_TOKEN: ${{github.token}}
           RELEASE_PLEASE_TAG_NAME: ${{steps.release.outputs.tag_name}}
+        if: steps.release.outputs.release_created
+      - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-checksums: sha256sums.txt
         if: steps.release.outputs.release_created


### PR DESCRIPTION
Ref https://docs.github.com/en/actions/concepts/security/artifact-attestations

We don't do "builds", but the dist tarball is a release artifact, and provenance for it is useful, too.

Untested but I believe it could work. We'll basically see on next release time (failure here does not prevent a release).