### PR TITLE
feat: add 3rd-party fallback completion loaders

### DIFF
--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -178,6 +178,7 @@
 /packer.bash
 /pass-cli.bash
 /pip3.bash
+/pipx.bash
 /pitchfork.bash
 /pluto.bash
 /pnpm.bash

--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -17,6 +17,7 @@
 /asdf.bash
 /atlas.bash
 /atmos.bash
+/awless.bash
 /bao.bash
 /bashbot.bash
 /black.bash

--- a/completions-fallback/.gitignore
+++ b/completions-fallback/.gitignore
@@ -97,6 +97,7 @@
 /hd.bash
 /helm.bash
 /helmfile.bash
+/herdr.bash
 /hostctl.bash
 /httpx.bash
 /hugo.bash

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -1,5 +1,6 @@
 cross_platform = adb.bash \
 		argc.bash \
+		aws.bash \
 		bombadil.bash \
 		cal.bash \
 		cargo.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -14,6 +14,7 @@ cross_platform = adb.bash \
 		dselect.bash \
 		eject.bash \
 		flamegraph.bash \
+		flutter.bash \
 		gaiacli.bash \
 		gh.bash \
 		golangci-lint.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -186,6 +186,7 @@ CLEANFILES = \
 	hd.bash \
 	helm.bash \
 	helmfile.bash \
+	herdr.bash \
 	hostctl.bash \
 	httpx.bash \
 	hugo.bash \
@@ -427,6 +428,7 @@ symlinks: $(DATA)
 		gup \
 		helm \
 		helmfile \
+		herdr \
 		hostctl \
 		hugo \
 		imgpkg \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -270,6 +270,7 @@ CLEANFILES = \
 	packer.bash \
 	pass-cli.bash \
 	pip3.bash \
+	pipx.bash \
 	pitchfork.bash \
 	pluto.bash \
 	pnpm.bash \
@@ -568,6 +569,7 @@ symlinks: $(DATA)
 		ansible-vault \
 		conda \
 		cz \
+		pipx \
 		waydroid
 	$(ss) pip \
 		pip3

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -43,6 +43,7 @@ cross_platform = adb.bash \
 		nmcli.bash \
 		nox.bash \
 		nvm.bash \
+		pew.bash \
 		pip.bash \
 		pipenv.bash \
 		prek.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -17,6 +17,7 @@ cross_platform = adb.bash \
 		flutter.bash \
 		gaiacli.bash \
 		gh.bash \
+		go.bash \
 		golangci-lint.bash \
 		gsctl.bash \
 		hexdump.bash \

--- a/completions-fallback/Makefile.am
+++ b/completions-fallback/Makefile.am
@@ -106,6 +106,7 @@ CLEANFILES = \
 	asdf.bash \
 	atlas.bash \
 	atmos.bash \
+	awless.bash \
 	bao.bash \
 	bashbot.bash \
 	black.bash \
@@ -365,6 +366,7 @@ symlinks: $(DATA)
 		asdf \
 		atlas \
 		atmos \
+		awless \
 		bashbot \
 		bosh \
 		buf \

--- a/completions-fallback/aws.bash
+++ b/completions-fallback/aws.bash
@@ -1,0 +1,12 @@
+# 3rd party completion loader for aws
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+# shellcheck disable=SC2168 # "local" is ok, assume sourced by _comp_load
+local completer
+for completer in {"${1%"${1##*/}"}",}aws_completer; do
+    if type "$completer" &>/dev/null; then
+        complete -C "\"$completer\" 2>/dev/null" "$1"
+        break
+    fi
+done

--- a/completions-fallback/flutter.bash
+++ b/completions-fallback/flutter.bash
@@ -1,0 +1,6 @@
+# 3rd party completion loader for commands emitting their completion using
+# "$cmd bash-completion".
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+eval -- "$("$1" bash-completion 2>/dev/null)"

--- a/completions-fallback/go.bash
+++ b/completions-fallback/go.bash
@@ -1,0 +1,12 @@
+# 3rd party completion loader for go
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+# shellcheck disable=SC2168 # "local" is ok, assume sourced by _comp_load
+local completer
+for completer in {"${1%"${1##*/}"}","${GOBIN-/__Dummy__}/","${GOPATH-/__Dummy__}/bin/",}gocomplete; do
+    if type "$completer" &>/dev/null; then
+        complete -C "\"$completer\" 2>/dev/null" "$1"
+        break
+    fi
+done

--- a/completions-fallback/pew.bash
+++ b/completions-fallback/pew.bash
@@ -1,0 +1,7 @@
+# 3rd party completion loader for pew
+#
+# This serves as a fallback in case the completion is not installed otherwise.
+
+# shellcheck disable=SC2168 # "local" is ok, assume sourced by _comp_load
+local PS1 # This is to prevent pew's shell_config/init.bash to modify PS1.
+eval -- "$("$1" shell_config 2>/dev/null)"


### PR DESCRIPTION
These are taken from trivial completion settings in Bash-it. See the respective commit messages. The completion loader for `pew` (https://github.com/scop/bash-completion/pull/1717/changes/dfcd6736c85d7d7c29b9ceef2491036b99f83d6c) can be controversial (see the description in the commit message).