### PR TITLE
fix(iscsiadm): separate merged options (--logoutall--show → --logoutall --show)

### DIFF
--- a/completions-core/iscsiadm.bash
+++ b/completions-core/iscsiadm.bash
@@ -38,7 +38,7 @@ _comp_cmd_iscsiadm()
                 ;;
             node)
                 options='--help --version --debug --print --loginall \
-                    --logoutall--show  -T --portal --interface --login \
+                    --logoutall --show  -T --portal --interface --login \
                     --logout --rescan --stats --op --name --value'
                 ;;
             session)

--- a/completions-core/iscsiadm.bash
+++ b/completions-core/iscsiadm.bash
@@ -38,7 +38,7 @@ _comp_cmd_iscsiadm()
                 ;;
             node)
                 options='--help --version --debug --print --loginall \
-                    --logoutall --show  -T --portal --interface --login \
+                    --logoutall --show -T --portal --interface --login \
                     --logout --rescan --stats --op --name --value'
                 ;;
             session)


### PR DESCRIPTION
## Description

Fix incorrect option concatenation in `iscsiadm` bash completion.

In `node` mode, the options `--logoutall` and `--show` are incorrectly merged in the completion script as:
--logoutall--show

This happens due to a missing space between the two options in:
`completions-core/iscsiadm.bash`

---
Fixes #1611  

## Problem

Because of this concatenation:

- Bash treats `--logoutall--show` as a single invalid option
- Tab completion suggestions become incorrect
- In some cases, repeated or malformed completions may be inserted into the command line

---

## Fix

This patch separates the options correctly by adding a space:

```diff
- --logoutall--show
+ --logoutall --show

