### PR TITLE
test: use "@pytest.mark.complete" where applicable

### DIFF
--- a/test/t/test_make.py
+++ b/test/t/test_make.py
@@ -3,8 +3,6 @@ import sys
 
 import pytest
 
-from conftest import assert_complete
-
 
 class TestMake:
     @pytest.fixture
@@ -88,36 +86,36 @@ class TestMake:
 
 @pytest.mark.bashcomp(require_cmd=True, cwd="make/test2")
 class TestMake2:
-    def test_github_issue_544_1(self, bash):
-        completion = assert_complete(bash, "make ab")
+    @pytest.mark.complete("make ab")
+    def test_github_issue_544_1(self, completion):
         assert completion == "c/xyz"
 
-    def test_github_issue_544_2(self, bash):
-        completion = assert_complete(bash, "make 1")
+    @pytest.mark.complete("make 1")
+    def test_github_issue_544_2(self, completion):
         assert completion == "23/"
 
-    def test_github_issue_544_3(self, bash):
-        completion = assert_complete(bash, "make 123/")
+    @pytest.mark.complete("make 123/")
+    def test_github_issue_544_3(self, completion):
         assert completion == ["123/xaa", "123/xbb"]
 
-    def test_github_issue_544_4(self, bash):
-        completion = assert_complete(bash, "make 123/xa")
+    @pytest.mark.complete("make 123/xa")
+    def test_github_issue_544_4(self, completion):
         assert completion == "a"
 
-    def test_subdir_1(self, bash):
-        completion = assert_complete(bash, "make sub1")
+    @pytest.mark.complete("make sub1")
+    def test_subdir_1(self, completion):
         assert completion == "test/bar/"
 
-    def test_subdir_2(self, bash):
-        completion = assert_complete(bash, "make sub2")
+    @pytest.mark.complete("make sub2")
+    def test_subdir_2(self, completion):
         assert completion == "test/bar/alpha"
 
-    def test_subdir_3(self, bash):
-        completion = assert_complete(bash, "make sub3")
+    @pytest.mark.complete("make sub3")
+    def test_subdir_3(self, completion):
         assert completion == "test/"
 
-    def test_subdir_4(self, bash):
-        completion = assert_complete(bash, "make sub4")
+    @pytest.mark.complete("make sub4")
+    def test_subdir_4(self, completion):
         assert completion == "sub4test/bar/ sub4test2/foo/gamma".split()
 
 
@@ -131,9 +129,9 @@ class TestMake3:
     favor of only `MyProgram/fast'.
     """
 
-    def test_all_targets(self, bash):
+    @pytest.mark.complete("make ")
+    def test_all_targets(self, completion):
         """Phony targets are offered as-is, not collapsed as directories."""
-        completion = assert_complete(bash, "make ")
         assert completion == [
             "MyProgram",
             "MyProgram/fast",
@@ -145,27 +143,27 @@ class TestMake3:
             "install/strip",
         ]
 
-    def test_single_child(self, bash):
+    @pytest.mark.complete("make My")
+    def test_single_child(self, completion):
         """`MyProgram' is offered alongside `MyProgram/fast'."""
-        completion = assert_complete(bash, "make My")
         assert completion == ["MyProgram", "MyProgram/fast"]
 
-    def test_single_child_drill_in(self, bash):
-        completion = assert_complete(bash, "make MyProgram/")
+    @pytest.mark.complete("make MyProgram/")
+    def test_single_child_drill_in(self, completion):
         assert completion == "fast"
 
-    def test_multi_child(self, bash):
+    @pytest.mark.complete("make install")
+    def test_multi_child(self, completion):
         """`install' is offered alongside `install/local', `install/strip'."""
-        completion = assert_complete(bash, "make install")
         assert completion == ["install", "install/local", "install/strip"]
 
-    def test_multi_child_drill_in(self, bash):
-        completion = assert_complete(bash, "make install/")
+    @pytest.mark.complete("make install/")
+    def test_multi_child_drill_in(self, completion):
         assert completion == ["install/local", "install/strip"]
 
-    def test_clean(self, bash):
+    @pytest.mark.complete("make clean")
+    def test_clean(self, completion):
         """A second single-child case: `clean' alongside `clean/fast'."""
-        completion = assert_complete(bash, "make clean")
         assert completion == ["clean", "clean/fast"]
 
 
@@ -177,14 +175,12 @@ class TestMakeOptions:
     Run from the fixtures root so the -C/-f paths are relative to it.
     """
 
-    def test_directory_option(self, bash):
-        completion = assert_complete(bash, "make -C make/test3 install")
+    @pytest.mark.complete("make -C make/test3 install")
+    def test_directory_option(self, completion):
         assert completion == ["install", "install/local", "install/strip"]
 
-    def test_file_option(self, bash):
-        completion = assert_complete(
-            bash, "make -f make/test3/Makefile install"
-        )
+    @pytest.mark.complete("make -f make/test3/Makefile install")
+    def test_file_option(self, completion):
         assert completion == ["install", "install/local", "install/strip"]
 
 
@@ -197,25 +193,25 @@ class TestMake4:
     as a plain runnable name.
     """
 
