### PR TITLE
style: remove unnecessary quoting of comsub in assignment rhs

### DIFF
--- a/completions-core/bk.bash
+++ b/completions-core/bk.bash
@@ -6,8 +6,8 @@ _comp_cmd_bk()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local BKCMDS="$(bk help topics 2>/dev/null |
-        _comp_awk '/^  bk/ { print $2 }' | xargs printf '%s ')"
+    local BKCMDS=$(bk help topics 2>/dev/null |
+        _comp_awk '/^  bk/ { print $2 }' | xargs printf '%s ')
 
     _comp_compgen -- -W "$BKCMDS"
     _comp_compgen -a filedir

--- a/completions-core/feh.bash
+++ b/completions-core/feh.bash
@@ -28,7 +28,7 @@ _comp_cmd_feh()
                 return
             fi
             local font_path
-            # font_path="$(imlib2-config --prefix 2>/dev/null)/share/imlib2/data/fonts"
+            # font_path=$(imlib2-config --prefix 2>/dev/null)/share/imlib2/data/fonts
             # _comp_compgen -C "$font_path" -- -f -X "!*.[tT][tT][fF]" -S /
             for ((i = ${#words[@]} - 2; i > 0; i--)); do
                 if [[ ${words[i]} == -@(C|-fontpath) ]]; then

--- a/completions-core/ip.bash
+++ b/completions-core/ip.bash
@@ -567,7 +567,7 @@ _comp_cmd_ip()
                         _comp_cmd_ip__netns "$1"
                     else
                         local offset
-                        offset="$((subcword + 2 - all_offset))"
+                        offset=$((subcword + 2 - all_offset))
                         _comp_command_offset "$offset"
                     fi
                     ;;

--- a/completions-core/mr.bash
+++ b/completions-core/mr.bash
@@ -7,14 +7,14 @@ _comp_cmd_mr()
 
     local help commands options
 
-    help="$(PERLDOC_PAGER=cat PERLDOC=-otext "${1}" help 2>/dev/null)"
+    help=$(PERLDOC_PAGER=cat PERLDOC=-otext "${1}" help 2>/dev/null)
 
-    commands="$(
+    commands=$(
         # shellcheck disable=SC2030
         printf %s "$help" | while read -r _ options cmd _; do
             [[ $options != "[options]" ]] || printf "%s\n" "$cmd"
         done
-    )"
+    )
     # Split [online|offline] and remove `action` placeholder.
     commands="${commands//@(action|[\[\|\]])/ }"
     # Add standard aliases.

--- a/completions-core/mutt.bash
+++ b/completions-core/mutt.bash
@@ -101,7 +101,7 @@ _comp_cmd_mutt__query()
     [[ $cur ]] || return 0
     local muttcmd=${words[0]}
 
-    local querycmd="$("$muttcmd" -Q query_command 2>/dev/null | command sed -e 's|^query_command="\(.*\)"$|\1|' -e 's|%s|'"$cur"'|')"
+    local querycmd=$("$muttcmd" -Q query_command 2>/dev/null | command sed -e 's|^query_command="\(.*\)"$|\1|' -e 's|%s|'"$cur"'|')
     if [[ $querycmd ]]; then
         local REPLY
         _comp_expand_tilde "$querycmd"
@@ -120,7 +120,7 @@ _comp_cmd_mutt__filedir()
     _comp_cmd_mutt__get_muttrc
     muttrc=$REPLY
     if [[ $cur == [=+]* ]]; then
-        folder="$("$muttcmd" -F "$muttrc" -Q folder 2>/dev/null | command sed -e 's|^folder="\(.*\)"$|\1|')"
+        folder=$("$muttcmd" -F "$muttrc" -Q folder 2>/dev/null | command sed -e 's|^folder="\(.*\)"$|\1|')
         [[ $folder ]] || folder=~/Mail
 
         # Match any file in $folder beginning with $cur
@@ -130,8 +130,8 @@ _comp_cmd_mutt__filedir()
         COMPREPLY=("${COMPREPLY[@]#"$folder"/}")
         return
     elif [[ $cur == !* ]]; then
-        spoolfile="$("$muttcmd" -F "$muttrc" -Q spoolfile 2>/dev/null |
-            command sed -e 's|^spoolfile="\(.*\)"$|\1|')"
+        spoolfile=$("$muttcmd" -F "$muttrc" -Q spoolfile 2>/dev/null |
+            command sed -e 's|^spoolfile="\(.*\)"$|\1|')
         if [[ $spoolfile ]]; then
             _comp_dequote "\"$spoolfile\"" && spoolfile=$REPLY
             cur=$spoolfile${cur:1}

--- a/completions-core/openssl.bash
+++ b/completions-core/openssl.bash
@@ -47,7 +47,7 @@ _comp_cmd_openssl()
     if ((cword == 1)); then
         local commands
         # We only want the standard commands, so we delete everything starting after and including "Message Digest commands"
-        commands="$("$1" help 2>&1 | command sed -e '/Standard commands/d;/help:/d' -e '/Message Digest commands/,$d')"
+        commands=$("$1" help 2>&1 | command sed -e '/Standard commands/d;/help:/d' -e '/Message Digest commands/,$d')
         _comp_compgen -- -W "$commands"
     else
         command=${words[1]}

--- a/completions-core/p4.bash
+++ b/completions-core/p4.bash
@@ -9,7 +9,7 @@ _comp_cmd_p4()
     local p4commands p4filetypes
 
     # rename isn't really a command
-    p4commands="$(p4 help commands 2>/dev/null | _comp_awk 'NF>3 {print $1}')"
+    p4commands=$(p4 help commands 2>/dev/null | _comp_awk 'NF>3 {print $1}')
     p4filetypes="ctext cxtext ktext kxtext ltext tempobj ubinary \
         uresource uxbinary xbinary xltext xtempobj xtext \
         text binary resource"

--- a/completions-core/pylint.bash
+++ b/completions-core/pylint.bash
@@ -8,14 +8,14 @@ _comp_cmd_pylint__message_ids()
     # TODO(scop): The fallback here is slow, maybe memoize whether
     #   --list-msgs-enabled worked (>= 2.4.0) and avoid unnecessary tries
     #   again later?
-    local msgs="$(
+    local msgs=$(
         set -o pipefail
         "$1" --list-msgs-enabled 2>/dev/null |
             command sed -ne "$filter" |
             command sed -ne 's/^[[:space:]]\{1,\}\([a-z-]\{6,\}\).*/\1/p' ||
             "$1" --list-msgs 2>/dev/null |
             command sed -ne 's/^:\([a-z-]\{6,\}\).*/\1/p'
-    )"
+    )
     _comp_delimited , -W "$msgs"
 }
 

