### PR TITLE
feat(dockerfmt): add fallback 3rd party completion loader

### DIFF
--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -60,6 +60,7 @@
 /dive.bash
 /dlv.bash
 /docker.bash
+/dockerfmt.bash
 /dpkg-deb.bash
 /dpkg-query.bash
 /dprint.bash

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -149,6 +149,7 @@ CLEANFILES = \
 	dive.bash \
 	dlv.bash \
 	docker.bash \
+	dockerfmt.bash \
 	dpkg-deb.bash \
 	dpkg-query.bash \
 	dprint.bash \
@@ -395,6 +396,7 @@ symlinks: $(DATA)
 		dive \
 		dlv \
 		docker \
+		dockerfmt \
 		driftctl \
 		dyff \
 		encore \


### PR DESCRIPTION
https://github.com/reteps/dockerfmt#usage