### PR TITLE
Deprecate dpkg completion

### DIFF
--- a/completions-core/.gitignore
+++ b/completions-core/.gitignore
@@ -45,8 +45,6 @@
 /dcop.bash
 /dfutool.bash
 /display.bash
-/dpkg-deb.bash
-/dpkg-query.bash
 /dropdb.bash
 /dropuser.bash
 /edquota.bash

--- a/completions-core/.gitignore
+++ b/completions-core/.gitignore
@@ -47,7 +47,6 @@
 /display.bash
 /dpkg-deb.bash
 /dpkg-query.bash
-/dpkg-reconfigure.bash
 /dropdb.bash
 /dropuser.bash
 /edquota.bash

--- a/completions-core/.gitignore
+++ b/completions-core/.gitignore
@@ -4,7 +4,6 @@
 /7zzs.bash
 /aclocal-1.1[012345678].bash
 /alpine.bash
-/alternatives.bash
 /animate.bash
 /apropos.bash
 /aptitude-curses.bash

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -85,7 +85,6 @@ cross_platform = 2to3.bash \
 		dnsspoof.bash \
 		doas.bash \
 		dot.bash \
-		dpkg.bash \
 		dpkg-reconfigure.bash \
 		dsniff.bash \
 		dumpdb.bash \
@@ -538,8 +537,6 @@ CLEANFILES = \
 	dcop.bash \
 	dfutool.bash \
 	display.bash \
-	dpkg-deb.bash \
-	dpkg-query.bash \
 	dropdb.bash \
 	dropuser.bash \
 	edquota.bash \
@@ -866,8 +863,6 @@ symlinks: $(DATA)
 		typeset
 	$(ss) dict \
 		rdict
-	$(ss) dpkg \
-		dpkg-deb dpkg-query
 	$(ss) ether-wake \
 		etherwake
 	$(ss) filesnarf \

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -87,7 +87,6 @@ cross_platform = 2to3.bash \
 		dot.bash \
 		dpkg.bash \
 		dpkg-reconfigure.bash \
-		dpkg-source.bash \
 		dsniff.bash \
 		dumpdb.bash \
 		dumpe2fs.bash \

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -86,6 +86,7 @@ cross_platform = 2to3.bash \
 		doas.bash \
 		dot.bash \
 		dpkg.bash \
+		dpkg-reconfigure.bash \
 		dpkg-source.bash \
 		dselect.bash \
 		dsniff.bash \
@@ -541,7 +542,6 @@ CLEANFILES = \
 	display.bash \
 	dpkg-deb.bash \
 	dpkg-query.bash \
-	dpkg-reconfigure.bash \
 	dropdb.bash \
 	dropuser.bash \
 	edquota.bash \
@@ -869,7 +869,7 @@ symlinks: $(DATA)
 	$(ss) dict \
 		rdict
 	$(ss) dpkg \
-		dpkg-deb dpkg-query dpkg-reconfigure
+		dpkg-deb dpkg-query
 	$(ss) ether-wake \
 		etherwake
 	$(ss) filesnarf \

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -88,7 +88,6 @@ cross_platform = 2to3.bash \
 		dpkg.bash \
 		dpkg-reconfigure.bash \
 		dpkg-source.bash \
-		dselect.bash \
 		dsniff.bash \
 		dumpdb.bash \
 		dumpe2fs.bash \

--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -6,6 +6,7 @@ cross_platform = 2to3.bash \
 		acpi.bash \
 		add_members.bash \
 		alias.bash \
+		alternatives.bash \
 		ant.bash \
 		apache2ctl.bash \
 		appdata-validate.bash \
@@ -399,7 +400,6 @@ cross_platform = 2to3.bash \
 		unpack200.bash \
 		unrar.bash \
 		unshunt.bash \
-		update-alternatives.bash \
 		update-rc.d.bash \
 		upgradepkg.bash \
 		urlsnarf.bash \
@@ -490,7 +490,6 @@ CLEANFILES = \
 	aclocal-1.17.bash \
 	aclocal-1.18.bash \
 	alpine.bash \
-	alternatives.bash \
 	animate.bash \
 	apropos.bash \
 	aptitude-curses.bash \
@@ -1025,8 +1024,6 @@ endif
 		bsdtar gtar star
 	$(ss) tracepath \
 		tracepath6
