### PR TITLE
test(pytest): skip instead of xfail where appropriate

### DIFF
--- a/test/t/test_chown.py
+++ b/test/t/test_chown.py
@@ -12,7 +12,7 @@ from conftest import assert_complete
     )
 )
 class TestChown:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         getpass.getuser() != "root", reason="Only root can chown to all users"
     )
     @pytest.mark.complete("chown ")

--- a/test/t/test_dict.py
+++ b/test/t/test_dict.py
@@ -8,7 +8,7 @@ class TestDict:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         os.environ.get("NETWORK") == "none",
         reason="The database list is unavailable without network",
     )
@@ -20,7 +20,7 @@ class TestDict:
         # completions.
         assert completion and "_comp_load/" not in completion
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         os.environ.get("NETWORK") == "none",
         reason="The database list is unavailable without network",
     )

--- a/test/t/test_dpkg_query.py
+++ b/test/t/test_dpkg_query.py
@@ -9,7 +9,7 @@ class TestDpkgQuery:
     def test_options(self, completion):
         assert completion
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         not os.path.exists("/etc/debian_version"),
         reason="Likely fails on systems not based on Debian",
     )

--- a/test/t/test_ether_wake.py
+++ b/test/t/test_ether_wake.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.bashcomp(cmd="ether-wake")
 class TestEtherWake:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         os.environ.get("NETWORK") == "none",
         reason="MAC addresses may be N/A with no networking configured",
     )

--- a/test/t/test_gkrellm.py
+++ b/test/t/test_gkrellm.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 
-@pytest.mark.xfail(not os.environ.get("DISPLAY"), reason="X display required")
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="X display required")
 class TestGkrellm:
     @pytest.mark.complete("gkrellm -", require_cmd=True)
     def test_1(self, completion):

--- a/test/t/test_ifdown.py
+++ b/test/t/test_ifdown.py
@@ -6,11 +6,11 @@ from conftest import in_container
 
 
 class TestIfdown:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         os.environ.get("NETWORK") == "none",
         reason="There won't be any configured interfaces without network",
     )
-    @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
+    @pytest.mark.skipif(in_container(), reason="Probably fails in a container")
     @pytest.mark.complete("ifdown ", require_cmd=True)
     def test_1(self, completion):
         assert completion

--- a/test/t/test_ifup.py
+++ b/test/t/test_ifup.py
@@ -6,11 +6,11 @@ from conftest import in_container
 
 
 class TestIfup:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         os.environ.get("NETWORK") == "none",
         reason="There won't be any configured interfaces without network",
     )
-    @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
+    @pytest.mark.skipif(in_container(), reason="Probably fails in a container")
     @pytest.mark.complete("ifup ", require_cmd=True)
     def test_1(self, completion):
         assert completion

--- a/test/t/test_invoke_rc_d.py
+++ b/test/t/test_invoke_rc_d.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.bashcomp(cmd="invoke-rc.d")
 class TestInvokeRcD:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         sys.platform == "darwin",
         reason="Service completion not available on macOS",
     )

--- a/test/t/test_postfix.py
+++ b/test/t/test_postfix.py
@@ -8,7 +8,7 @@ class TestPostfix:
     def test_1(self, completion):
         assert completion
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         getpass.getuser() != "root",
         reason="Likely outputs usage only for root",
     )

--- a/test/t/test_service.py
+++ b/test/t/test_service.py
@@ -6,7 +6,7 @@ from conftest import assert_complete, bash_env_saved
 
 
 class TestService:
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         sys.platform == "darwin",
         reason="Service completion not available on macOS",
     )

--- a/test/t/unit/test_unit_compgen_ip_addresses.py
+++ b/test/t/unit/test_unit_compgen_ip_addresses.py
@@ -41,7 +41,7 @@ class TestUnitCompgenIpAddresses:
         assert completion
         assert all("." in x for x in completion)
 
-    @pytest.mark.xfail(in_container(), reason="Probably fails in a container")
+    @pytest.mark.skipif(in_container(), reason="Probably fails in a container")
     @pytest.mark.complete("ia6 ")
     def test_4(self, functions, completion):
         """_comp_compgen_ip_addresses -6 should complete ipv6 addresses."""


### PR DESCRIPTION
Skipping is appropriate for cases where there's no point in running the tests for some reason we can detect, whereas expecting failure is more like a TODO thing -- known bug or a missing feature.

Ref https://docs.pytest.org/en/stable/how-to/skipping.html

This only addresses pytest.mark.xfail/skipif for now, not yet our pytest.mark.complete skipif=/xfail= (there's a lot of that in the tree).