### PR TITLE
fix: avoid consuming stdin on remote scp/ssh/rsync completion wait

### DIFF
--- a/completions-core/ssh.bash
+++ b/completions-core/ssh.bash
@@ -569,7 +569,7 @@ _comp_xfunc_scp_compgen_remote_files()
 
     # default to home dir of specified user on remote host
     if [[ ! $_path ]]; then
-        _path=$(ssh -o 'Batchmode yes' "$_userhost" pwd 2>/dev/null)
+        _path=$(ssh -o 'Batchmode yes' "$_userhost" pwd </dev/null 2>/dev/null)
     fi
 
     local _escape_replacement='\\\\\\&'
@@ -579,7 +579,7 @@ _comp_xfunc_scp_compgen_remote_files()
 
     local _files
     _files=$(ssh -o 'Batchmode yes' "$_userhost" \
-        command ls -aF1dL "$_path*" 2>/dev/null |
+        command ls -aF1dL "$_path*" </dev/null 2>/dev/null |
         _comp_cmd_scp__escape_path ${_dirs_only:+'-d'} -- \
             "$_escape_replacement")
     _comp_compgen -R split -l -- "$_files"


### PR DESCRIPTION
While using tab-completion to scp files to a remote directory, the type-ahead buffer is discarded due to ssh consuming stdin. Typed characters do not appear on the command-line once the ssh call completes. For example:

    scp some-remote-host:/remote-pat<TAB>

On a laggy connection, any characters typed while the directory lookup completes are discarded.

OpenSSH has the option -n to avoid this, which is concise but not portable to, say, dropbear. Simply redirecting stdin from /dev/null does the trick just as well and should be more portable.

Closes https://github.com/scop/bash-completion/issues/1688