-	$(ss) update-alternatives \
-		alternatives
 	$(ss) vipw \
 		vigr
 	$(ss) vncviewer \

--- a/completions-core/alternatives.bash
+++ b/completions-core/alternatives.bash
@@ -2,7 +2,7 @@
 
 _comp_cmd_alternatives__installed()
 {
-    local i admindir
+    local i admindir=""
     # find the admin dir
     for i in alternatives rpm/alternatives; do
         [[ -d /var/lib/$i ]] && admindir=/var/lib/$i && break

--- a/completions-core/alternatives.bash
+++ b/completions-core/alternatives.bash
@@ -1,10 +1,10 @@
-# bash completion for update-alternatives
+# bash completion for alternatives
 
-_comp_cmd_update_alternatives__installed()
+_comp_cmd_alternatives__installed()
 {
     local i admindir
     # find the admin dir
-    for i in alternatives dpkg/alternatives rpm/alternatives; do
+    for i in alternatives rpm/alternatives; do
         [[ -d /var/lib/$i ]] && admindir=/var/lib/$i && break
     done
     for ((i = 1; i < cword; i++)); do
@@ -16,7 +16,7 @@ _comp_cmd_update_alternatives__installed()
     [[ -d $admindir ]] && _comp_compgen_split -- "$(command ls "$admindir")"
 }
 
-_comp_cmd_update_alternatives()
+_comp_cmd_alternatives()
 {
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
@@ -49,7 +49,7 @@ _comp_cmd_update_alternatives()
                     _comp_compgen_filedir
                     ;;
                 2)
-                    _comp_cmd_update_alternatives__installed
+                    _comp_cmd_alternatives__installed
                     ;;
                 4)
                     # priority - no completions
@@ -63,7 +63,7 @@ _comp_cmd_update_alternatives()
                             _comp_compgen -- -W '--slave'
                             ;;
                         3)
-                            _comp_cmd_update_alternatives__installed
+                            _comp_cmd_alternatives__installed
                             ;;
                     esac
                     ;;
@@ -72,7 +72,7 @@ _comp_cmd_update_alternatives()
         --remove | --set)
             case $args in
                 1)
-                    _comp_cmd_update_alternatives__installed
+                    _comp_cmd_alternatives__installed
                     ;;
                 2)
                     _comp_compgen_filedir
@@ -80,7 +80,7 @@ _comp_cmd_update_alternatives()
             esac
             ;;
         --auto | --remove-all | --display | --config)
-            _comp_cmd_update_alternatives__installed
+            _comp_cmd_alternatives__installed
             ;;
         *)
             _comp_compgen_help - <<<"$(LANG=C "$1" --help 2>&1 | command sed '
@@ -92,4 +92,4 @@ _comp_cmd_update_alternatives()
             ;;
     esac
 } &&
-    complete -F _comp_cmd_update_alternatives update-alternatives alternatives
+    complete -F _comp_cmd_alternatives alternatives

--- a/completions-core/alternatives.bash
+++ b/completions-core/alternatives.bash
@@ -13,7 +13,7 @@ _comp_cmd_alternatives__installed()
             break
         fi
     done
-    [[ -d $admindir ]] && _comp_compgen_split -- "$(command ls "$admindir")"
+    [[ -d $admindir ]] && _comp_compgen -C "$admindir" -- -fX '*/*'
 }
 
 _comp_cmd_alternatives()

--- a/completions-core/dpkg-reconfigure.bash
+++ b/completions-core/dpkg-reconfigure.bash
@@ -1,0 +1,34 @@
+# dpkg-reconfigure(1) completion
+
+_comp_cmd_dpkg_reconfigure()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    local opt
+
+    local noargopts='!(-*|*[fp]*)'
+    # shellcheck disable=SC2254
+    case $prev in
+        --frontend | -${noargopts}f)
+            if _comp_expand_glob opt '/usr/share/perl5/Debconf/FrontEnd/*'; then
+                opt=("${opt[@]##*/}")
+                opt=("${opt[@]%.pm}")
+                _comp_compgen -- -W '"${opt[@]}"'
+            fi
+            return
+            ;;
+        --priority | -${noargopts}p)
+            _comp_compgen -- -W 'low medium high critical'
+            return
+            ;;
+    esac
+
+    if [[ $cur == -* ]]; then
+        _comp_compgen -- -W '--frontend --priority --all --unseen-only --help
+            --showold --force --terse'
+    else
+        _comp_compgen -x dpkg installed_packages
+    fi
+} &&
+    complete -F _comp_cmd_dpkg_reconfigure -o default dpkg-reconfigure

