### PR TITLE
refactor: remove redundant `COMPREPLY=()`

### DIFF
--- a/completions-core/dpkg-source.bash
+++ b/completions-core/dpkg-source.bash
@@ -60,15 +60,11 @@ _comp_cmd_dpkg_source()
                     # -V: set a substitution variable
                     # we don't know anything about possible variables or values
                     # so we don't try to suggest any completion.
-                    COMPREPLY=()
                     ;;
                 -D)
                     # -D: override or add a .dsc field and value
                     # if $cur doesn't contain a = yet, suggest variable names
-                    if [[ $cur == *=* ]]; then
-                        # $cur contains a "="
-                        COMPREPLY=()
-                    else
+                    if [[ $cur != *=* ]]; then
                         _comp_compgen -- -W "$fields"
                     fi
                     ;;

--- a/completions-core/invoke-rc.d.bash
+++ b/completions-core/invoke-rc.d.bash
@@ -26,8 +26,6 @@ _comp_cmd_invoke_rc_d()
         _comp_compgen_split -- "$(command sed -e 'y/|/ /' \
             -ne 's/^.*Usage:[ ]*[^ ]*[ ]*{*\([^}"]*\).*$/\1/p' \
             "${sysvdirs[0]}/$prev")"
-    else
-        COMPREPLY=()
     fi
 
 } &&

--- a/completions-core/tipc.bash
+++ b/completions-core/tipc.bash
@@ -79,11 +79,11 @@ _comp_cmd_tipc__link()
 
 _comp_cmd_tipc()
 {
-    local cur prev words cword comp_args optind i p
+    local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
+    local optind i p
     optind=1
-    COMPREPLY=()
 
     # Flags can be placed anywhere in the commandline
     case "$cur" in

--- a/completions-core/update-rc.d.bash
+++ b/completions-core/update-rc.d.bash
@@ -28,8 +28,6 @@ _comp_cmd_update_rc_d()
             COMPREPLY=(0 1 2 3 4 5 6 7 8 9)
         elif [[ $cur == [0-9][0-9] ]]; then
             COMPREPLY=("$cur")
-        else
-            COMPREPLY=()
         fi
     elif [[ $prev == ?([0-9][0-9]|[0-6S]) ]]; then
         if [[ ! $cur ]]; then
@@ -40,13 +38,9 @@ _comp_cmd_update_rc_d()
             fi
         elif [[ $cur == [0-6S.] ]]; then
             COMPREPLY=("$cur")
-        else
-            COMPREPLY=()
         fi
     elif [[ $prev == "." ]]; then
         _comp_compgen -- -W "start stop"
-    else
-        COMPREPLY=()
     fi
 } &&
     complete -F _comp_cmd_update_rc_d update-rc.d

--- a/completions-core/uscan.bash
+++ b/completions-core/uscan.bash
@@ -20,7 +20,6 @@ _comp_cmd_uscan()
             ;;
         --timeout | --upstream-version | --download-version | \
             --check-dirname-level | --check-dirname-regex)
-            COMPREPLY=()
             return
             ;;
     esac

--- a/completions-fallback/umount.linux.bash
+++ b/completions-fallback/umount.linux.bash
@@ -45,8 +45,6 @@ _comp_cmd_umount__linux_fstab_unescape()
 # shellcheck disable=SC2120
 _comp_cmd_umount__linux_fstab()
 {
-    COMPREPLY=()
-
     # Read and unescape values into COMPREPLY
     local fs_spec fs_file fs_other
     while read -r fs_spec fs_file fs_other; do


### PR DESCRIPTION
This is another trivial one.