### PR TITLE
test(docker): add AlmaLinux 9 image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - dist: almalinux9
           - dist: alpine
           - dist: centos7
           - dist: debian10

--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - dist: almalinux9
           - dist: alpine
           - dist: centos7
           - dist: debian10

--- a/test/docker/almalinux9/Dockerfile
+++ b/test/docker/almalinux9/Dockerfile
@@ -1,0 +1,24 @@
+FROM almalinux:9
+
+RUN set -x \
+    echo install_weak_deps=False >> /etc/dnf/dnf.conf \
+    && dnf -y --refresh upgrade \
+    && dnf -y install epel-release \
+    && dnf -y --refresh install \
+        /usr/bin/autoconf \
+        /usr/bin/automake \
+        /usr/bin/make \
+        /usr/bin/xvfb-run \
+        /usr/bin/pytest-3 \
+        openssh-server \
+        python3-pexpect \
+        python3-pytest-xdist \
+    && ln -s $(type -P pytest-3) /usr/local/bin/pytest
+
+ADD test-cmd-list.txt \
+    docker/almalinux9/install-packages.sh \
+    /tmp/
+
+RUN /tmp/install-packages.sh </tmp/test-cmd-list.txt \
+    && dnf -Cy clean all \
+    && rm -r /tmp/* /var/lib/dnf/history.sqlite* /var/lib/dnf/repos/*

--- a/test/docker/almalinux9/install-packages.sh
+++ b/test/docker/almalinux9/install-packages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -xeuo pipefail
+
+shopt -s extglob
+
+cd "${TMPDIR:-/tmp}"
+
+while read -r file; do
+    case $file in
+        /*) printf "%s\n" "$file" ;;
+        *) printf "%s\n" {/usr,}/{,s}bin/"$file" ;;
+    esac
+done |
+    xargs dnf -y install --skip-broken
+# --skip-broken: avoid failing on not found packages. Also prevents actually
+# broken packages from failing the install which is not what we want, but
+# there doesn't seem to be way to cleanly just skip the not found ones.


### PR DESCRIPTION
Mostly for Bash 5.1 test coverage, and likely eventual CentOS 7 replacement.