### PR TITLE
chore(emacs): don't insist on shfmt-on-save mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -4,6 +4,5 @@
 ((python-mode
   (mode . ruff-format-on-save))
  (sh-mode
-  (mode . shfmt-on-save)
   (flycheck-sh-bash-args "-O" "extglob")
   (sh-indent-comment . t)))


### PR DESCRIPTION
For example, apheleia-mode works just fine too for this.

And whether to format on save or not is a user preference that we should not enforce anyway.