### PR TITLE
fix(make): properly skip the "Not a target" block in the helper AWK

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -72,3 +72,8 @@ extend-exclude = ["CHANGELOG.md"]
 [type.test_export]
 extend-glob = ["test_export.py"]
 extend-identifiers = { BASH_VERSIO = "BASH_VERSIO" }
+
+# test/t/test_make.py
+[type.test_make]
+extend-glob = ["test_make.py"]
+extend-words = { ba = "ba" }

--- a/helpers-core/make-extract-targets.awk
+++ b/helpers-core/make-extract-targets.awk
@@ -29,7 +29,20 @@ NR == 1, /^# +Make data base/ { next; }
 /^# +Variables/, /^# +Files/ { next; }
 
 # skip not-target blocks
-/^# +Not a target/, /^$/     { next; }
+/^# +Not a target/, /^$/ {
+  # We need to manually clear the state.  Without it, the cleanup associated
+  # with the present block would be skipped because /^$/ on the above line also
+  # consumes the empty line.  This would become an issue with the case where
+  # the "Not a target" line appears in the middle of a block, e.g., for the
+  # case with "foobar: OUCH = glitch" without the actual rule for "foobar".
+  # The leftover information would be associated with the next target block
+  # unexpectedly.
+  #
+  # https://github.com/scop/bash-completion/pull/1577
+  is_target_block = 0;
+  target = "";
+  next;
+}
 
 # The stuff above here describes lines that are not
 #  explicit targets or not targets other than special ones

--- a/test/fixtures/make/Makefile
+++ b/test/fixtures/make/Makefile
@@ -44,3 +44,8 @@ VARIABLE_LOOKS_A_BIT_LIKE_A_TARGET := fooled-you
 extra_makefile:
 	touch $@
 include extra_makefile
+
+# foobar is not actually a target, the line is setting target-specific variables
+# not defining a target so it shouldn't show up in the completion list
+fluff:
+foobar: OUCH = glitch

--- a/test/fixtures/make/test_github_pr_1577/Makefile
+++ b/test/fixtures/make/test_github_pr_1577/Makefile
@@ -1,0 +1,13 @@
+all: fluff
+fluff:
+	touch fluff
+
+common-proc:
+	echo $(OUCH)
+.PHONY: common-proc
+
+foobar: OUCH = glitch
+foobar: common-proc
+
+barbaz: OUCH = switch
+barbaz: common-proc

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -37,7 +37,10 @@ class TestMake:
 
     @pytest.mark.complete("make ", cwd="make", require_cmd=True)
     def test_6(self, bash, completion, remove_extra_makefile):
-        assert completion == "all clean extra_makefile install sample".split()
+        assert (
+            completion
+            == "all clean extra_makefile fluff install sample".split()
+        )
 
     @pytest.mark.complete("make .cache/.", cwd="make", require_cmd=True)
     def test_7(self, bash, completion, remove_extra_makefile):
@@ -45,15 +48,42 @@ class TestMake:
 
     @pytest.mark.complete("make -C make ", require_cmd=True)
     def test_8(self, bash, completion, remove_extra_makefile):
-        assert completion == "all clean extra_makefile install sample".split()
+        assert (
+            completion
+            == "all clean extra_makefile fluff install sample".split()
+        )
 
     @pytest.mark.complete("make -nC make ", require_cmd=True)
     def test_8n(self, bash, completion, remove_extra_makefile):
-        assert completion == "all clean extra_makefile install sample".split()
+        assert (
+            completion
+            == "all clean extra_makefile fluff install sample".split()
+        )
 
     @pytest.mark.complete("make -", require_cmd=True)
     def test_9(self, completion):
         assert completion
+
+    @pytest.mark.complete("make f", cwd="make", require_cmd=True)
+    def test_github_pr_1577_1(self, bash, completion, remove_extra_makefile):
+        """The completion should not generate an unmatching target like "all",
+        which appears after the "Not a target" sequence, affected by the
+        leftover state for "foobar".  Otherwise, "fluff" would fail to be
+        completed as the unique completion.
+
+        https://github.com/scop/bash-completion/pull/1577
+        """
+        assert completion == "luff"
+
+    @pytest.mark.complete(
+        "make ba", cwd="make/test_github_pr_1577", require_cmd=True
+    )
+    def test_github_pr_1577_2(self, bash, completion):
+        """Although the "Not a target" version of "foobar: OUCH = glitch"
+        should be excluded, the version with the actual recipe should still be
+        generated.
+        """
+        assert completion == "rbaz"
 
 
 @pytest.mark.bashcomp(require_cmd=True, cwd="make/test2")


### PR DESCRIPTION
In some obscure cases, `target: VAR = val` can cause `make t` to autocomplete to the incorrect result.

This is happening in one of my projects with a somewhat complex set of makefiles, such that `make w` returns windows, webgl, and a random build file. A silly, though minimal repro is:

```
all: fluff
fluff:
	touch fluff
foobar: OUCH = glitch
```

where `make f` will erroneously list completion possibilities `all fluff`

The root cause is that the foobar 'block' looks like this

```
# makefile (from 'Makefile', line 4)
foobar: OUCH = glitch
# Not a target:
foobar:
#  Implicit rule search has not been done.
#  Modification time never checked.
#  File has not been updated.
# variable set hash-table stats:
# Load=1/32=3%, Rehash=0, Collisions=0/2=0%
```
  
the script matches f against foobar, setting the target flag true, then it encounters `# Not a target` over and over and over again until it hits the all target, and because the target flag is true, it accepts that. The solution is to make `# Not a target` reset the flag as it skips.

You can test the script in isolation with: `make -npq __BASH_MAKE_COMPLETION__=1 -C . .DEFAULT 2>/dev/null | prefix="f" prefix_replace="f" awk -f make-extract-targets.awk`

Tested on Debian Trixie with GNU Make 4.4.1, the latest in Debian.

Here is the output of make -nqp on the minimal repro makefile for your convenience: [make-nqp-output.txt](https://github.com/user-attachments/files/25617961/make-nqp-output.txt)
