### PR TITLE
fix(nsupdate): fix typo `_comp_com{tp => pg}en`

### DIFF
--- a/completions-core/nsupdate.bash
+++ b/completions-core/nsupdate.bash
@@ -19,7 +19,7 @@ _comp_cmd_nsupdate()
             ;;
         -*y)
             if [[ $cur == h* ]]; then
-                _comp_comtpen -- -W "hmac-{md5,sha{1,224,256,384,512}}" -S :
+                _comp_compgen -- -W "hmac-{md5,sha{1,224,256,384,512}}" -S :
                 [[ ${COMPREPLY-} == *: ]] && compopt -o nospace
             fi
             return


### PR DESCRIPTION
This is a regression introduced by commit 18723c81. I noticed this in https://github.com/scop/bash-completion/pull/1569#issuecomment-4276206193.