### PR TITLE
feat(aclocal,automake): support versioned 1.18 executables

### DIFF
--- a/completions-core/.gitignore
+++ b/completions-core/.gitignore
@@ -2,7 +2,7 @@
 /7zr.bash
 /7zz.bash
 /7zzs.bash
-/aclocal-1.1[01234567].bash
+/aclocal-1.1[012345678].bash
 /alpine.bash
 /alternatives.bash
 /animate.bash
@@ -11,7 +11,7 @@
 /arm-koji.bash
 /asciidoc.py.bash
 /autoheader.bash
-/automake-1.1[01234567].bash
+/automake-1.1[012345678].bash
 /autossh.bash
 /autoupdate.bash
 /avahi-browse-domains.bash

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -488,6 +488,7 @@ CLEANFILES = \
 	aclocal-1.15.bash \
 	aclocal-1.16.bash \
 	aclocal-1.17.bash \
+	aclocal-1.18.bash \
 	alpine.bash \
 	alternatives.bash \
 	animate.bash \
@@ -504,6 +505,7 @@ CLEANFILES = \
 	automake-1.15.bash \
 	automake-1.16.bash \
 	automake-1.17.bash \
+	automake-1.18.bash \
 	autossh.bash \
 	autoupdate.bash \
 	avahi-browse-domains.bash \
@@ -823,7 +825,8 @@ symlinks: $(DATA)
 		7zzs
 	$(ss) aclocal \
 		aclocal-1.10 aclocal-1.11 aclocal-1.12 aclocal-1.13 \
-		aclocal-1.14 aclocal-1.15 aclocal-1.16 aclocal-1.17
+		aclocal-1.14 aclocal-1.15 aclocal-1.16 aclocal-1.17 \
+		aclocal-1.18
 	$(ss) ant \
 		phing
 	$(ss) aptitude \
@@ -832,7 +835,8 @@ symlinks: $(DATA)
 		asciidoc.py
 	$(ss) automake \
 		automake-1.10 automake-1.11 automake-1.12 automake-1.13 \
-		automake-1.14 automake-1.15 automake-1.16 automake-1.17
+		automake-1.14 automake-1.15 automake-1.16 automake-1.17 \
+		automake-1.18
 	$(ss) autoreconf \
 		autoheader
 	$(ss) autoscan \

--- a/completions-core/aclocal.bash
+++ b/completions-core/aclocal.bash
@@ -30,6 +30,6 @@ _comp_cmd_aclocal()
     _comp_compgen_help
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
-    complete -F _comp_cmd_aclocal aclocal aclocal-1.1{0..6}
+    complete -F _comp_cmd_aclocal aclocal aclocal-1.1{0..8}
 
 # ex: filetype=sh

--- a/completions-core/automake.bash
+++ b/completions-core/automake.bash
@@ -31,6 +31,6 @@ _comp_cmd_automake()
 
     _comp_compgen_filedir
 } &&
-    complete -F _comp_cmd_automake automake automake-1.1{0..6}
+    complete -F _comp_cmd_automake automake automake-1.1{0..8}
 
 # ex: filetype=sh


### PR DESCRIPTION
As a side effect, fixes support for 1.17 ones.