### PR TITLE
chore: switch from pre-commit to prek

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,3 +1,3 @@
 -r ../test/requirements-dev.txt
 
-pre-commit>=3.2.0
+prek>=0.3.8

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,3 +1,3 @@
 -r ../test/requirements-dev.txt
 
-pre-commit>=3.2.0
+prek>=0.4.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
             test/requirements*.txt
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{hashFiles('.pre-commit-config.yaml')}}
+          path: ~/.cache/prek
+          key: prek-${{hashFiles('.pre-commit-config.yaml')}}
       - name: Install dependencies
         run: |
           python3 -m venv venv  # for venv-run
@@ -34,7 +34,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           source venv/bin/activate
-          pre-commit run --color=always --all-files --show-diff-on-failure
+          prek run --color=always --all-files --show-diff-on-failure
 
   distcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
             test/requirements*.txt
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{hashFiles('.pre-commit-config.yaml')}}
+          path: ~/.cache/prek
+          key: prek-${{hashFiles('.pre-commit-config.yaml')}}
       - name: Install dependencies
         run: |
           python3 -m venv venv  # for venv-run
@@ -34,7 +34,7 @@ jobs:
       - name: Run pre-commit checks
         run: |
           source venv/bin/activate
-          pre-commit run --color=always --all-files --show-diff-on-failure
+          prek run --color=always --all-files --show-diff-on-failure
 
   distcheck:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,14 +226,14 @@ Also, please bear the following coding guidelines in mind:
   python3 -m pip install -r test/requirements-dev.txt
   ```
 
-- Install pre-commit and set it up, see <https://pre-commit.com/>.
+- Install prek and set it up, see <https://prek.j178.dev>.
   That'll run a bunch of linters and the like, the same as the
   bash-completion CI does. Running it locally and fixing found issues before
   commit/push/PR reduces some roundtrips with the review.
   After installing it, enable it for stages we use it with like:
 
   ```shell
-  pre-commit install --hook-type pre-commit --hook-type commit-msg
+  prek install --hook-type pre-commit --hook-type commit-msg
   ```
 
 - File bugs, enhancement, and pull requests at GitHub,


### PR DESCRIPTION
This is an interim change as we may end up revamping pre-commit checks further, but in the meantime, might just as well [reap benefits of prek over pre-commit](https://prek.j178.dev/#why-prek).

To migrate existing pre-commit enabled setups:
  `prek install --overwrite --hook-type pre-commit --hook-type commit-msg`