### PR TITLE
chore(deps): upgrade rumdl to 0.1.96

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
         files: ^(helpers-core/perl|.+\.p[ml])$
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.81
+    rev: v0.1.96
     hooks:
       - id: rumdl-fmt
 


### PR DESCRIPTION
Versions >= 0.2.0 make some indentation changes that don't seem quite desirable, stick with an older version for a bit unless deemed good or worked around.