### PR TITLE
feat(syncthing): add 3rd party fallback completion loader

### DIFF
--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -58,6 +58,7 @@ cross_platform = adb.bash \
 		svn.bash \
 		svnadmin.bash \
 		svnlook.bash \
+		syncthing.bash \
 		task.bash \
 		tokio-console.bash \
 		udevadm.bash \

--- a/completions-fallback/syncthing.bash
+++ b/completions-fallback/syncthing.bash
@@ -1,0 +1,9 @@
+# 3rd party completion loader for commands emitting        -*- shell-script -*-
+# their completion using "$cmd install-completions". For example,
+# some Go programs using https://github.com/WillAbides/kongplete do.
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+eval -- "$("$1" install-completions 2>/dev/null)"
+
+# ex: filetype=sh


### PR DESCRIPTION
https://syncthing.net (no online documentation for installing completions that I can find)