### PR TITLE
feat(ogg123): associate opus extension

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -3346,7 +3346,7 @@ _comp__init_install_xspec '!*@(.@(mp?(e)g|MP?(E)G|wm[av]|WM[AV]|avi|AVI|asf|vob|
 _comp__init_install_xspec '!*.@(avi|asf|wmv)' aviplay
 _comp__init_install_xspec '!*.@(rm?(j)|ra?(m)|smi?(l))' realplay
 _comp__init_install_xspec '!*.@(mpg|mpeg|avi|mov|qt)' xanim
-_comp__init_install_xspec '!*.@(og[ag]|m3u|flac|spx)' ogg123
+_comp__init_install_xspec '!*.@(og[ag]|m3u|flac|spx|opus)' ogg123
 _comp__init_install_xspec '!*.@(mp3|og[ag]|pls|m3u)' gqmpeg freeamp
 _comp__init_install_xspec '!*.fig' xfig
 _comp__init_install_xspec '!*.@(mid?(i)|cmf)' playmidi


### PR DESCRIPTION
According to [RFC 7845](https://www.rfc-editor.org/info/rfc7845/#section-9) `opus` is the recommended extension for opus streams encapsulated in Ogg files.