### PR TITLE
docs(README): clarify that we provide completion contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 
 ## Introduction
 
-bash-completion is a collection of recipes for [command-line
-completions](https://en.wikipedia.org/wiki/Command-line_completion) of a number
-of commands for the [Bash shell](https://www.gnu.org/software/bash/)'s
-completion system.  This enhances Bash's plain completion of filenames to
-provide better suggestions of options and arguments for many commands.  Also
-provided is a collection of helper functions to assist in creating new
-completions, and a set of facilities for loading completions automatically on
+bash-completion is a collection of
+[command-line completion](https://en.wikipedia.org/wiki/Command-line_completion)
+recipes for a number of commands for the completion system of the
+[Bash shell](https://www.gnu.org/software/bash/).
+These recipes enhance Bash's typical plain completion of filenames to
+provide better suggestions of options and arguments for many commands.
+Also provided is a collection of helper functions to assist in creating new
+recipes, and a set of facilities for loading recipes automatically on
 demand, as well as installing them.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 
 ## Introduction
 
-bash-completion is a collection of command line command completions for the
-[Bash shell](https://www.gnu.org/software/bash/), collection of helper
-functions to assist in creating new completions, and set of facilities for
-loading completions automatically on demand, as well as installing them.
+bash-completion is a collection of recipes for [command-line
+completions](https://en.wikipedia.org/wiki/Command-line_completion) of a number
+of commands for the [Bash shell](https://www.gnu.org/software/bash/)'s
+completion system.  Also provided is a collection of helper functions to assist
+in creating new completions, and a set of facilities for loading completions
+automatically on demand, as well as installing them.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 bash-completion is a collection of recipes for [command-line
 completions](https://en.wikipedia.org/wiki/Command-line_completion) of a number
 of commands for the [Bash shell](https://www.gnu.org/software/bash/)'s
-completion system.  Also provided is a collection of helper functions to assist
-in creating new completions, and a set of facilities for loading completions
-automatically on demand, as well as installing them.
+completion system.  This enhances Bash's plain completion of filenames to
+provide better suggestions of options and arguments for many commands.  Also
+provided is a collection of helper functions to assist in creating new
+completions, and a set of facilities for loading completions automatically on
+demand, as well as installing them.
 
 ## Installation
 


### PR DESCRIPTION
Closes #1623

In the GitHub interface, it may be harder to identify the changes in the paragraph with the linewise diff, so here are the edits indicated by `<del></del><ins></ins>`:

```md
## Introduction

bash-completion is a collection of <ins>command-specific</ins> command<del> </del><ins>-</ins>line
<del>command</del> completions<ins>, providing completion contents</ins> for the [Bash
shell](https://www.gnu.org/software/bash/)<del>,</del><ins>'s completion system.  This also
provides a</ins> collection of helper functions to assist in creating new completions,
and <ins>a</ins> set of facilities for loading completions automatically on demand, as well
as installing them.
```