### PR TITLE
fix(tox): move to the fallback directory for tox >= 4.36

### DIFF
--- a/completions-core/Makefile.am
+++ b/completions-core/Makefile.am
@@ -387,7 +387,6 @@ cross_platform = 2to3.bash \
 		timeout.bash \
 		tipc.bash \
 		tmux.bash \
-		tox.bash \
 		tracepath.bash \
 		tree.bash \
 		truncate.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -62,6 +62,7 @@ cross_platform = adb.bash \
 		syncthing.bash \
 		task.bash \
 		tokio-console.bash \
+		tox.bash \
 		udevadm.bash \
 		umount.bash \
 		umount.linux.bash \

--- a/completions-fallback/tox.bash
+++ b/completions-fallback/tox.bash
@@ -1,5 +1,12 @@
 # tox completion
 
+# Use of this file is deprecated.  Upstream completion is available in tox >=
+# 4.36, use that instead.  This was reported in Ref. [1].  The corresponding
+# change in the upstream is introduced in Ref. [2].
+#
+# [1] https://github.com/scop/bash-completion/issues/1628
+# [2] https://github.com/tox-dev/tox/pull/3695
+
 _comp_cmd_tox()
 {
     local cur prev words cword comp_args


### PR DESCRIPTION
See the added code comment in `tox.bash`.

- [1] https://github.com/scop/bash-completion/issues/1628
- [2] https://github.com/tox-dev/tox/pull/3695