--- a/completions-core/dpkg.bash
+++ b/completions-core/dpkg.bash
@@ -145,36 +145,3 @@ _comp_cmd_dpkg()
     [[ ${COMPREPLY-} == *= ]] && compopt -o nospace
 } &&
     complete -F _comp_cmd_dpkg dpkg dpkg-deb dpkg-query
-
-_comp_cmd_dpkg_reconfigure()
-{
-    local cur prev words cword comp_args
-    _comp_initialize -- "$@" || return
-
-    local opt
-
-    local noargopts='!(-*|*[fp]*)'
-    # shellcheck disable=SC2254
-    case $prev in
-        --frontend | -${noargopts}f)
-            if _comp_expand_glob opt '/usr/share/perl5/Debconf/FrontEnd/*'; then
-                opt=("${opt[@]##*/}")
-                opt=("${opt[@]%.pm}")
-                _comp_compgen -- -W '"${opt[@]}"'
-            fi
-            return
-            ;;
-        --priority | -${noargopts}p)
-            _comp_compgen -- -W 'low medium high critical'
-            return
-            ;;
-    esac
-
-    if [[ $cur == -* ]]; then
-        _comp_compgen -- -W '--frontend --priority --all --unseen-only --help
-            --showold --force --terse'
-    else
-        _comp_xfunc_dpkg_compgen_installed_packages
-    fi
-} &&
-    complete -F _comp_cmd_dpkg_reconfigure -o default dpkg-reconfigure

--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -60,6 +60,8 @@
 /dive.bash
 /dlv.bash
 /docker.bash
+/dpkg-deb.bash
+/dpkg-query.bash
 /dprint.bash
 /driftctl.bash
 /dyff.bash

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -8,6 +8,7 @@ cross_platform = adb.bash \
 		coder.bash \
 		delta.bash \
 		dmesg.bash \
+		dpkg.bash \
 		dpkg-source.bash \
 		dselect.bash \
 		eject.bash \
@@ -146,6 +147,8 @@ CLEANFILES = \
 	dive.bash \
 	dlv.bash \
 	docker.bash \
+	dpkg-deb.bash \
+	dpkg-query.bash \
 	dprint.bash \
 	driftctl.bash \
 	dyff.bash \
@@ -328,6 +331,9 @@ symlinks: $(DATA)
 		mago release-plz
 	$(ss) cal \
 		ncal
+	$(ss) dpkg \
+		dpkg-deb \
+		dpkg-query
 	$(ss) flamegraph \
 		just \
 		watchexec \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -64,6 +64,7 @@ cross_platform = adb.bash \
 		tokio-console.bash \
 		tox.bash \
 		udevadm.bash \
+		update-alternatives.bash \
 		umount.bash \
 		umount.linux.bash \
 		uvx.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -8,6 +8,7 @@ cross_platform = adb.bash \
 		coder.bash \
 		delta.bash \
 		dmesg.bash \
+		dpkg-source.bash \
 		dselect.bash \
 		eject.bash \
 		flamegraph.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -8,6 +8,7 @@ cross_platform = adb.bash \
 		coder.bash \
 		delta.bash \
 		dmesg.bash \
+		dselect.bash \
 		eject.bash \
 		flamegraph.bash \
 		gaiacli.bash \

--- a/completions-fallback/dpkg-source.bash
+++ b/completions-fallback/dpkg-source.bash
@@ -1,5 +1,8 @@
 # Debian dpkg-source completion
 
