### PR TITLE
feat(ty): add 3rd party fallback completion loader

### DIFF
--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -214,6 +214,7 @@
 /trash-put.bash
 /trash-restore.bash
 /trivy.bash
+/ty.bash
 /upctl.bash
 /uv.bash
 /vacuum.bash

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -296,6 +296,7 @@ CLEANFILES = \
 	trash-put.bash \
 	trash-restore.bash \
 	trivy.bash \
+	ty.bash \
 	upctl.bash \
 	uv.bash \
 	vacuum.bash \
@@ -536,7 +537,8 @@ symlinks: $(DATA)
 		black blackd flask httpx
 	$(ss) ruff \
 		mado \
-		uv
+		uv \
+		ty
 	$(ss) sops \
 		kata-runtime todoist
 	$(ss) vault \


### PR DESCRIPTION
I saw uv, uvx, and ruff had the fallbacks here already but not ty, so just wanted to get that one in here too.