### PR TITLE
fix(scp): Use less escaping for filenames when not needed

### DIFF
--- a/completions-core/ssh.bash
+++ b/completions-core/ssh.bash
@@ -688,7 +688,26 @@ _comp_cmd_scp()
     case $cur in
         !(*:*)/* | [.~]*) ;; # looks like a path
         *:*)
-            _comp_xfunc_scp_compgen_remote_files
+            # if scp supports "-O", which forces legacy scp/rcp protocols,
+            # it means it uses the sftp protocol by default, so we need less
+            # escaping.
+            # The change was done in OpenSSH 9.0 [0], see [1]
+            #
+            # [0] https://www.openssh.org/releasenotes.html#9.0
+            # [1] https://github.com/scop/bash-completion/issues/1540
+            local arg legacy_scp=""
+            for arg in "${words[@]}"; do
+                if [[ $arg == -*O* ]]; then
+                    legacy_scp=set
+                    break
+                fi
+            done
+
+            if [[ $legacy_scp || ! $("$1" --usage 2>&1) =~ scp\ \[-[^]]*O ]]; then
+                _comp_xfunc_scp_compgen_remote_files
+            else
+                _comp_xfunc_scp_compgen_remote_files -l
+            fi
             return
             ;;
     esac

--- a/test/t/test_scp.py
+++ b/test/t/test_scp.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from itertools import chain
 
@@ -114,30 +115,63 @@ class TestScp:
     def test_remote_path_with_failglob(self, completion):
         assert not completion
 
-    def test_remote_path_with_spaces(self, bash):
+    @pytest.fixture(scope="class")
+    def needs_extra_escaping(self, bash):
+        usage = assert_bash_exec(
+            bash, "scp --usage 2>&1 || :", want_output=True
+        )
+        expr = re.compile(r"scp \[-[^[]+O")
+        if expr.search(usage):
+            return False
+        return True
+
+    def test_explicit_legacy_proto(self, bash):
+        assert_bash_exec(
+            bash, r"ssh() { printf '%s\n' 'abc def.txt' 'abc\ def.txt'; }"
+        )
+        abc_completion = assert_complete(bash, "scp -O remote_host:abc\\")
+        assert abc_completion == sorted(
+            [r"abc\\\ def.txt", r"abc\\\\\\\ def.txt"]
+        )
+
+        assert_bash_exec(bash, r"ssh() { printf '%s\n' 'ends_with_slash\'; }")
+        slash_end_completion = assert_complete(
+            bash, "scp -O remote_host:ends_w"
+        )
+        assert slash_end_completion.output == r"ith_slash\\\\ "
+        assert_bash_exec(bash, "unset -f ssh")
+
+    def test_remote_path_with_spaces(self, bash, needs_extra_escaping):
         assert_bash_exec(bash, "ssh() { echo 'spaces in filename.txt'; }")
         completion = assert_complete(bash, "scp remote_host:spaces")
         assert_bash_exec(bash, "unset -f ssh")
-        assert completion == r"\\\ in\\\ filename.txt"
+        if needs_extra_escaping:
+            assert completion == r"\\\ in\\\ filename.txt"
+        else:
+            assert completion == r"\ in\ filename.txt"
 
-    def test_remote_path_with_backslash(self, bash):
+    def test_remote_path_with_backslash(self, bash, needs_extra_escaping):
         assert_bash_exec(
             bash, r"ssh() { printf '%s\n' 'abc def.txt' 'abc\ def.txt'; }"
         )
         completion = assert_complete(bash, "scp remote_host:abc\\")
         assert_bash_exec(bash, "unset -f ssh")
 
-        # Note: The number of backslash escaping differs depending on the scp
-        # version.
-        assert completion == sorted(
-            [r"abc\ def.txt", r"abc\\\ def.txt"]
-        ) or completion == sorted([r"abc\\\ def.txt", r"abc\\\\\\\ def.txt"])
+        if needs_extra_escaping:
+            assert completion == sorted(
+                [r"abc\\\ def.txt", r"abc\\\\\\\ def.txt"]
+            )
+        else:
+            assert completion == sorted([r"abc\ def.txt", r"abc\\\ def.txt"])
 
-    def test_remote_path_with_backslash_2(self, bash):
+    def test_remote_path_with_backslash_2(self, bash, needs_extra_escaping):
         assert_bash_exec(
             bash, r"ssh() { [[ $1 == abc ]]; printf '%s\n' 'abc OK'; }"
         )
-        completion = assert_complete(bash, "scp remote_host:abc\\\\\\")
+        if needs_extra_escaping:
+            completion = assert_complete(bash, r"scp remote_host:abc\\\ ")
+        else:
+            completion = assert_complete(bash, r"scp remote_host:abc\ ")
         assert_bash_exec(bash, "unset -f ssh")
 
         assert completion == "OK"
@@ -204,11 +238,16 @@ class TestScp:
         )
         assert completion.output == r"file\\ "
 
-    def test_remote_path_ending_with_backslash(self, bash):
+    def test_remote_path_ending_with_backslash(
+        self, bash, needs_extra_escaping
+    ):
         assert_bash_exec(bash, "ssh() { echo 'hypothetical\\'; }")
         completion = assert_complete(bash, "scp remote_host:hypo")
         assert_bash_exec(bash, "unset -f ssh")
-        assert completion.output == r"thetical\\\\ "
+        if needs_extra_escaping:
+            assert completion.output == r"thetical\\\\ "
+        else:
+            assert completion.output == r"thetical\\ "
 
     @pytest.fixture
     def tmpdir_mkfifo(self, bash, tmp_path_factory):


### PR DESCRIPTION
fix(scp): Use less escaping for filenames when not needed

OpenSSH 9.0 changed the default protocol the "scp" command uses to
sftp, which needs less escaping for special characters in remote
filenames. Check if the command has the option to use the legacy
protocol and do less escaping.

If the command line has the "-O" option to use the legacy protocol,
we revert to the old behaviour.

The extra escaping is necessary for older versions, so we can't do it
unconditionally.

Fixes: https://github.com/scop/bash-completion/issues/1540