### PR TITLE
fix(make): exclude .NOTINTERMEDIATE from target completion

### DIFF
--- a/helpers-core/make-extract-targets.awk
+++ b/helpers-core/make-extract-targets.awk
@@ -98,6 +98,7 @@ is_target_block == 0 { next; }
   if (/^\.DEFAULT:/             ) next;
   if (/^\.PRECIOUS:/            ) next;
   if (/^\.INTERMEDIATE:/        ) next;
+  if (/^\.NOTINTERMEDIATE:/     ) next;
   if (/^\.SECONDARY:/           ) next;
   if (/^\.SECONDEXPANSION:/     ) next;
   if (/^\.DELETE_ON_ERROR:/     ) next;
@@ -108,6 +109,7 @@ is_target_block == 0 { next; }
   if (/^\.NOTPARALLEL:/         ) next;
   if (/^\.ONESHELL:/            ) next;
   if (/^\.POSIX:/               ) next;
+  if (/^\.WAIT:/                ) next;
   if (/^\.NOEXPORT:/            ) next;
   if (/^\.MAKE:/                ) next;
 

--- a/test/fixtures/make/test5/Makefile
+++ b/test/fixtures/make/test5/Makefile
@@ -1,0 +1,20 @@
+# `.NOTINTERMEDIATE' (GNU make 4.4) and `.WAIT' are special targets, so -- like
+# the other names in the extractor's special-target skip list -- they must not
+# be offered as completion candidates (e.g. `make .NOT<TAB>' / `make .WA<TAB>').
+#
+# `.WAIT' is a parallel-build barrier used as a prerequisite (`a .WAIT b').  The
+# GNU make manual documents creating an actual empty `.WAIT' target for
+# portability with older make; that rule shows up as a target block in
+# `make -npq', so it has to be filtered too.
+
+.PHONY: all
+all: a .WAIT b
+
+a:
+	@echo $@
+b:
+	@echo $@
+
+.WAIT:
+
+.NOTINTERMEDIATE:

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -219,3 +219,22 @@ class TestMake4:
         completion = assert_complete(bash, "make dir")
         assert completion == "/"
         assert completion.endswith("/")
+
+
+@pytest.mark.bashcomp(cmd="make", require_cmd=True, cwd="make/test5")
+class TestMakeSpecialTargets:
+    """The special-target skip list must exclude `.NOTINTERMEDIATE' and `.WAIT'
+    (GNU make 4.4), like the other special targets it already filters."""
+
+    def test_notintermediate_filtered(self, bash):
+        """`.NOTINTERMEDIATE' is a special target, so it must not leak into
+        completion on a dotted prefix such as `make .NOT<TAB>'."""
+        completion = assert_complete(bash, "make .NOT")
+        assert not completion
+
+    def test_wait_filtered(self, bash):
+        """`.WAIT' is a special target.  The portability idiom of an explicit
+        empty `.WAIT' rule makes it a target block in `make -npq', so it must
+        not leak into completion on `make .WA<TAB>'."""
+        completion = assert_complete(bash, "make .WA")
+        assert not completion

--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -219,3 +219,22 @@ class TestMake4:
         completion = assert_complete(bash, "make dir")
         assert completion == "/"
         assert completion.endswith("/")
+
+
+@pytest.mark.bashcomp(require_cmd=True, cwd="make/test5")
+class TestMakeSpecialTargets:
+    """The special-target skip list must exclude `.NOTINTERMEDIATE' and `.WAIT'
+    (GNU make 4.4), like the other special targets it already filters."""
+
+    @pytest.mark.complete("make .NOT")
+    def test_notintermediate_filtered(self, completion):
+        """`.NOTINTERMEDIATE' is a special target, so it must not leak into
+        completion on a dotted prefix such as `make .NOT<TAB>'."""
+        assert not completion
+
+    @pytest.mark.complete("make .WA")
+    def test_wait_filtered(self, completion):
+        """`.WAIT' is a special target.  The portability idiom of an explicit
+        empty `.WAIT' rule makes it a target block in `make -npq', so it must
+        not leak into completion on `make .WA<TAB>'."""
+        assert not completion


### PR DESCRIPTION
`.NOTINTERMEDIATE` (a GNU make 4.4 special target) was missing from the
extractor's special-target skip list, so it leaked into completion on a
dotted prefix like `make .NOT<TAB>` — a make directive, not a runnable
target. The hidden-target guard only suppresses dotted names on an empty
or trailing-`/` prefix, so the explicit list is the sole filter for
specials under a dotted partial prefix.

Fix: add `.NOTINTERMEDIATE` to the list — a one-line, additive change,
with a regression test/fixture. `.WAIT` and `.EXTRA_PREREQS` are
deliberately not added: `.WAIT` is a parse-consumed prerequisite marker
and `.EXTRA_PREREQS` is a variable, so neither surfaces as a target block.

Follow-up from the #1693 review.