+# Use of this file is deprecated.  Upstream completion is available in
+# dpkg >= 1.23.8, use that instead.
+
 _comp_cmd_dpkg_source()
 {
     local cur prev words cword comp_args

--- a/completions-fallback/dpkg.bash
+++ b/completions-fallback/dpkg.bash
@@ -1,5 +1,8 @@
 # dpkg(1) and related commands completion
 
+# Use of this file is deprecated.  Upstream completion is available in
+# dpkg >= 1.23.8, use that instead.
+
 # @since 2.12
 _comp_xfunc_dpkg_compgen_installed_packages()
 {

--- a/completions-fallback/dselect.bash
+++ b/completions-fallback/dselect.bash
@@ -1,5 +1,8 @@
 # Debian Linux dselect(8) completion
 
+# Use of this file is deprecated.  Upstream completion is available in
+# dpkg >= 1.23.8, use that instead.
+
 _comp_cmd_dselect()
 {
     local cur prev words cword comp_args

--- a/completions-fallback/update-alternatives.bash
+++ b/completions-fallback/update-alternatives.bash
@@ -1,0 +1,103 @@
+# bash completion for update-alternatives
+
+# On dpkg-based systems or systems that use an update-alternatives from the
+# dpkg code base, use of this file is deprecated.  On those systems
+# upstream completion is available in dpkg >= 1.23.8, use that instead.
+#
+# On chkconfig-based systems this completion complements the alternatives.bash
+# completion where update-alternatives is a symlink to alternatives. This
+# implementation is based on an old dpkg version, and has diverged since then.
+
+_comp_cmd_update_alternatives__installed()
+{
+    local i admindir
+    # find the admin dir
+    for i in alternatives dpkg/alternatives rpm/alternatives; do
+        [[ -d /var/lib/$i ]] && admindir=/var/lib/$i && break
+    done
+    for ((i = 1; i < cword; i++)); do
+        if [[ ${words[i]} == --admindir ]]; then
+            admindir=${words[i + 1]}
+            break
+        fi
+    done
+    [[ -d $admindir ]] && _comp_compgen_split -- "$(command ls "$admindir")"
+}
+
+_comp_cmd_update_alternatives()
+{
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
+
+    case $prev in
+        --altdir | --admindir)
+            _comp_compgen_filedir -d
+            return
+            ;;
+        --help | --usage | --version)
+            return
+            ;;
+    esac
+
+    local mode="" args i
+
+    # find which mode to use and how many real args used so far
+    for ((i = 1; i < cword; i++)); do
+        if [[ ${words[i]} == --@(install|remove|auto|display|config|remove-all|set) ]]; then
+            mode=${words[i]}
+            args=$((cword - i))
+            break
+        fi
+    done
+
+    case ${mode-} in
+        --install)
+            case $args in
+                1 | 3)
+                    _comp_compgen_filedir
+                    ;;
+                2)
+                    _comp_cmd_update_alternatives__installed
+                    ;;
+                4)
+                    # priority - no completions
+                    ;;
+                *)
+                    case $((args % 4)) in
+                        0 | 2)
+                            _comp_compgen_filedir
+                            ;;
+                        1)
+                            _comp_compgen -- -W '--slave'
+                            ;;
+                        3)
+                            _comp_cmd_update_alternatives__installed
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+        --remove | --set)
+            case $args in
+                1)
+                    _comp_cmd_update_alternatives__installed
+                    ;;
+                2)
+                    _comp_compgen_filedir
+                    ;;
+            esac
+            ;;
+        --auto | --remove-all | --display | --config)
+            _comp_cmd_update_alternatives__installed
+            ;;
+        *)
+            _comp_compgen_help - <<<"$(LANG=C "$1" --help 2>&1 | command sed '
+                /usage:/,/^[[:space:]]*$/{
+                  s/^\([[:space:]]*usage:\)\{0,1\}[[:space:]]*[^[:space:]]*alternatives /  /
+                  s/^[[:space:]]*\[\(-.*\)\]/  \1/
+                }
+                /common options:/,$s/ --/\n --/g')"
+            ;;
+    esac
+} &&
+    complete -F _comp_cmd_update_alternatives update-alternatives


### PR DESCRIPTION
To make it possible for dpkg to provide its own bash completion, the support here needs to be namespaced. In addition, the support for dpkg-reconfigure (which is actually provided by debconf not dpkg), needs to be split.

Because the dpkg completion provides public interfaces used by other completion scripts, the completion imported into dpkg will preserve those public functions for backwards compatibility for now. Ideally bash-completions would switch those functions into another file. But that's left for later to be able to unblock the integration with the next dpkg upstream release 1.23.8.

Fixes: #694