### PR TITLE
test: retry sendintr/expect once on timeout (addresses #706)

### DIFF
--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -182,6 +182,21 @@ def get_testdir():
     return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
+def _sendintr_and_expect_prompt(bash: pexpect.spawn) -> None:
+    """Send Ctrl+C and wait for the prompt, retrying once on timeout.
+
+    A lone retry absorbs a transient scheduling/host-load stall without
+    masking a genuinely broken session: if the second attempt also times
+    out, the TIMEOUT still propagates as before.
+    """
+    try:
+        bash.sendintr()
+        bash.expect_exact(PS1)
+    except pexpect.exceptions.TIMEOUT:
+        bash.sendintr()
+        bash.expect_exact(PS1)
+
+
 @pytest.fixture(scope="session")
 def test_session_tmpdir(tmp_path_factory) -> Path:
     tmpdir = tmp_path_factory.mktemp("bash-completion.session.")
@@ -349,8 +364,7 @@ def bash(request, test_session_tmpdir, tmp_path_factory) -> pexpect.spawn:
             # Not exactly sure why, but some errors leave bash in state where
             # getting the env here would fail and trash our test output. So
             # reset to a good state first (Ctrl+C, expect prompt).
-            bash.sendintr()
-            bash.expect_exact(PS1)
+            _sendintr_and_expect_prompt(bash)
             diff_env(
                 before_env,
                 get_env(bash),
@@ -494,8 +508,7 @@ class bash_env_saved:
 
     def _safe_sendintr(self):
         try:
-            self.bash.sendintr()
-            self.bash.expect_exact(PS1)
+            _sendintr_and_expect_prompt(self.bash)
         except Exception as e:
             if self.noexcept:
                 self.captured_error = e

--- a/test/t/conftest.py
+++ b/test/t/conftest.py
@@ -189,8 +189,8 @@ def _sendintr_and_expect_prompt(bash: pexpect.spawn) -> None:
     masking a genuinely broken session: if the second attempt also times
     out, the TIMEOUT still propagates as before.
     """
+    bash.sendintr()
     try:
-        bash.sendintr()
         bash.expect_exact(PS1)
     except pexpect.exceptions.TIMEOUT:
         bash.sendintr()


### PR DESCRIPTION
This MR is an attempt to address the Intermittent timeouts under high host load issue in #706.

It adds one retry on "Send Ctrl+C, and wait for the prompt to come back" for tests that raise a `TIMEOUT`. If the test failed due to high load, rather than due to a test error, then there is a good chance that it will pass on the second round.

This would then fix CI issues like the ones [Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1119845) is having with TIMEOUTs in the test suite.

Tested under deliberately induced CPU load (several runs with all cores saturated): a few sendintr/expect timeouts occurred, all recovered by the retry, so that the test suite did not error out.

_Claude was used in triaging this issue, but code and solution are mine._