--- a/completions-core/ri.bash
+++ b/completions-core/ri.bash
@@ -77,7 +77,7 @@ _comp_cmd_ri()
     # which version of ri are we using?
     # -W0 is required here to stop warnings from older versions of ri
     # from being captured when used with Ruby 1.8.1 and later
-    ri_version="$(ruby -W0 "$ri_path" -v 2>&1)" || ri_version=integrated
+    ri_version=$(ruby -W0 "$ri_path" -v 2>&1) || ri_version=integrated
     [[ $ri_version != "${ri_version%200*}" ]] && ri_version=integrated
     [[ $ri_version =~ ri[[:space:]]v?([0-9]+) ]] && ri_major=${BASH_REMATCH[1]}
 

--- a/completions-core/tar.bash
+++ b/completions-core/tar.bash
@@ -803,7 +803,7 @@ _comp_cmd_tar__posix()
 _comp_cmd_tar()
 {
     local cmd=${COMP_WORDS[0]} func line
-    line="$("$cmd" --version 2>/dev/null)"
+    line=$("$cmd" --version 2>/dev/null)
     case "$line" in
         *GNU*)
             func=_comp_cmd_tar__gnu

--- a/completions-core/tshark.bash
+++ b/completions-core/tshark.bash
@@ -23,8 +23,8 @@ _comp_cmd_tshark()
                 _comp_compgen -c "${cur#*:}" filedir
             else
                 [[ -v _comp_cmd_tshark__prefs ]] ||
-                    _comp_cmd_tshark__prefs="$("$1" -G defaultprefs 2>/dev/null | command sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
-                        tr '\n' ' ')"
+                    _comp_cmd_tshark__prefs=$("$1" -G defaultprefs 2>/dev/null | command sed -ne 's/^#\{0,1\}\([a-z0-9_.-]\{1,\}:\).*/\1/p' |
+                        tr '\n' ' ')
                 : ${prefix:=}
                 _comp_compgen -P "$prefix" -- -W "$_comp_cmd_tshark__prefs"
                 [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
@@ -72,8 +72,8 @@ _comp_cmd_tshark()
             ;;
         -*O)
             [[ -v _comp_cmd_tshark__protocols ]] ||
