### PR TITLE
refactor(pkg-get): use bash-completion utilities

### DIFF
--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -35,8 +35,8 @@ _comp_cmd_pkg_get()
     fi
 
     local i=${#words[@]}
-    while ((i > 0)); do
-        if [[ ${words[--i]} == -s ]]; then
+    while ((--i >= 1)); do
+        if [[ ${words[i]} == -s ]]; then
             url=${words[i + 1]-}
         fi
         if [[ ${words[i]} == @(-[aDdiUu]|available|describe|download|install|list|updatecatalog|upgrade) ]]; then

--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -50,7 +50,7 @@ _comp_cmd_pkg_get()
             _comp_cmd_pkg_get__catalog_file "$url"
             if [[ -f $REPLY ]]; then
                 local packages_list=$(_comp_awk '$0 ~ /BEGIN PGP SIGNATURE/ { exit } $1 ~ /^Hash:/ || $1 ~ /^ *(-|#|$)/ { next } { print $1 }' "$REPLY")
-                _comp_compgen -- -W "${packages_list}"
+                _comp_compgen -- -W '$packages_list'
             fi
         fi
         return

--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -5,7 +5,7 @@
 _comp_cmd_pkg_get__catalog_file()
 {
     local url=$1
-    local i conffile
+    local file conffile
 
     for file in /etc/opt/csw/pkg-get.conf /opt/csw/etc/pkg-get.conf /etc/pkg-get.conf; do
         if [[ -f $file ]]; then
@@ -29,7 +29,7 @@ _comp_cmd_pkg_get()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local file url command=""
+    local url command=""
     if [[ $prev == "-s" ]]; then
         return 1
     fi

--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -5,7 +5,7 @@
 _comp_cmd_pkg_get__catalog_file()
 {
     local url=$1
-    local file conffile
+    local file conffile=""
 
     for file in /etc/opt/csw/pkg-get.conf /opt/csw/etc/pkg-get.conf /etc/pkg-get.conf; do
         if [[ -f $file ]]; then
@@ -29,7 +29,7 @@ _comp_cmd_pkg_get()
     local cur prev words cword comp_args
     _comp_initialize -- "$@" || return
 
-    local url command=""
+    local url="" command=""
     if [[ $prev == "-s" ]]; then
         return 1
     fi

--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -4,44 +4,43 @@
 
 _comp_cmd_pkg_get__catalog_file()
 {
-    local url="$1"
+    local url=$1
     local i conffile
 
     for file in /etc/opt/csw/pkg-get.conf /opt/csw/etc/pkg-get.conf /etc/pkg-get.conf; do
         if [[ -f $file ]]; then
-            conffile="$file"
+            conffile=$file
             break
         fi
     done
-    conffile="${conffile:-/opt/csw/etc/pkg-get.conf}"
+    conffile=${conffile:-/opt/csw/etc/pkg-get.conf}
 
     if [[ ! $url ]]; then
-        url=$(_comp_awk -F = ' $1=="url" { print $2 }' "$conffile")
+        url=$(_comp_awk -F = '$1 == "url" { print $2 }' "$conffile")
     fi
 
-    REPLY="${url##*//}"
-    REPLY="${REPLY%%/*}"
-    REPLY="/var/pkg-get/catalog-$REPLY"
+    REPLY=${url##*//}
+    REPLY=${REPLY%%/*}
+    REPLY=/var/pkg-get/catalog-$REPLY
 }
 
 _comp_cmd_pkg_get()
 {
-    local cur prev file url command=""
-    COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+    local cur prev words cword comp_args
+    _comp_initialize -- "$@" || return
 
-    if [[ ${prev} == "-s" ]]; then
+    local file url command=""
+    if [[ $prev == "-s" ]]; then
         return 1
     fi
 
-    local i=${#COMP_WORDS[*]}
+    local i=${#words[@]}
     while ((i > 0)); do
-        if [[ ${COMP_WORDS[--i]} == -s ]]; then
-            url="${COMP_WORDS[i + 1]}"
+        if [[ ${words[--i]} == -s ]]; then
+            url=${words[i + 1]}
         fi
-        if [[ ${COMP_WORDS[i]} == @(-[aDdiUu]|available|describe|download|install|list|updatecatalog|upgrade) ]]; then
-            command="${COMP_WORDS[i]}"
+        if [[ ${words[i]} == @(-[aDdiUu]|available|describe|download|install|list|updatecatalog|upgrade) ]]; then
+            command=${words[i]}
         fi
     done
 
@@ -57,7 +56,7 @@ _comp_cmd_pkg_get()
         return
     fi
 
-    if [[ ${cur} == -* ]]; then
+    if [[ $cur == -* ]]; then
         local -a opts=(-c -d -D -f -i -l -s -S -u -U -v)
         _comp_compgen -- -W '"${opts[@]}"'
         return

--- a/completions-core/pkg-get.bash
+++ b/completions-core/pkg-get.bash
@@ -37,7 +37,7 @@ _comp_cmd_pkg_get()
     local i=${#words[@]}
     while ((i > 0)); do
         if [[ ${words[--i]} == -s ]]; then
-            url=${words[i + 1]}
+            url=${words[i + 1]-}
         fi
         if [[ ${words[i]} == @(-[aDdiUu]|available|describe|download|install|list|updatecatalog|upgrade) ]]; then
             command=${words[i]}


### PR DESCRIPTION
This is the only completion that tries to extract `cur` and `prev` from `COMP_WORDS` manually.

This can be updated to use `_comp_initialize` and use the existing coding style. In addition, I added minor/trivial fixes.