-    def test_all_targets(self, bash):
-        completion = assert_complete(bash, "make ")
+    @pytest.mark.complete("make ")
+    def test_all_targets(self, completion):
         assert completion == ["dir/", "sub/"]
 
-    def test_dir_prep_target_stays_collapsed(self, bash):
+    @pytest.mark.complete("make sub")
+    def test_dir_prep_target_stays_collapsed(self, completion):
         """`sub' is a real directory target, not a phony label, so it is not
         surfaced as a plain name; it stays collapsed to `sub/'."""
-        completion = assert_complete(bash, "make sub")
         assert completion == "/"
         # Collapsed `sub/' must not get a trailing space (nospace is set).
         assert completion.endswith("/")
 
-    def test_dir_prep_drill_in(self, bash):
-        completion = assert_complete(bash, "make sub/")
+    @pytest.mark.complete("make sub/")
+    def test_dir_prep_drill_in(self, completion):
         assert completion == ["sub/a", "sub/b"]
 
-    def test_non_target_prefix_collapses(self, bash):
+    @pytest.mark.complete("make dir")
+    def test_non_target_prefix_collapses(self, completion):
         """`dir' is not a target, only a shared prefix, so it collapses to
         `dir/'."""
-        completion = assert_complete(bash, "make dir")
         assert completion == "/"
         assert completion.endswith("/")

--- a/test/t/unit/test_unit_compgen_commands.py
+++ b/test/t/unit/test_unit_compgen_commands.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import assert_bash_exec, assert_complete, bash_env_saved
+from conftest import assert_bash_exec, bash_env_saved
 
 
 @pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+COMPREPLY=")
@@ -42,6 +42,6 @@ class TestUtilCompgenCommands:
             )
         assert (output.strip() == "") == result_empty
 
-    def test_spaces(self, bash, functions):
-        completion = assert_complete(bash, "ccc shared/default/bar")
+    @pytest.mark.complete("ccc shared/default/bar")
+    def test_spaces(self, functions, completion):
         assert completion == r"\ bar.d/"

--- a/test/t/unit/test_unit_compgen_filedir.py
+++ b/test/t/unit/test_unit_compgen_filedir.py
@@ -317,8 +317,8 @@ class TestUnitCompgenFiledir:
             "..folder/",
         ]
 
-    def test_option_X_1(self, bash, functions):
-        completion = assert_complete(bash, "X ", cwd="_filedir/ext")
+    @pytest.mark.complete("X ", cwd="_filedir/ext")
+    def test_option_X_1(self, functions, completion):
         assert completion == sorted("ff.e2 foo/ hh.e2 ii.E1".split())
 
     def test_fallback_1(self, bash, functions):

--- a/test/t/unit/test_unit_compgen_filedir_xspec.py
+++ b/test/t/unit/test_unit_compgen_filedir_xspec.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import assert_bash_exec, assert_complete
+from conftest import assert_bash_exec
 
 
 @pytest.mark.bashcomp(cmd=None, ignore_env=r"^\+COMPREPLY=|^[-+]_comp_xspecs=")
@@ -15,22 +15,22 @@ class TestUnitFiledirXspec:
             "complete -F _filedir_xspec xspec{1..4}",
         )
 
-    def test_1(self, bash, functions):
+    @pytest.mark.complete("xspec1 ", cwd="_filedir_xspec")
+    def test_1(self, functions, completion):
         """Test the pattern for an extension"""
-        completion = assert_complete(bash, "xspec1 ", cwd="_filedir_xspec")
         assert completion == sorted("a.txt b.TXT".split())
 
-    def test_2(self, bash, functions):
+    @pytest.mark.complete("xspec2 ", cwd="_filedir_xspec")
+    def test_2(self, functions, completion):
         """Test an empty _comp_xspecs entry"""
-        completion = assert_complete(bash, "xspec2 ", cwd="_filedir_xspec")
         assert completion == sorted("a.txt b.TXT c.dat d.bin".split())
 
-    def test_3(self, bash, functions):
+    @pytest.mark.complete("xspec3 ", cwd="_filedir_xspec")
+    def test_3(self, functions, completion):
         """Test an unset _comp_xspecs entry"""
-        completion = assert_complete(bash, "xspec3 ", cwd="_filedir_xspec")
         assert completion == sorted("a.txt b.TXT c.dat d.bin".split())
 
-    def test_4(self, bash, functions):
+    @pytest.mark.complete("xspec4 ", cwd="_filedir_xspec")
+    def test_4(self, functions, completion):
         """Test an exclusion pattern"""
-        completion = assert_complete(bash, "xspec4 ", cwd="_filedir_xspec")
         assert completion == sorted("c.dat d.bin".split())


### PR DESCRIPTION
https://github.com/scop/bash-completion/pull/1715#discussion_r3768390324

I've checked all the occurrences of `completion = `. I realized that those were mainly added by me, in particular in `class TestMake2` and `class TestUnitFiledirXspec`. The other `TestMake*` were copied by followers.