### PR TITLE
Some more runLint cleanups

### DIFF
--- a/completions-core/ccze.bash
+++ b/completions-core/ccze.bash
@@ -29,8 +29,8 @@ _comp_cmd_ccze()
             return
             ;;
         --plugin | -${noargopts}p)
-            _comp_compgen_split -- "$("$1" --list-plugins | command \
-                sed -ne 's/^\([a-z0-9]\{1,\}\)[[:space:]]\{1,\}|.*/\1/p')"
+            _comp_compgen_split -- "$("$1" --list-plugins |
+                command sed -ne 's/^\([a-z0-9]\{1,\}\)[[:space:]]\{1,\}|.*/\1/p')"
             return
             ;;
     esac

--- a/test/runLint
+++ b/test/runLint
@@ -3,8 +3,8 @@ set -u
 
 gitgrep()
 {
-    local pathspecs=('bash_completion' 'completions-fallback/'
-        'completions-core/' 'test/' 'bash_completion.d/' ':!:test/runLint'
+    local pathspecs=('bash_completion' 'completions-fallback/*.bash'
+        'completions-core/*.bash' 'test/' 'bash_completion.d/' ':!:test/runLint'
         ':!:test/docker/' ':!:test/test-cmd-list.txt')
     local filter_list
     read -ra filter_list <<<"$filter_out"

--- a/test/runLint
+++ b/test/runLint
@@ -72,9 +72,6 @@ gitgrep '@\([^()|$]+\)' \
 #------------------------------------------------------------------------------
 # Bash pitfalls/styles/compatibilities (which are not detected by shellcheck)
 
-filter_out='test/ bash_completion.sh.in' gitgrep ' \[ ' \
-    'use [[ ]] instead of [ ]'
-
 gitgrep "$cmdstart"'unset [^-]' 'Explicitly specify "unset -v/-f"'
 
 filter_out="test/config/bashrc" gitgrep "$cmdstart"'((set|shopt)\s+[+-][a-z]+\s+posix\b|(local\s+)?POSIXLY_CORRECT\b)' \


### PR DESCRIPTION
- Only check `*.bash` files in `completions*`, so we don't catch stuff in makefiles
- Remove redundant check for `[`
- rearrange completions-core/ccze.bash to prevent a false positive

See commits for a bit more detail