### PR TITLE
fix(make): keep plain target names that are also path prefixes

### DIFF
--- a/completions-core/make.bash
+++ b/completions-core/make.bash
@@ -26,6 +26,12 @@ _comp_cmd_make__extract_targets()
 # "abc/" instead of generating both candidates directly.  When there is only
 # one candidate "abc/def", we generate the full path "abc/def".
 #
+# The phony targets (prefixed by "phony:") are offered as-is: a `/' in a phony
+# name is a naming convention (e.g. CMake's `install', `install/local'), not a
+# directory boundary, so they are never collapsed.  Only the non-phony targets
+# (prefixed by "file:"), which are real filepaths, go through the path
+# collapse.
+#
 # @var[in] cur
 # @var[in] mode
 # @var[in] targets - Array containing the target names.  This array is supposed
@@ -36,13 +42,24 @@ _comp_cmd_make__truncate_non_unique_paths()
     local prefix=$cur
     [[ $mode == -d ]] && prefix=
 
+    COMPREPLY=()
+    local nreply=0
+
     # collect the possible completions including the directory names in
     # `paths' and count the number of children of each subdirectory in
     # `nchild'.
     local -A paths nchild
     local target
     for target in "${targets[@]}"; do
-        local path=${target%/}
+        if [[ $target == phony:* ]]; then
+            # The phony targets are directly added to COMPREPLY without
+            # considering the pathname structures with slashes.
+            COMPREPLY[nreply++]=${target#phony:}
+            continue
+        fi
+
+        local path=${target#file:}
+        path=${path%/}
         while [[ ! ${paths[$path]+set} ]] &&
             paths[$path]=set &&
             [[ $path == "$prefix"*/* ]]; do
@@ -51,8 +68,6 @@ _comp_cmd_make__truncate_non_unique_paths()
         done
     done
 
-    COMPREPLY=()
-    local nreply=0
     for target in "${!paths[@]}"; do
         # generate only the paths that do not have a unique child and whose
         # all parent and ancestor directories have a unique child.

--- a/completions-core/make.bash
+++ b/completions-core/make.bash
@@ -18,54 +18,55 @@ _comp_cmd_make__extract_targets()
     _comp_awk -f "${BASH_SOURCE[0]%/*}/../helpers-core/make-extract-targets.awk"
 }
 
-# Truncate the non-unique filepaths in COMPREPLY to only generate unique
-# directories or files.  This function discards the files under subdirectories
-# unless the path is unique under each subdirectory and instead generate the
-# subdirectory path.  For example, when there are two candidates, "abc/def" and
-# "abc/xyz", we generate "abc/" instead of generating both candidates directly.
-# When there is only one candidate "abc/def", we generate the full path
-# "abc/def".
+# Truncate the non-unique filepaths in the "targets" array to only generate
+# phony targets, unique directories, or files in the COMPREPLY array.  This
+# function discards the files under subdirectories unless the path is unique
+# under each subdirectory and instead generate the subdirectory path.  For
+# example, when there are two candidates, "abc/def" and "abc/xyz", we generate
+# "abc/" instead of generating both candidates directly.  When there is only
+# one candidate "abc/def", we generate the full path "abc/def".
 #
 # @var[in] cur
 # @var[in] mode
-# @var[in,out] COMPREPLY
+# @var[in] targets - Array containing the target names.  This array is supposed
+#   to contain at least one element for the Bash-4.2 nounset bug.
+# @var[out] COMPREPLY
 _comp_cmd_make__truncate_non_unique_paths()
 {
     local prefix=$cur
     [[ $mode == -d ]] && prefix=
-    if ((${#COMPREPLY[@]} > 0)); then
-        # collect the possible completions including the directory names in
-        # `paths' and count the number of children of each subdirectory in
-        # `nchild'.
-        local -A paths nchild
-        local target
-        for target in "${COMPREPLY[@]}"; do
-            local path=${target%/}
-            while [[ ! ${paths[$path]+set} ]] &&
-                paths[$path]=set &&
-                [[ $path == "$prefix"*/* ]]; do
-                path=${path%/*}
-                nchild[$path]=$((${nchild[$path]-0} + 1))
-            done
+
+    # collect the possible completions including the directory names in
+    # `paths' and count the number of children of each subdirectory in
+    # `nchild'.
+    local -A paths nchild
+    local target
+    for target in "${targets[@]}"; do
+        local path=${target%/}
+        while [[ ! ${paths[$path]+set} ]] &&
+            paths[$path]=set &&
+            [[ $path == "$prefix"*/* ]]; do
+            path=${path%/*}
+            nchild[$path]=$((${nchild[$path]-0} + 1))
+        done
+    done
+
+    COMPREPLY=()
+    local nreply=0
+    for target in "${!paths[@]}"; do
+        # generate only the paths that do not have a unique child and whose
+        # all parent and ancestor directories have a unique child.
+        ((${nchild[$target]-0} == 1)) && continue
+        local path=$target
+        while [[ $path == "$prefix"*/* ]]; do
+            path=${path%/*}
+            ((${nchild[$path]-0} == 1)) || continue 2
         done
 
-        COMPREPLY=()
-        local nreply=0
-        for target in "${!paths[@]}"; do
-            # generate only the paths that do not have a unique child and whose
-            # all parent and ancestor directories have a unique child.
-            ((${nchild[$target]-0} == 1)) && continue
-            local path=$target
-            while [[ $path == "$prefix"*/* ]]; do
-                path=${path%/*}
-                ((${nchild[$path]-0} == 1)) || continue 2
-            done
-
-            # suffix `/' when the target path is a subdiretory, which has
-            # at least one child.
-            COMPREPLY[nreply++]=$target${nchild[$target]+/}
-        done
-    fi
+        # suffix `/' when the target path is a subdiretory, which has
+        # at least one child.
+        COMPREPLY[nreply++]=$target${nchild[$target]+/}
+    done
 }
 
 _comp_cmd_make()
@@ -154,12 +155,12 @@ _comp_cmd_make()
         #     mode=-d # display-only mode
         # fi
 
-        _comp_split COMPREPLY "$(LC_ALL=C \
+        local targets
+        _comp_split targets "$(LC_ALL=C \
             $1 -npq __BASH_MAKE_COMPLETION__=1 \
             ${makef+"${makef[@]}"} "${makef_dir[@]}" .DEFAULT 2>/dev/null |
-            _comp_cmd_make__extract_targets "$mode" "$cur")"
-
-        _comp_cmd_make__truncate_non_unique_paths
+            _comp_cmd_make__extract_targets "$mode" "$cur")" &&
+            _comp_cmd_make__truncate_non_unique_paths
 
         if [[ $mode != -d ]]; then
             # Completion will occur if there is only one suggestion

--- a/helpers-core/make-extract-targets.awk
+++ b/helpers-core/make-extract-targets.awk
@@ -3,6 +3,8 @@
 # This AWK script is used by the function `_comp_cmd_make__extract_targets` in
 # `completions-core/make`.  This script receives the output of `make -npq' as
 # the input file or stdin and outputs the list of targets matching the prefix.
+# The phony targets are prefixed by "phony:", and the others are prefixed by
+# "file:".
 #
 # @env prefix         Specifies the prefix to match.
 # @env prefix_replace Specifies the string that replaces the prefix in the
@@ -14,6 +16,7 @@ BEGIN {
   prefix = ENVIRON["prefix"];
   prefix_replace = ENVIRON["prefix_replace"];
   is_target_block = 0;
+  is_phony_target = 0;
   target = "";
 }
 
@@ -40,6 +43,7 @@ NR == 1, /^# +Make data base/ { next; }
   #
   # https://github.com/scop/bash-completion/pull/1577
   is_target_block = 0;
+  is_phony_target = 0;
   target = "";
   next;
 }
@@ -55,17 +59,34 @@ is_target_block == 0 { next; }
 
 /^# +File is an intermediate prerequisite/ { # cancel the block
   is_target_block = 0;
+  is_phony_target = 0;
   target = "";
+  next;
+}
+
+# The comment sections after the .PHONY targets include the following line,
+# which was confirmed in make-3.80 (2002) and make-4.4.90 (master b380278,
+# 2026):
+#
+# #  Phony target (prerequisite of .PHONY).
+#
+/^# +Phony target/ {
+  is_phony_target = 1;
   next;
 }
 
 # end of target block
 /^$/ {
-  is_target_block = 0;
   if (target != "") {
-    print target;
+    if (is_phony_target) {
+      print "phony:" target;
+    } else {
+      print "file:" target;
+    }
     target = "";
   }
+  is_target_block = 0;
+  is_phony_target = 0;
   next;
 }
 

--- a/test/fixtures/make/test3/Makefile
+++ b/test/fixtures/make/test3/Makefile
@@ -1,0 +1,22 @@
+# CMake "Unix Makefiles" style: phony targets whose names use `/' as a naming
+# convention, not a directory boundary.  `make -p' marks them phony, so the
+# completion offers them as-is instead of collapsing `install' into `install/'
+# or dropping the plain `MyProgram' in favor of only `MyProgram/fast'.
+#
+#   - single-child case: `MyProgram' alongside `MyProgram/fast'
+#   - multi-child case:  `install' alongside `install/local' and `install/strip'
+
+all: MyProgram
+.PHONY: all
+
+MyProgram MyProgram/fast:
+	@echo $@
+.PHONY: MyProgram MyProgram/fast
+
+clean clean/fast:
+	@echo $@
+.PHONY: clean clean/fast
+
+install install/local install/strip:
+	@echo $@
+.PHONY: install install/local install/strip

--- a/test/fixtures/make/test4/Makefile
+++ b/test/fixtures/make/test4/Makefile
@@ -1,0 +1,17 @@
+# Non-phony targets whose names contain `/' really are file paths, so the
+# completion keeps collapsing shared prefixes into `dir/' (issues #544/#858).
+# Crucially, a non-phony target that is *also* a directory prefix of others
+# -- here `sub', a real directory created by a recipe, with children `sub/a'
+# and `sub/b' -- must STAY collapsed to `sub/', never surfaced as a plain
+# runnable `sub'.  Only `.PHONY' logical labels are offered as-is.
+
+sub/a sub/b: | sub
+	@echo $@
+
+sub:
+	@mkdir -p sub
+
+# `dir' is NOT itself a target, only a shared path prefix, so completion still
+# collapses to `dir/'.
+dir/all dir/rule:
+	@echo $@

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -119,3 +119,103 @@ class TestMake2:
     def test_subdir_4(self, bash):
         completion = assert_complete(bash, "make sub4")
         assert completion == "sub4test/bar/ sub4test2/foo/gamma".split()
+
+
+@pytest.mark.bashcomp(cmd="make", require_cmd=True, cwd="make/test3")
+class TestMake3:
+    """CMake-style phony targets whose names use `/' as a naming convention.
+
+    A `/' in a target name is not necessarily a directory boundary.  `make -p'
+    marks these targets phony, so the completion offers them as-is instead of
+    collapsing `install' into `install/' or dropping the plain `MyProgram' in
+    favor of only `MyProgram/fast'.
+    """
+
+    def test_all_targets(self, bash):
+        """Phony targets are offered as-is, not collapsed as directories."""
+        completion = assert_complete(bash, "make ")
+        assert completion == [
+            "MyProgram",
+            "MyProgram/fast",
+            "all",
+            "clean",
+            "clean/fast",
+            "install",
+            "install/local",
+            "install/strip",
+        ]
+
+    def test_single_child(self, bash):
+        """`MyProgram' is offered alongside `MyProgram/fast'."""
+        completion = assert_complete(bash, "make My")
+        assert completion == ["MyProgram", "MyProgram/fast"]
+
+    def test_single_child_drill_in(self, bash):
+        completion = assert_complete(bash, "make MyProgram/")
+        assert completion == "fast"
+
+    def test_multi_child(self, bash):
+        """`install' is offered alongside `install/local', `install/strip'."""
+        completion = assert_complete(bash, "make install")
+        assert completion == ["install", "install/local", "install/strip"]
+
+    def test_multi_child_drill_in(self, bash):
+        completion = assert_complete(bash, "make install/")
+        assert completion == ["install/local", "install/strip"]
+
+    def test_clean(self, bash):
+        """A second single-child case: `clean' alongside `clean/fast'."""
+        completion = assert_complete(bash, "make clean")
+        assert completion == ["clean", "clean/fast"]
+
+
+@pytest.mark.bashcomp(cmd="make", require_cmd=True)
+class TestMakeOptions:
+    """Phony targets are offered as-is when the makefile or its directory is
+    selected via -f/-C.
+
+    Run from the fixtures root so the -C/-f paths are relative to it.
+    """
+
+    def test_directory_option(self, bash):
+        completion = assert_complete(bash, "make -C make/test3 install")
+        assert completion == ["install", "install/local", "install/strip"]
+
+    def test_file_option(self, bash):
+        completion = assert_complete(
+            bash, "make -f make/test3/Makefile install"
+        )
+        assert completion == ["install", "install/local", "install/strip"]
+
+
+@pytest.mark.bashcomp(cmd="make", require_cmd=True, cwd="make/test4")
+class TestMake4:
+    """Non-phony targets containing `/' are real file paths, so completion
+    keeps collapsing shared prefixes to `dir/' (issues #544/#858).  A
+    non-phony target that is itself a directory prefix (`sub', a real
+    directory built by a recipe) stays collapsed to `sub/', never surfaced
+    as a plain runnable name.
+    """
+
+    def test_all_targets(self, bash):
+        completion = assert_complete(bash, "make ")
+        assert completion == ["dir/", "sub/"]
+
+    def test_dir_prep_target_stays_collapsed(self, bash):
+        """`sub' is a real directory target, not a phony label, so it is not
+        surfaced as a plain name; it stays collapsed to `sub/'."""
+        completion = assert_complete(bash, "make sub")
+        assert completion == "/"
+        # Collapsed `sub/' must not get a trailing space (nospace is set).
+        assert completion.endswith("/")
+
+    def test_dir_prep_drill_in(self, bash):
+        completion = assert_complete(bash, "make sub/")
+        assert completion == ["sub/a", "sub/b"]
+
+    def test_non_target_prefix_collapses(self, bash):
+        """`dir' is not a target, only a shared prefix, so it collapses to
+        `dir/'."""
+        completion = assert_complete(bash, "make dir")
+        assert completion == "/"
+        assert completion.endswith("/")


### PR DESCRIPTION
The make completion collapses /-separated target names as filesystem paths, so a target that is also the prefix of others (install with install/local, X with X/fast) is dropped and only its /-suffixed siblings are offered. 

Fixes #1219 

Approach:

- In _comp_cmd_make__truncate_non_unique_paths, record the candidates make actually reported in an is_target map (keyed on the original candidate). In the emit loop, additionally offer a candidate's plain form when it is both a reported target and a path node with children. Synthesized ancestor nodes (pure prefixes make never reported) are not in is_target, so the recursive-Makefile collapsing from #544/#858 is unchanged.
- Coupled nospace fix: a plain target and its dir/ prefix can now coexist in an unspecified COMPREPLY order. Set compopt -o nospace when any candidate (not just the first) ends in /, so drilling into the prefix keeps working.
- Known limitation (pre-existing): a target whose name literally ends in / is still not surfaced.