-                _comp_cmd_tshark__protocols="$("$1" -G protocols 2>/dev/null |
-                    cut -f 3 | tr '\n' ' ')"
+                _comp_cmd_tshark__protocols=$("$1" -G protocols 2>/dev/null |
+                    cut -f 3 | tr '\n' ' ')
             _comp_delimited , -W "$_comp_cmd_tshark__protocols"
             return
             ;;

--- a/completions-core/xfreerdp.bash
+++ b/completions-core/xfreerdp.bash
@@ -67,7 +67,7 @@ _comp_cmd_xfreerdp()
         [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
     elif [[ $cur == [+-]* ]]; then
         local char=${cur:0:1}
-        local help="$("$1" --help)"
+        local help=$("$1" --help)
         if [[ $help == */help* ]]; then # new/slash syntax
             _comp_compgen_split -- "$(_comp_awk '$1 ~ /^[+-]/ && $1 !~ /^.toggle$/ {
                     sub("^.","'"$char"'",$1); print $1 }' <<<"$help")"

--- a/completions-fallback/modules.bash
+++ b/completions-fallback/modules.bash
@@ -23,23 +23,23 @@
 
 _comp_cmd_module__compgen_list()
 {
-    local modules="$(command sed 's/:/ /g' <<<"$LOADEDMODULES" | sort)"
+    local modules=$(command sed 's/:/ /g' <<<"$LOADEDMODULES" | sort)
     _comp_compgen -- -W "$modules"
 }
 
 _comp_cmd_module__compgen_path()
 {
-    local modules="$(command sed 's/:/ /g' <<<"$MODULEPATH" | sort)"
+    local modules=$(command sed 's/:/ /g' <<<"$MODULEPATH" | sort)
     _comp_compgen -- -W "$modules"
 }
 
 _comp_cmd_module__compgen_avail()
 {
-    local modules="$(
+    local modules=$(
         module avail 2>&1 |
             command grep -E -v '^(-|$)' |
             xargs printf '%s\n' | command sed -e 's/(default)//g' | sort
-    )"
+    )
     _comp_compgen -- -W "$modules"
 }
 
@@ -53,8 +53,8 @@ _comp_cmd_module()
         # First parameter on line -- we expect it to be a mode selection
 
         local options
-        options="$(module help 2>&1 | command grep -E '^[[:space:]]*\+' |
-            _comp_awk '{print $2}' | command sed -e 's/|/ /g' | sort)"
+        options=$(module help 2>&1 | command grep -E '^[[:space:]]*\+' |
+            _comp_awk '{print $2}' | command sed -e 's/|/ /g' | sort)
 
         _comp_compgen -- -W "$options"
 

--- a/completions-fallback/umount.linux.bash
+++ b/completions-fallback/umount.linux.bash
@@ -69,7 +69,7 @@ _comp_cmd_umount__linux_fstab()
     if [[ $cur && $cur != /* ]]; then
         local realcur
         [[ $cur == */ ]] && # don't let readlink drop last / from path
-            realcur="$(readlink -f "$cur." 2>/dev/null)/" ||
+            realcur=$(readlink -f "$cur." 2>/dev/null)/ ||
             realcur=$(readlink -f "$cur" 2>/dev/null)
         if [[ $realcur ]]; then
             local dirrealcur="" dircur=. basecur

--- a/test/docker/entrypoint.sh
+++ b/test/docker/entrypoint.sh
@@ -21,7 +21,7 @@ ssh-keygen -t ed25519 -N '' -f "$HOME/.ssh/id_ed25519"
 cat "$HOME/.ssh/id_ed25519.pub" >>"$HOME/.ssh/authorized_keys"
 
 # sshd forces you to run with the full path
-sshpath="$(command -v sshd)"
+sshpath=$(command -v sshd)
 $sshpath
 
 autoreconf -i


### PR DESCRIPTION
As suggested in https://github.com/scop/bash-completion/pull/1564#discussion_r2749378798.

After merging this, I'm going to submit another PR to refactor some of the commands inside those command substitutions.